### PR TITLE
Center align items and removed numbering for HeroBanner component

### DIFF
--- a/src/components/HeroBanner/HeroBanner.js
+++ b/src/components/HeroBanner/HeroBanner.js
@@ -1,24 +1,23 @@
-import {
-  ButtonBasicStyle,
-  ButtonGoldStyle,
-  GridStyled,
-  TextStyled,  
-  TitleContainer,
-  CaptionContainer,
-  ButtonContainers,  
-  BlankContainer,
-} from './styles';
-import { LoginButton } from "../Navbar/styles";
 import { Grid } from '@mui/material';
+import { useAuthInfo, useRedirectFunctions } from "@propelauth/react";
 import React, { Suspense, useEffect } from 'react';
 import * as ga from '../../lib/ga';
-import { useRedirectFunctions } from "@propelauth/react"
-import { useAuthInfo } from '@propelauth/react'
+import { LoginButton } from "../Navbar/styles";
+import {
+  BlankContainer,
+  ButtonBasicStyle,
+  ButtonContainers,
+  ButtonGoldStyle,
+  CaptionContainer,
+  GridStyled,
+  TextStyled,
+  TitleContainer,
+} from './styles';
 
 
 
-import { useEnv } from '../../context/env.context';
 import ReactPixel from 'react-facebook-pixel';
+import { useEnv } from '../../context/env.context';
 
 // Assuming you're using Next.js for SSR
 import dynamic from 'next/dynamic';
