### PR TITLE
Add external application URL support for hackathons

### DIFF
--- a/src/components/Hackathon/EventLinks.js
+++ b/src/components/Hackathon/EventLinks.js
@@ -95,8 +95,9 @@ const EventLinks = ({ links, variant = "full", constraints = {} }) => {
       description: "Participate as a developer, designer, product or project manager",
       icon: <PersonIcon />,
       color: "primary",
-      link: `/hack/${event_id}/hacker-application`,
+      link: constraints.application_hacker_external_url || `/hack/${event_id}/hacker-application`,
       enabled: constraints.application_hacker_enabled !== false,
+      isExternal: !!constraints.application_hacker_external_url,
       roleType: "hackers",
       socialProof: socialProofConfig.hacker,
     },
@@ -106,8 +107,9 @@ const EventLinks = ({ links, variant = "full", constraints = {} }) => {
       description: "Guide teams with your technical expertise",
       icon: <VolunteerActivismIcon />,
       color: "secondary",
-      link: `/hack/${event_id}/mentor-application`,
+      link: constraints.application_mentor_external_url || `/hack/${event_id}/mentor-application`,
       enabled: constraints.application_mentor_enabled !== false,
+      isExternal: !!constraints.application_mentor_external_url,
       roleType: "mentors",
       socialProof: socialProofConfig.mentor,
     },
@@ -117,8 +119,9 @@ const EventLinks = ({ links, variant = "full", constraints = {} }) => {
       description: "Evaluate solutions and provide feedback",
       icon: <GavelIcon />,
       color: "success",
-      link: `/hack/${event_id}/judge-application`,
+      link: constraints.application_judge_external_url || `/hack/${event_id}/judge-application`,
       enabled: constraints.application_judge_enabled !== false,
+      isExternal: !!constraints.application_judge_external_url,
       roleType: "judges",
       socialProof: socialProofConfig.judge,
     },
