### PR TITLE
Project Application Button For Nonprofits Without Active Projects

### DIFF
--- a/src/components/NonProfit/NonProfit.js
+++ b/src/components/NonProfit/NonProfit.js
@@ -42,6 +42,10 @@ import {
   TitleChipContainer,
   TitleContainer,
   TitleStyled,
+  // ProjectSubmissionContainer,
+  ApplyButtonContainer,
+  // Buttons
+  ApplyButton
 } from '../../styles/nonprofit/styles';
 
 /*
@@ -111,6 +115,17 @@ export default function NonProfit(props) {
     } else {
       if (nonprofit?.problem_statements?.length === 0) {
         return <div>Working on it!</div>;
+      } else if (!nonprofit?.problem_statements) {
+        return (
+          <Grid container justifyContent=''>
+            <Grid item style={{ fontSize: "13px"}} xs={12}>
+              Looks like there are no active projects with this organization. Let us know how we can help:<br/>
+            </Grid>
+            <ApplyButtonContainer>
+              <ApplyButton href="https://www.ohack.dev/nonprofits/apply">Submit your project ideas!</ApplyButton>
+            </ApplyButtonContainer>
+          </Grid>
+        )
       } else {        
         return nonprofit?.problem_statements?.map((ps) => {
           return (

--- a/src/styles/nonprofit/styles.js
+++ b/src/styles/nonprofit/styles.js
@@ -25,6 +25,26 @@ export const MoreNewsStyle = styling(Button)({
   },
 });
 
+export const ApplyButton = styling(Button) ({
+  borderRadius: "2rem",
+  paddingLeft: "1.5rem",
+  paddingRight: "1.5rem",
+  fontWeight: 600,
+  fontSize: "15px",
+  textTransform: "unset !important",
+  backgroundColor: "#FFD700",
+  color: "#000000",
+  minWidth: "25rem",
+
+  "&:hover": {
+    backgroundColor: `var(--blue)`,
+  },
+})
+
+export const ApplyButtonContainer = styling(Grid)({
+  paddingTop: "1rem"
+})
+
 export const LayoutContainer = styling(Grid)({
   justifyContent: "center",
   alignContent: "center",


### PR DESCRIPTION
Added button to encourage project applications for nonprofits that do not have any active projects.

Added lines 118 - 128 in src/components/NonProfit/NonProfit.js to conditionally render text and button encouraging users to submit project applications if the nonprofit does not have any active projects. Added styles in src/styles/nonprofit/styles.js and imported to src/components/NonProfit/NonProfit.js.