### PR TITLE
Resolve Material UI Issues

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -103,7 +103,7 @@ export default function Footer() {
       color: accessibilityStyles.linkColor,
     }}>
       <InnerContainer container>
-        <TextContainer container xs={12} md={7} lg={8} style={{ minHeight: '220px' }}>
+        <TextContainer container item xs={12} md={7} lg={8} style={{ minHeight: '220px' }}>
           <div style={{ width: '100%' }}>
             <StyledText style={{ color: accessibilityStyles.linkColor, fontWeight: "600" }}>Our Mission</StyledText>
             <MutedText style={{ 
@@ -252,7 +252,7 @@ export default function Footer() {
             Opportunity Hack Inc. EIN: 84-5113049
           </MutedText>
         </TextContainer>
-        <TextContainer container xs={12} md={5} lg={4} style={{ minHeight: '320px' }}>
+        <TextContainer container item xs={12} md={5} lg={4} style={{ minHeight: '320px' }}>
           <LinkList style={{ width: '100%' }}>
             {/* Link integration with icons for a single-click interaction */}
             <LinkListItem key="whatisohack">

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -241,7 +241,7 @@ export default function NavBar() {
               <Divider />
               <ListSubheader>About Opportunity Hack</ListSubheader>
               {aboutMenuGroups.map((group, index) => (
-                <React.Fragment key={group.title}>
+                <div key={group.title}>
                   {index > 0 && <Divider />}
                   <ListSubheader>{group.title}</ListSubheader>
                   {group.items.map((setting) => (
@@ -254,7 +254,7 @@ export default function NavBar() {
                       </MenuItem>
                     </Link>
                   ))}
-                </React.Fragment>
+                </div>
               ))}
             </Menu>
           </Box>
@@ -319,7 +319,7 @@ export default function NavBar() {
               onClose={handleCloseAboutMenu}
             >
               {aboutMenuGroups.map((group, index) => (
-                <React.Fragment key={group.title}>
+                <div key={group.title}>
                   {index > 0 && <Divider />}
                   <ListSubheader>{group.title}</ListSubheader>
                   {group.items.map((setting) => (
@@ -332,7 +332,7 @@ export default function NavBar() {
                       </MenuItem>
                     </Link>
                   ))}
-                </React.Fragment>
+                </div>
               ))}
             </Menu>
           </Box>


### PR DESCRIPTION
Some Material UI fixes to ensure consistent behavior:
* [x] `Menu` can't have `Fragment` as a child.
  * Updated to `div`
* [x] The prop `sm`, `md`, and `lg` of `Grid` can only be used when the `item` prop is also provided.