### PR TITLE
Use Resend API for email delivery status tracking

### DIFF
--- a/src/components/admin/VolunteerCommunication.js
+++ b/src/components/admin/VolunteerCommunication.js
@@ -71,7 +71,8 @@ const VolunteerCommunication = ({
           message: messageText,
           subject: selectedTemplate ? selectedTemplate.title : "Message from Opportunity Hack",
           recipient_type: volunteer.type || 'volunteer',
-          name: volunteer.name || volunteer.email || 'Recipient'
+          name: volunteer.name || volunteer.email || 'Recipient',
+          volunteer_id: volunteer.id || null
         };
       } else {
         // Use user ID endpoint for registered users

--- a/src/components/admin/VolunteerTable.js
+++ b/src/components/admin/VolunteerTable.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 import {
   Table,
   TableBody,
@@ -198,8 +198,13 @@ const VolunteerTable = ({
   // Filter props
   checkedInFilter = 'all',
   onCheckedInFilterChange,
+  // Auth props for Resend status lookup
+  accessToken,
+  orgId,
 }) => {
   const [copyFeedback, setCopyFeedback] = useState({ open: false, message: '' });
+  const [resendStatuses, setResendStatuses] = useState({}); // { resend_id: { last_event, ... } }
+  const [loadingResendStatus, setLoadingResendStatus] = useState({});
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isSmallMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -234,6 +239,70 @@ const VolunteerTable = ({
       });
     }
   };
+
+  // Fetch delivery status from Resend for a volunteer's sent emails
+  const fetchResendStatuses = useCallback(async (resendIds) => {
+    if (!resendIds?.length || !accessToken || !orgId) return;
+
+    // Filter out IDs we already have or are loading
+    const idsToFetch = resendIds.filter(id => id && !resendStatuses[id] && !loadingResendStatus[id]);
+    if (idsToFetch.length === 0) return;
+
+    setLoadingResendStatus(prev => {
+      const next = { ...prev };
+      idsToFetch.forEach(id => { next[id] = true; });
+      return next;
+    });
+
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/admin/emails/resend-status`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+            'X-Org-Id': orgId,
+          },
+          body: JSON.stringify({ email_ids: idsToFetch }),
+        }
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.statuses) {
+          setResendStatuses(prev => ({ ...prev, ...data.statuses }));
+        }
+      }
+    } catch (err) {
+      console.warn('Failed to fetch Resend statuses:', err);
+    } finally {
+      setLoadingResendStatus(prev => {
+        const next = { ...prev };
+        idsToFetch.forEach(id => { delete next[id]; });
+        return next;
+      });
+    }
+  }, [accessToken, orgId, resendStatuses, loadingResendStatus]);
+
+  // Helper to get sent emails from either new sent_emails or legacy messages_sent
+  const getSentEmails = useCallback((volunteer) => {
+    if (Array.isArray(volunteer.sent_emails) && volunteer.sent_emails.length > 0) {
+      return volunteer.sent_emails;
+    }
+    // Backward compatibility with old messages_sent format
+    if (Array.isArray(volunteer.messages_sent) && volunteer.messages_sent.length > 0) {
+      return volunteer.messages_sent.map(msg => ({
+        resend_id: null,
+        subject: msg.subject,
+        timestamp: msg.timestamp,
+        sent_by: msg.sent_by,
+        recipient_type: msg.recipient_type,
+        _legacy_delivery_status: msg.delivery_status,
+      }));
+    }
+    return [];
+  }, []);
 
   const handleCloseFeedback = () => {
     setCopyFeedback({ open: false, message: '' });
@@ -499,50 +568,78 @@ const VolunteerTable = ({
           />
         );
       case "messages_sent":
-        const messageCount = Array.isArray(volunteer.messages_sent) 
-          ? volunteer.messages_sent.length 
-          : 0;
-        
+        const sentEmails = getSentEmails(volunteer);
+        const messageCount = sentEmails.length;
+
         if (messageCount === 0) {
           return (
-            <Chip 
-              label="0" 
-              size="small" 
+            <Chip
+              label="0"
+              size="small"
               variant="outlined"
               sx={{ minWidth: 32, fontSize: '0.75rem' }}
             />
           );
         }
 
+        // Delivery status chip for a single sent email
+        const renderDeliveryStatus = (email) => {
+          // Check for Resend live status first
+          if (email.resend_id && resendStatuses[email.resend_id]) {
+            const status = resendStatuses[email.resend_id];
+            const eventMap = {
+              delivered: { label: 'Delivered', color: 'success' },
+              sent: { label: 'Sent', color: 'info' },
+              bounced: { label: 'Bounced', color: 'error' },
+              complained: { label: 'Complained', color: 'error' },
+              delivery_delayed: { label: 'Delayed', color: 'warning' },
+            };
+            const display = eventMap[status.last_event] || { label: status.last_event || 'Unknown', color: 'default' };
+            return <Chip label={display.label} size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color={display.color} />;
+          }
+          // Loading state
+          if (email.resend_id && loadingResendStatus[email.resend_id]) {
+            return <Chip label="Loading..." size="small" sx={{ fontSize: '0.6rem', height: '16px' }} variant="outlined" />;
+          }
+          // Legacy delivery_status fallback
+          if (email._legacy_delivery_status) {
+            const ds = email._legacy_delivery_status;
+            return (
+              <>
+                {ds.email_sent && <Chip label="Email ✓" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color="success" />}
+                {ds.slack_sent && <Chip label="Slack ✓" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color="info" />}
+                {ds.email_error && <Chip label="Email ✗" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color="error" />}
+                {ds.slack_error && <Chip label="Slack ✗" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color="error" />}
+              </>
+            );
+          }
+          // Has resend_id but not yet fetched
+          if (email.resend_id) {
+            return <Chip label="Click for status" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} variant="outlined" />;
+          }
+          return null;
+        };
+
         const messagesToolTipContent = (
           <Box>
             <Typography variant="subtitle2" sx={{ mb: 1 }}>
               Recent Messages ({messageCount})
             </Typography>
-            {volunteer.messages_sent.slice(0, 5).map((message, idx) => (
+            {sentEmails.slice(0, 5).map((email, idx) => (
               <Box key={idx} sx={{ mb: 1, pb: 1, borderBottom: idx < Math.min(4, messageCount - 1) ? '1px solid rgba(255,255,255,0.2)' : 'none' }}>
                 <Typography variant="caption" sx={{ display: 'block', fontWeight: 'bold' }}>
-                  {new Date(message.timestamp).toLocaleString()}
+                  {new Date(email.timestamp).toLocaleString()}
                 </Typography>
                 <Typography variant="caption" sx={{ display: 'block', mb: 0.5 }}>
-                  Subject: {message.subject}
+                  Subject: {email.subject}
                 </Typography>
-                <Typography variant="caption" sx={{ display: 'block' }}>
-                  Sent by: {message.sent_by}
-                </Typography>
+                {email.sent_by && (
+                  <Typography variant="caption" sx={{ display: 'block' }}>
+                    Sent by: {email.sent_by}
+                  </Typography>
+                )}
                 <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }}>
-                  {message.delivery_status.email_sent && (
-                    <Chip label="Email ✓" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color="success" />
-                  )}
-                  {message.delivery_status.slack_sent && (
-                    <Chip label="Slack ✓" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color="info" />
-                  )}
-                  {message.delivery_status.email_error && (
-                    <Chip label="Email ✗" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color="error" />
-                  )}
-                  {message.delivery_status.slack_error && (
-                    <Chip label="Slack ✗" size="small" sx={{ fontSize: '0.6rem', height: '16px' }} color="error" />
-                  )}
+                  {renderDeliveryStatus(email)}
                 </Box>
               </Box>
             ))}
@@ -554,11 +651,22 @@ const VolunteerTable = ({
           </Box>
         );
 
+        // Fetch Resend statuses when the tooltip opens
+        const handleTooltipOpen = () => {
+          const resendIds = sentEmails
+            .filter(e => e.resend_id)
+            .map(e => e.resend_id);
+          if (resendIds.length > 0) {
+            fetchResendStatuses(resendIds);
+          }
+        };
+
         return (
-          <Tooltip 
-            title={messagesToolTipContent} 
-            arrow 
+          <Tooltip
+            title={messagesToolTipContent}
+            arrow
             placement="bottom-start"
+            onOpen={handleTooltipOpen}
             componentsProps={{
               tooltip: {
                 sx: {
@@ -570,9 +678,9 @@ const VolunteerTable = ({
               },
             }}
           >
-            <Chip 
-              label={messageCount} 
-              size="small" 
+            <Chip
+              label={messageCount}
+              size="small"
               variant="outlined"
               color="primary"
               sx={{ cursor: 'pointer', minWidth: 32, fontSize: '0.75rem' }}
@@ -1154,9 +1262,9 @@ const VolunteerTable = ({
                       sx={{ '& .MuiChip-icon': { mr: 0.5 } }}
                     />
                   )}
-                  {Array.isArray(volunteer.messages_sent) && volunteer.messages_sent.length > 0 && (
+                  {getSentEmails(volunteer).length > 0 && (
                     <Chip
-                      label={`${volunteer.messages_sent.length} msgs`}
+                      label={`${getSentEmails(volunteer).length} msgs`}
                       size="small"
                       variant="outlined"
                       color="primary"

--- a/src/lib/batchEmailService.js
+++ b/src/lib/batchEmailService.js
@@ -47,7 +47,8 @@ class BatchEmailService {
           message: processedMessage,
           subject: subject,
           recipient_type: recipientType,
-          name: user.name || user.email || 'Recipient'
+          name: user.name || user.email || 'Recipient',
+          volunteer_id: user.id || null
         };
       } else {
         // Use user ID endpoint for registered users

--- a/src/pages/admin/volunteer/index.js
+++ b/src/pages/admin/volunteer/index.js
@@ -190,6 +190,7 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
   const savedScrollPositionRef = useRef(0);
   const lastUrlRef = useRef('');
   const dataLoadedRef = useRef(false);
+  const initializedFromUrlRef = useRef(false);
 
   // Save scroll position when navigating away and restore when returning
   useEffect(() => {
@@ -269,9 +270,12 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
   }
   
   // Handle URL parameters and set initial state with defensive checks
+  // Only runs for initialization — once event ID is set from URL, stops overriding user selections
   useEffect(() => {
     if (!router?.query) return;
-    
+    if (!Array.isArray(hackathons) || hackathons.length === 0) return;
+    if (initializedFromUrlRef.current) return;
+
     const {
       event_id,
       tab,
@@ -285,10 +289,10 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
       volunteer_id,
       volunteer_type
     } = router.query;
-    
-    if (event_id && Array.isArray(hackathons) && hackathons.some(h => h?.event_id === event_id)) {
+
+    if (event_id && hackathons.some(h => h?.event_id === event_id)) {
       setSelectedEventId(event_id);
-    } else if (Array.isArray(hackathons) && hackathons.length > 0 && !selectedEventId) {
+    } else {
       // Sort hackathons by date (descending) and use the most recent one
       const sortedHackathons = [...hackathons]
         .filter(h => h?.start_date) // Filter out invalid entries
@@ -297,12 +301,14 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
           const dateB = new Date(b.start_date);
           return dateB - dateA; // Most recent first
         });
-      
+
       if (sortedHackathons.length > 0) {
         setSelectedEventId(sortedHackathons[0].event_id);
       }
     }
-    
+
+    initializedFromUrlRef.current = true;
+
     // Handle volunteer_type parameter to set correct tab
     if (volunteer_type && !tab) {
       const typeToTabMap = {
@@ -323,8 +329,8 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
     }
 
     // Handle filter state restoration and volunteer_id filtering
-    const finalTabValue = volunteer_type && !tab ? 
-      ({ mentor: 0, judge: 1, volunteer: 2, hacker: 3, sponsor: 4 })[volunteer_type] || tabValue : 
+    const finalTabValue = volunteer_type && !tab ?
+      ({ mentor: 0, judge: 1, volunteer: 2, hacker: 3, sponsor: 4 })[volunteer_type] || tabValue :
       (tab !== undefined ? parseInt(tab, 10) : tabValue);
 
     if (finalTabValue >= 0 && finalTabValue <= 4) {
@@ -353,7 +359,7 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
         }
       }
     }
-  }, [hackathons, selectedEventId, router?.query]);
+  }, [hackathons, router?.query]);
 
   // Update URL when selectedEventId, tabValue, or filter states change
   useEffect(() => {
@@ -1468,6 +1474,8 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
                 onBulkCertificate={handleBulkCertificate}
                 checkedInFilter={getCurrentFilterState().checkedInFilter}
                 onCheckedInFilterChange={(value) => updateFilterState('checkedInFilter', value)}
+                accessToken={accessToken}
+                orgId={orgId}
               />
               {sortedVolunteers.length === 0 && (
                 <Box sx={{ mt: 2, textAlign: "center" }}>


### PR DESCRIPTION
## Summary
- Replaces the broken `messages_sent` Firestore storage approach with live Resend API delivery status lookups
- Backend was silently failing to save `messages_sent` records; now the Resend email ID is saved instead and delivery status is fetched on demand from Resend
- VolunteerTable tooltip fetches live delivery status (delivered, bounced, delayed, etc.) when hovered
- Backward compatible with existing `messages_sent` data (legacy fallback)

## Changes
- **VolunteerTable**: Reads `sent_emails` (new field) with fallback to `messages_sent` (legacy); fetches live status from Resend on tooltip hover
- **VolunteerCommunication & batchEmailService**: Pass `volunteer_id` in email-only request path so backend can save the Resend email ID
- **Admin volunteer page**: Passes `accessToken`/`orgId` to VolunteerTable for Resend status API calls

## Dependencies
- Requires backend commit `532ae5f` which adds `POST /api/admin/emails/resend-status` endpoint and saves `sent_emails` records with Resend IDs

## Test plan
- [ ] Send a single email from the volunteer admin page and verify `sent_emails` is saved on the volunteer document
- [ ] Send a batch email and verify `sent_emails` records are created
- [ ] Hover over the message count chip and verify delivery status loads from Resend (should show "Delivered", "Sent", etc.)
- [ ] Verify backward compatibility: volunteers with existing `messages_sent` data still show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)