@@ -255,6 +258,7 @@ const EventLinks = ({ links, variant = "full", constraints = {} }) => {
                   href={app.enabled ? app.link : undefined}
                   disabled={!app.enabled}
                   component={app.enabled ? "a" : "button"}
+                  {...(app.enabled && app.isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                   sx={{
                     display: 'flex',
                     flexDirection: 'column',
@@ -274,6 +278,7 @@ const EventLinks = ({ links, variant = "full", constraints = {} }) => {
                     <Typography variant="caption" component="span" align="left">
                       {app.description}
                       {!app.enabled && " (Closed)"}
+                      {app.enabled && app.isExternal && " (Opens in new tab)"}
                     </Typography>
 
                     {/* Social Proof Indicator */}
@@ -381,9 +386,10 @@ const EventLinks = ({ links, variant = "full", constraints = {} }) => {
                 href={app.enabled ? app.link : undefined}
                 disabled={!app.enabled}
                 component={app.enabled ? "a" : "button"}
-                sx={{ 
-                  display: 'flex', 
-                  flexDirection: 'column', 
+                {...(app.enabled && app.isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
                   alignItems: 'flex-start',
                   height: '100%',
                   minHeight: '80px',
@@ -398,6 +404,7 @@ const EventLinks = ({ links, variant = "full", constraints = {} }) => {
                   <Typography variant="caption" component="span" align="left">
                     {app.description}
                     {!app.enabled && " (Closed)"}
+                    {app.enabled && app.isExternal && " (Opens in new tab)"}
                   </Typography>
                 </Box>
               </ApplicationButton>

--- a/src/pages/admin/hackathons/index.js
+++ b/src/pages/admin/hackathons/index.js
@@ -738,6 +738,21 @@ const AdminHackathonPage = () => {
                         }
                         label="Hacker Applications"
                       />
+                      {!!editingHackathon?.constraints?.application_hacker_enabled && (
+                        <TextField
+                          label="External Hacker Application URL"
+                          value={editingHackathon?.constraints?.application_hacker_external_url || ""}
+                          onChange={(e) => handleUpdateConstraint("application_hacker_external_url", e.target.value)}
+                          fullWidth
+                          margin="dense"
+                          helperText="Leave blank to use built-in form. Must start with http:// or https://"
+                          error={
+                            !!editingHackathon?.constraints?.application_hacker_external_url &&
+                            !editingHackathon.constraints.application_hacker_external_url.match(/^https?:\/\//)
+                          }
+                          sx={{ ml: 4, maxWidth: 500 }}
+                        />
+                      )}
                       <FormControlLabel
                         control={
                           <Switch
@@ -747,6 +762,21 @@ const AdminHackathonPage = () => {
                         }
                         label="Mentor Applications"
                       />
+                      {!!editingHackathon?.constraints?.application_mentor_enabled && (
+                        <TextField
+                          label="External Mentor Application URL"
+                          value={editingHackathon?.constraints?.application_mentor_external_url || ""}
+                          onChange={(e) => handleUpdateConstraint("application_mentor_external_url", e.target.value)}
+                          fullWidth
+                          margin="dense"
+                          helperText="Leave blank to use built-in form. Must start with http:// or https://"
+                          error={
+                            !!editingHackathon?.constraints?.application_mentor_external_url &&
+                            !editingHackathon.constraints.application_mentor_external_url.match(/^https?:\/\//)
+                          }
+                          sx={{ ml: 4, maxWidth: 500 }}
+                        />
+                      )}
                       <FormControlLabel
                         control={
                           <Switch
@@ -756,6 +786,21 @@ const AdminHackathonPage = () => {
                         }
                         label="Judge Applications"
                       />
+                      {!!editingHackathon?.constraints?.application_judge_enabled && (
+                        <TextField
+                          label="External Judge Application URL"
+                          value={editingHackathon?.constraints?.application_judge_external_url || ""}
+                          onChange={(e) => handleUpdateConstraint("application_judge_external_url", e.target.value)}
+                          fullWidth
+                          margin="dense"
+                          helperText="Leave blank to use built-in form. Must start with http:// or https://"
+                          error={
+                            !!editingHackathon?.constraints?.application_judge_external_url &&
+                            !editingHackathon.constraints.application_judge_external_url.match(/^https?:\/\//)
+                          }
+                          sx={{ ml: 4, maxWidth: 500 }}
+                        />
+                      )}
                       <TextField
                         label="Judge Access Code"
                         value={editingHackathon?.constraints?.application_judge_enabled_code || ""}

--- a/src/pages/hack/[event_id]/hacker-application.js
+++ b/src/pages/hack/[event_id]/hacker-application.js
@@ -614,6 +614,13 @@ const HackerApplicationComponent = () => {
           throw new Error("Invalid event data received");
         }
 
+        // Redirect to external application URL if configured
+        const externalUrl = eventData.constraints?.application_hacker_external_url;
+        if (externalUrl) {
+          window.location.href = externalUrl;
+          return;
+        }
+
         // Format dates for display
         const eventTz = getEventTimezone(eventData);
         const startDate = Moment.tz(eventData.start_date, eventTz);

--- a/src/pages/hack/[event_id]/judge-application.js
+++ b/src/pages/hack/[event_id]/judge-application.js
@@ -334,6 +334,13 @@ const JudgeApplicationComponent = () => {
           throw new Error("Invalid event data received");
         }
 
+        // Redirect to external application URL if configured
+        const externalUrl = eventData.constraints?.application_judge_external_url;
+        if (externalUrl) {
+          window.location.href = externalUrl;
+          return;
+        }
+
         // Format dates for display
         const startDate = new Date(eventData.start_date);
         const endDate = new Date(eventData.end_date);

--- a/src/pages/hack/[event_id]/mentor-application.js
+++ b/src/pages/hack/[event_id]/mentor-application.js
@@ -301,6 +301,13 @@ const MentorApplicationComponent = () => {
           throw new Error("Invalid event data received");
         }
 
+        // Redirect to external application URL if configured
+        const externalUrl = eventData.constraints?.application_mentor_external_url;
+        if (externalUrl) {
+          window.location.href = externalUrl;
+          return;
+        }
+
         // Format dates for display
         const startDate = new Date(eventData.start_date);
         const endDate = new Date(eventData.end_date);


### PR DESCRIPTION
## Summary
- Adds optional external URL fields (e.g., Google Forms) for hacker, mentor, and judge applications in the admin hackathon constraints settings
- Event page application buttons link to the external URL (opens in new tab) when configured, falling back to the built-in form when blank
- Direct navigation to built-in application pages (`/hack/{id}/hacker-application`, etc.) redirects to the external URL if one is set

## Test plan
- [ ] Navigate to `/admin/hackathons`, edit a hackathon → Advanced Settings → Constraints
- [ ] Enable hacker applications, enter an external URL (e.g., `https://forms.google.com/test`), save
- [ ] Verify the public event page's "Apply as Hacker" button links to the external URL and opens in a new tab
- [ ] Navigate directly to `/hack/{event_id}/hacker-application` and confirm it redirects to the external URL
- [ ] Clear the external URL, save, and confirm the built-in form works again
- [ ] Repeat for mentor and judge application types
- [ ] Verify URL validation shows error state for non-http URLs
- [ ] Verify URL fields only appear when the corresponding application toggle is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)