@@ -122,11 +121,11 @@ function HeroBanner() {
               target="_blank"
               style={{ color: 'white', backgroundColor: '#0070BA' }}
             >
-              0. Donate via PayPal
+             Donate via PayPal
             </ButtonBasicStyle>
 
             <ButtonGoldStyle onClick={openCodeSample}>
-              1. Create an OHack Slack account
+              Create an OHack Slack account
             </ButtonGoldStyle>
 
             {!isLoggedIn && <LoginButton
@@ -135,7 +134,7 @@ function HeroBanner() {
                   onClick={() => redirectToLoginPage()}
                 className="login-button"
               >
-                2. Log In                                                  
+                Log In                                                  
               </LoginButton> 
             }
 
@@ -144,7 +143,7 @@ function HeroBanner() {
               onClick={() => gaButton('button_profile', 'clicked to see profile')}
               href='/profile'              
             >
-              2. View your profile
+              View your profile
             </ButtonBasicStyle>
             }
             
@@ -152,23 +151,20 @@ function HeroBanner() {
               onClick={() => gaButton('button_about', 'about us')}
               href='/about'
             >
-              3. Read more about us
+              Read more about us
             </ButtonBasicStyle>
 
             <ButtonBasicStyle
               onClick={() => gaButton('button_see_all', 'see_all_nonprofit_projects')}
               href='/nonprofits'
             >
-              4. See all nonprofit projects
+              See all nonprofit projects
             </ButtonBasicStyle>
 
           </ButtonContainers>
         </CaptionContainer>
       </BlankContainer>
-      {/* Right Container */}
-      <BlankContainer xs={12} md={5} lg={5}  justifyContent="center" alignItems="center">
-          
-      </BlankContainer>
+    
     </GridStyled>
   );
 }

--- a/src/components/HeroBanner/styles.js
+++ b/src/components/HeroBanner/styles.js
@@ -1,10 +1,11 @@
-import { 
-  Grid, 
-  Button, 
-  Typography, 
-  // Box 
+import {
+  Button,
+  Grid,
+  Typography,
+  css,
+  keyframes,
+  styled,
 } from "@mui/material";
-import { styled, keyframes, css } from "@mui/material";
 
 // Button
 export const ButtonStyled = styled(Button)({
@@ -61,6 +62,7 @@ export const GridStyled = styled(Grid)((props) => ({
   height: "100%",
   width: "80%",
   margin: "auto",
+  justifyContent: "center",
 
   [props.theme.breakpoints.down("lg")]: {
     padding: "8rem 0rem 6rem 0rem",
@@ -75,12 +77,16 @@ export const BlankContainer = styled(Grid)({
   display: "flex",
   flexDirection: "column",
   position: "relative",
+  alignItems: "center",
+  justifyContent: "center",
 });
 
 export const TitleContainer = styled(Grid)((props) => ({
   padding: "1rem 5% 0px 0px",
   marginTop: "3rem",
   minHeight: '200px',
+  alignItems: "center",
+  justifyContent: "center",
 
   [props.theme.breakpoints.down("md")]: {
     padding: props.right === "true" ? "15% 5% 5% 5%" : "3rem 2px 0 10px",
@@ -92,6 +98,10 @@ export const TitleContainer = styled(Grid)((props) => ({
 export const CaptionContainer = styled(Grid)((props) => ({
   color: "#425466",
   maxWidth: "390px",
+  display : "flex",
+  flexDirection :  "column",
+  alignItems: "center",
+  justifyContent: "center",
 
   [props.theme.breakpoints.down("md")]: {
     display: "flex",
@@ -106,6 +116,7 @@ export const ButtonContainers = styled(Grid)((props) => ({
   flexDirection: "column",
   width: "auto",
   gap: "1rem",
+  justifyContent: "center",
 }));
 
 // Typography
@@ -117,6 +128,8 @@ export const TitleStyled = styled(Typography)((props) => ({
   color: "#333333",
   textShadow: "0 2px 5px rgba(0, 0, 0, 0.1)",
   letterSpacing: "-0.1rem",
+  alignItems: "center",
+
 
   [props.theme.breakpoints.down("md")]: {
     fontSize: "8vw",
@@ -130,6 +143,8 @@ export const TextStyled = styled(Typography)({
   marginTop: "0.8rem",
   marginBottom: "0.8rem",
   width: "100%",
+  alignItems: "center",
+  justifyContent: "center",
 });
 
 export const SpanText = styled("span") ((props) => ({

--- a/src/components/News/News.js
+++ b/src/components/News/News.js
@@ -1,28 +1,27 @@
-import Grid from '@mui/material/Grid';
-import {  
-  NewsLinkButton,
-  SlackButton,  
-  TitleStyled,
-  TitleContainer,
-  CaptionContainer,
-  MoreNewsStyle,
-  ButtonContainersSmall,
-  TextMuted,  
-  EventCards,
-  BlankContainer,
-  StyledTextLink
-} from './styles';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import FileCopyIcon from '@mui/icons-material/FileCopy';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import FileCopyIcon from '@mui/icons-material/FileCopy';
+import { Alert, Snackbar } from '@mui/material';
+import Grid from '@mui/material/Grid';
 import { useState } from 'react';
-import { Snackbar } from '@mui/material';
-import { Alert } from '@mui/material';
+import {
+  BlankContainer,
+  ButtonContainersSmall,
+  CaptionContainer,
+  EventCards,
+  MoreNewsStyle,
+  NewsLinkButton,
+  SlackButton,
+  StyledTextLink,
+  TextMuted,
+  TitleContainer,
+  TitleStyled
+} from './styles';
 
-import * as ga from '../../lib/ga';
-import React from 'react';
 import { Divider } from "@mui/material";
-import Image from 'next/image'
+import Image from 'next/image';
+import React from 'react';
+import * as ga from '../../lib/ga';
 
 import Link from 'next/link';
 
@@ -165,14 +164,6 @@ function News( {newsData, frontpage} ) {
             <Divider style={{ marginTop: '2em' }}/>
         </BlankContainer>         
       ))}
-
-      { frontpage && <Link prefetch={false} href="/blog">        
-        <MoreNewsStyle>
-          More news
-          <ArrowForwardIcon/>
-        </MoreNewsStyle>        
-      </Link>
-      }
 
       <Snackbar open={snackbarOpen} autoHideDuration={3000} onClose={handleSnackbarClose}>
         <Alert onClose={handleSnackbarClose} severity="success" sx={{ width: '100%' }}>


### PR DESCRIPTION
This pull request includes several small but meaningful changes to improve the Hero banner and overall layout:

1. Removed Extra BlankContainer Div: Eliminated an unnecessary BlankContainer div to streamline the structure.
2. Updated Button HeroBanner: Removed unnecessary numbers for the button grids in the Hero banner to simplify the layout.
3. Eliminated Redundant "More News" Button: Removed a redundant "More news" button to avoid duplication and enhance the user interface.
These changes help to clean up the code and improve the user experience.
<img width="1470" alt="Screenshot 2024-06-10 at 11 02 39 AM" src="https://github.com/opportunity-hack/frontend-ohack.dev/assets/112138113/7f5f6960-ab01-408d-8ebb-218e3ac4bd16">

