### PR TITLE
Update DevSetup guide with Windows command

### DIFF
--- a/docs/DevSetup.md
+++ b/docs/DevSetup.md
@@ -61,9 +61,8 @@ npm install
 npm run dev
 ```
 * To force this to run on port 3000, you can use the following
-```bash
-PORT=3000 npm run dev
-```
+    * MacOS/Linux: `PORT=3000 npm run dev`
+    * Windows: `set PORT=3000 && npm run dev`
 
 You have successfully set up your frontend development environment!
 


### PR DESCRIPTION
Updated `DevSetup` guide to distinguish command between Unix and Windows.

I don't feel strongly about this change if you don't think it's necessary. Just something I noticed while onboarding.