### PR TITLE
Add admin contact submissions page and email correspondence tracking

### DIFF
--- a/src/components/admin/AdminEmailCompose.js
+++ b/src/components/admin/AdminEmailCompose.js
@@ -1,0 +1,218 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Paper,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Chip,
+  List,
+  ListItem,
+  ListItemText,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import SendIcon from "@mui/icons-material/Send";
+import MailOutlineIcon from "@mui/icons-material/MailOutline";
+import HistoryIcon from "@mui/icons-material/History";
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return "-";
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
+    return d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return dateStr;
+  }
+};
+
+const AdminEmailCompose = ({
+  recipientEmail,
+  recipientName,
+  collectionName,
+  documentId,
+  sentEmails = [],
+  accessToken,
+  orgId,
+  onEmailSent,
+}) => {
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [alert, setAlert] = useState(null);
+  const [composeOpen, setComposeOpen] = useState(false);
+
+  const handleSend = async () => {
+    if (!subject.trim() || !message.trim()) {
+      setAlert({ severity: "warning", text: "Subject and message are required." });
+      return;
+    }
+
+    setSending(true);
+    setAlert(null);
+
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/admin/email/send`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            "content-type": "application/json",
+            "X-Org-Id": orgId,
+          },
+          body: JSON.stringify({
+            email: recipientEmail,
+            name: recipientName,
+            subject,
+            message,
+            recipient_type: "contact",
+            collection_name: collectionName,
+            document_id: documentId,
+          }),
+        }
+      );
+
+      if (response.ok) {
+        setAlert({ severity: "success", text: "Email sent successfully!" });
+        setSubject("");
+        setMessage("");
+        setComposeOpen(false);
+        if (onEmailSent) onEmailSent();
+      } else {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to send email");
+      }
+    } catch (err) {
+      setAlert({ severity: "error", text: err.message || "Failed to send email." });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const sortedEmails = [...sentEmails].sort(
+    (a, b) => new Date(b.timestamp) - new Date(a.timestamp)
+  );
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ mt: 2, p: 2, borderColor: "info.light", borderRadius: 2 }}
+    >
+      <Typography
+        variant="subtitle1"
+        sx={{ fontWeight: 600, mb: 1, color: "info.main", display: "flex", alignItems: "center", gap: 1 }}
+      >
+        <MailOutlineIcon fontSize="small" />
+        Email Correspondence
+      </Typography>
+
+      {alert && (
+        <Alert severity={alert.severity} sx={{ mb: 2 }} onClose={() => setAlert(null)}>
+          {alert.text}
+        </Alert>
+      )}
+
+      {/* Compose */}
+      <Accordion expanded={composeOpen} onChange={() => setComposeOpen(!composeOpen)}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            Compose New Email to {recipientName || recipientEmail}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <TextField
+              size="small"
+              label="Subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              fullWidth
+            />
+            <TextField
+              size="small"
+              label="Message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              multiline
+              rows={4}
+              fullWidth
+            />
+            <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+              <Button
+                variant="contained"
+                startIcon={sending ? <CircularProgress size={16} /> : <SendIcon />}
+                onClick={handleSend}
+                disabled={sending}
+                size="small"
+              >
+                {sending ? "Sending..." : "Send Email"}
+              </Button>
+            </Box>
+          </Box>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* Email History */}
+      {sortedEmails.length > 0 && (
+        <Box sx={{ mt: 2 }}>
+          <Typography
+            variant="body2"
+            sx={{ fontWeight: 500, mb: 1, display: "flex", alignItems: "center", gap: 0.5 }}
+          >
+            <HistoryIcon fontSize="small" />
+            Email History ({sortedEmails.length})
+          </Typography>
+          <List dense disablePadding>
+            {sortedEmails.map((email, idx) => (
+              <ListItem
+                key={email.resend_id || idx}
+                sx={{
+                  borderLeft: "3px solid",
+                  borderColor: "info.light",
+                  mb: 0.5,
+                  bgcolor: "grey.50",
+                  borderRadius: 1,
+                }}
+              >
+                <ListItemText
+                  primary={email.subject || "No subject"}
+                  secondary={
+                    <Box component="span" sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
+                      <span>{formatDate(email.timestamp)}</span>
+                      <span>by {email.sent_by || "Admin"}</span>
+                      {email.resend_id && (
+                        <Chip label="Sent" size="small" color="success" variant="outlined" />
+                      )}
+                    </Box>
+                  }
+                  primaryTypographyProps={{ variant: "body2", fontWeight: 500 }}
+                  secondaryTypographyProps={{ variant: "caption", component: "div" }}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      )}
+
+      {sortedEmails.length === 0 && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1, fontStyle: "italic" }}>
+          No emails sent yet.
+        </Typography>
+      )}
+    </Paper>
+  );
+};
+
+export default AdminEmailCompose;

--- a/src/components/admin/AdminNavigation.js
+++ b/src/components/admin/AdminNavigation.js
@@ -39,6 +39,7 @@ import {
   Share as ShareIcon,
   Gavel as JudgingIcon,
   PostAdd as RequestIcon,
+  ContactMail as ContactMailIcon,
 } from "@mui/icons-material";
 import HandshakeIcon from '@mui/icons-material/Handshake';
 
@@ -85,6 +86,11 @@ const adminPages = [
     path: "/admin/hackathon-requests",
     label: "Hackathon Requests",
     icon: <RequestIcon style={{ color: "#e91e63" }} />
+  },
+  {
+    path: "/admin/contact",
+    label: "Contact",
+    icon: <ContactMailIcon style={{ color: "#00897b" }} />
   },
   {
     path: "/admin/check-in",

--- a/src/components/admin/ContactSubmissionDetailDialog.js
+++ b/src/components/admin/ContactSubmissionDetailDialog.js
@@ -1,0 +1,251 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Grid,
+  Chip,
+  Divider,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Paper,
+  IconButton,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import AdminEmailCompose from "./AdminEmailCompose";
+
+const statusOptions = [
+  { value: "new", label: "New", color: "warning" },
+  { value: "responded", label: "Responded", color: "success" },
+];
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return "Not set";
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
+    return d.toLocaleDateString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return dateStr;
+  }
+};
+
+const Section = ({ title, children }) => (
+  <Box sx={{ mb: 3 }}>
+    <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1, color: "primary.main" }}>
+      {title}
+    </Typography>
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      {children}
+    </Paper>
+  </Box>
+);
+
+const Field = ({ label, value }) => (
+  <Box sx={{ mb: 1.5 }}>
+    <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+      {label}
+    </Typography>
+    <Typography variant="body1">{value || "-"}</Typography>
+  </Box>
+);
+
+const ContactSubmissionDetailDialog = ({
+  open,
+  onClose,
+  submission,
+  onSave,
+  accessToken,
+  orgId,
+  onRefresh,
+}) => {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const [status, setStatus] = useState("");
+  const [adminNotes, setAdminNotes] = useState("");
+
+  useEffect(() => {
+    if (submission) {
+      setStatus(submission.status || "new");
+      setAdminNotes(submission.adminNotes || "");
+    }
+  }, [submission]);
+
+  if (!submission) return null;
+
+  const handleSave = () => {
+    onSave({
+      id: submission.id,
+      status,
+      adminNotes,
+    });
+  };
+
+  const fullName = `${submission.firstName || ""} ${submission.lastName || ""}`.trim();
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullScreen={fullScreen}
+      maxWidth="md"
+      fullWidth
+      scroll="paper"
+    >
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Typography variant="h6" component="span">
+            {fullName || "Contact Submission"}
+          </Typography>
+          <Chip
+            label={submission.status || "new"}
+            color={statusOptions.find((s) => s.value === (submission.status || "new"))?.color || "default"}
+            size="small"
+            sx={{ textTransform: "capitalize" }}
+          />
+        </Box>
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {/* Admin Controls */}
+        <Paper
+          elevation={0}
+          sx={{
+            p: 2,
+            mb: 3,
+            bgcolor: "grey.50",
+            border: "2px solid",
+            borderColor: "primary.light",
+            borderRadius: 2,
+          }}
+        >
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 2, color: "primary.main" }}>
+            Admin Controls
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={4}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Status</InputLabel>
+                <Select value={status} onChange={(e) => setStatus(e.target.value)} label="Status">
+                  {statusOptions.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} sm={8}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Admin Notes"
+                value={adminNotes}
+                onChange={(e) => setAdminNotes(e.target.value)}
+                multiline
+                rows={2}
+              />
+            </Grid>
+          </Grid>
+        </Paper>
+
+        {/* Contact Information */}
+        <Section title="Contact Information">
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={4}>
+              <Field label="Name" value={fullName} />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <Field label="Email" value={submission.email} />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <Field label="Organization" value={submission.organization} />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <Field
+                label="Inquiry Type"
+                value={
+                  <Chip
+                    label={submission.inquiryType || "-"}
+                    size="small"
+                    variant="outlined"
+                    sx={{ textTransform: "capitalize" }}
+                  />
+                }
+              />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <Field
+                label="Wants Updates"
+                value={submission.receiveUpdates ? "Yes" : "No"}
+              />
+            </Grid>
+          </Grid>
+        </Section>
+
+        {/* Message */}
+        <Section title="Message">
+          <Typography variant="body1" sx={{ whiteSpace: "pre-wrap" }}>
+            {submission.message || "-"}
+          </Typography>
+        </Section>
+
+        {/* Email Correspondence */}
+        <AdminEmailCompose
+          recipientEmail={submission.email}
+          recipientName={fullName}
+          collectionName="contact_submissions"
+          documentId={submission.id}
+          sentEmails={submission.sent_emails || []}
+          accessToken={accessToken}
+          orgId={orgId}
+          onEmailSent={onRefresh}
+        />
+
+        {/* Metadata */}
+        <Divider sx={{ my: 2 }} />
+        <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
+          <Typography variant="body2" color="text.secondary">
+            Submitted: {formatDate(submission.timestamp)}
+          </Typography>
+          {submission.updatedAt && (
+            <Typography variant="body2" color="text.secondary">
+              Last Updated: {formatDate(submission.updatedAt)}
+            </Typography>
+          )}
+          <Typography variant="body2" color="text.secondary">
+            ID: {submission.id}
+          </Typography>
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ p: 2 }}>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave}>
+          Save Changes
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ContactSubmissionDetailDialog;

--- a/src/components/admin/ContactSubmissionTable.js
+++ b/src/components/admin/ContactSubmissionTable.js
@@ -1,0 +1,189 @@
+import React from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Paper,
+  Button,
+  Chip,
+  Tooltip,
+  Badge,
+} from "@mui/material";
+import { styled } from "@mui/system";
+import MailOutlineIcon from "@mui/icons-material/MailOutline";
+
+const StyledTableContainer = styled(TableContainer)(({ theme }) => ({
+  width: "100%",
+  overflowX: "auto",
+  "& .MuiTable-root": {
+    minWidth: "100%",
+  },
+}));
+
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  padding: theme.spacing(1, 2),
+  [theme.breakpoints.down("md")]: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    borderBottom: "none",
+    padding: theme.spacing(1, 2),
+    "&:before": {
+      content: "attr(data-label)",
+      fontWeight: "bold",
+      marginBottom: theme.spacing(0.5),
+    },
+  },
+}));
+
+const StyledTableRow = styled(TableRow)(({ theme }) => ({
+  [theme.breakpoints.down("md")]: {
+    display: "flex",
+    flexDirection: "column",
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+}));
+
+const statusColorMap = {
+  new: "warning",
+  responded: "success",
+};
+
+const columns = [
+  { id: "timestamp", label: "Submitted", minWidth: 120 },
+  { id: "name", label: "Name", minWidth: 140 },
+  { id: "email", label: "Email", minWidth: 160 },
+  { id: "organization", label: "Organization", minWidth: 140 },
+  { id: "inquiryType", label: "Inquiry Type", minWidth: 120 },
+  { id: "status", label: "Status", minWidth: 100 },
+  { id: "emails", label: "Emails", minWidth: 80 },
+];
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return "-";
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
+    return d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return dateStr;
+  }
+};
+
+const getCellValue = (submission, columnId) => {
+  switch (columnId) {
+    case "name":
+      return `${submission.firstName || ""} ${submission.lastName || ""}`.trim() || "-";
+    case "emails":
+      return (submission.sent_emails || []).length;
+    default:
+      return submission[columnId];
+  }
+};
+
+const ContactSubmissionTable = ({
+  submissions,
+  orderBy,
+  order,
+  onRequestSort,
+  onViewSubmission,
+}) => {
+  return (
+    <StyledTableContainer component={Paper}>
+      <Table stickyHeader>
+        <TableHead>
+          <TableRow>
+            {columns.map((column) => (
+              <StyledTableCell
+                key={column.id}
+                style={{ minWidth: column.minWidth }}
+              >
+                <TableSortLabel
+                  active={orderBy === column.id}
+                  direction={orderBy === column.id ? order : "asc"}
+                  onClick={() => onRequestSort(column.id)}
+                >
+                  {column.label}
+                </TableSortLabel>
+              </StyledTableCell>
+            ))}
+            <StyledTableCell style={{ minWidth: 100 }}>Actions</StyledTableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {submissions.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={columns.length + 1} align="center">
+                No contact submissions found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            submissions.map((sub) => (
+              <StyledTableRow key={sub.id}>
+                {columns.map((column) => (
+                  <StyledTableCell key={column.id} data-label={column.label}>
+                    {column.id === "status" ? (
+                      <Chip
+                        label={sub.status || "new"}
+                        color={statusColorMap[sub.status] || "warning"}
+                        size="small"
+                        sx={{ textTransform: "capitalize" }}
+                      />
+                    ) : column.id === "timestamp" ? (
+                      formatDate(sub.timestamp)
+                    ) : column.id === "emails" ? (
+                      (sub.sent_emails || []).length > 0 ? (
+                        <Badge
+                          badgeContent={(sub.sent_emails || []).length}
+                          color="info"
+                        >
+                          <MailOutlineIcon fontSize="small" color="action" />
+                        </Badge>
+                      ) : (
+                        "-"
+                      )
+                    ) : column.id === "inquiryType" ? (
+                      <Chip
+                        label={getCellValue(sub, column.id) || "-"}
+                        size="small"
+                        variant="outlined"
+                        sx={{ textTransform: "capitalize" }}
+                      />
+                    ) : (
+                      <Tooltip title={getCellValue(sub, column.id) || ""}>
+                        <span>
+                          {(getCellValue(sub, column.id) || "-").toString().length > 30
+                            ? (getCellValue(sub, column.id) || "").toString().substring(0, 30) + "..."
+                            : getCellValue(sub, column.id) || "-"}
+                        </span>
+                      </Tooltip>
+                    )}
+                  </StyledTableCell>
+                ))}
+                <StyledTableCell data-label="Actions">
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => onViewSubmission(sub)}
+                  >
+                    View
+                  </Button>
+                </StyledTableCell>
+              </StyledTableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </StyledTableContainer>
+  );
+};
+
+export default ContactSubmissionTable;

--- a/src/components/admin/HackathonRequestDetailDialog.js
+++ b/src/components/admin/HackathonRequestDetailDialog.js
@@ -22,6 +22,7 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import AdminEmailCompose from "./AdminEmailCompose";
 
 const statusOptions = [
   { value: "pending", label: "Pending", color: "warning" },
@@ -92,7 +93,7 @@ const Field = ({ label, value }) => (
   </Box>
 );
 
-const HackathonRequestDetailDialog = ({ open, onClose, request, onSave }) => {
+const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessToken, orgId, onRefresh }) => {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("md"));
   const [status, setStatus] = useState("");
@@ -361,6 +362,18 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave }) => {
             </Typography>
           </Section>
         )}
+
+        {/* Email Correspondence */}
+        <AdminEmailCompose
+          recipientEmail={request.contactEmail}
+          recipientName={request.contactName}
+          collectionName="hackathon_requests"
+          documentId={request.id}
+          sentEmails={request.sent_emails || []}
+          accessToken={accessToken}
+          orgId={orgId}
+          onEmailSent={onRefresh}
+        />
 
         {/* Metadata */}
         <Divider sx={{ my: 2 }} />

--- a/src/components/admin/__tests__/hackathon-requests.test.js
+++ b/src/components/admin/__tests__/hackathon-requests.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider, createTheme } from "@mui/material";
-import AdminHackathonRequestsPage from "../index";
+import AdminHackathonRequestsPage from "../../../pages/admin/hackathon-requests/index";
 
 const theme = createTheme();
 

--- a/src/pages/admin/contact/index.js
+++ b/src/pages/admin/contact/index.js
@@ -7,41 +7,37 @@ import {
   TextField,
   Button,
   Typography,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
   Chip,
 } from "@mui/material";
 import AdminPage from "../../../components/admin/AdminPage";
-import HackathonRequestTable from "../../../components/admin/HackathonRequestTable";
-import HackathonRequestDetailDialog from "../../../components/admin/HackathonRequestDetailDialog";
+import ContactSubmissionTable from "../../../components/admin/ContactSubmissionTable";
+import ContactSubmissionDetailDialog from "../../../components/admin/ContactSubmissionDetailDialog";
 
-const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
+const AdminContactPage = withRequiredAuthInfo(({ userClass }) => {
   const { accessToken } = useAuthInfo();
-  const [requests, setRequests] = useState([]);
+  const [submissions, setSubmissions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [snackbar, setSnackbar] = useState({
     open: false,
     message: "",
     severity: "success",
   });
-  const [orderBy, setOrderBy] = useState("created");
+  const [orderBy, setOrderBy] = useState("timestamp");
   const [order, setOrder] = useState("desc");
   const [filter, setFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
-  const [selectedRequest, setSelectedRequest] = useState(null);
+  const [selectedSubmission, setSelectedSubmission] = useState(null);
 
   const org = userClass.getOrgByName("Opportunity Hack Org");
   const isAdmin = org.hasPermission("volunteer.admin");
   const orgId = org.orgId;
 
-  const fetchRequests = async () => {
+  const fetchSubmissions = async () => {
     setLoading(true);
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/admin/hackathon-requests`,
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/contact/submissions`,
         {
           method: "GET",
           headers: {
@@ -54,14 +50,14 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
 
       if (response.ok) {
         const data = await response.json();
-        setRequests(data.requests || []);
+        setSubmissions(data.submissions || []);
       } else {
-        throw new Error("Failed to fetch hackathon requests");
+        throw new Error("Failed to fetch contact submissions");
       }
     } catch (error) {
       setSnackbar({
         open: true,
-        message: "Failed to fetch hackathon requests. Please try again.",
+        message: "Failed to fetch contact submissions. Please try again.",
         severity: "error",
       });
     } finally {
@@ -71,7 +67,7 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
 
   useEffect(() => {
     if (isAdmin) {
-      fetchRequests();
+      fetchSubmissions();
     }
   }, [isAdmin, accessToken]);
 
@@ -81,16 +77,16 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
     setOrderBy(property);
   };
 
-  const handleViewRequest = (request) => {
-    setSelectedRequest(request);
+  const handleViewSubmission = (submission) => {
+    setSelectedSubmission(submission);
     setDetailDialogOpen(true);
   };
 
-  const handleSaveRequest = async (updatedData) => {
+  const handleSaveSubmission = async (updatedData) => {
     setLoading(true);
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/admin/hackathon-requests/${updatedData.id}`,
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/contact/submissions/${updatedData.id}`,
         {
           method: "PATCH",
           headers: {
@@ -108,17 +104,17 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
       if (response.ok) {
         setSnackbar({
           open: true,
-          message: "Hackathon request updated successfully",
+          message: "Contact submission updated successfully",
           severity: "success",
         });
-        fetchRequests();
+        fetchSubmissions();
       } else {
-        throw new Error("Failed to update hackathon request");
+        throw new Error("Failed to update contact submission");
       }
     } catch (error) {
       setSnackbar({
         open: true,
-        message: "Failed to update hackathon request. Please try again.",
+        message: "Failed to update contact submission. Please try again.",
         severity: "error",
       });
     } finally {
@@ -131,36 +127,51 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
     setSnackbar({ ...snackbar, open: false });
   };
 
-  const sortedAndFilteredRequests = requests
-    .filter((req) => {
-      if (statusFilter !== "all" && req.status !== statusFilter) return false;
+  const getSortValue = (sub, key) => {
+    if (key === "name") {
+      return `${sub.firstName || ""} ${sub.lastName || ""}`.trim();
+    }
+    if (key === "emails") {
+      return (sub.sent_emails || []).length;
+    }
+    return sub[key] || "";
+  };
+
+  const sortedAndFilteredSubmissions = submissions
+    .filter((sub) => {
+      if (statusFilter !== "all" && (sub.status || "new") !== statusFilter) return false;
       if (!filter) return true;
       const searchValue = filter.toLowerCase();
+      const fullName = `${sub.firstName || ""} ${sub.lastName || ""}`.toLowerCase();
       return (
-        (req.companyName || "").toLowerCase().includes(searchValue) ||
-        (req.contactName || "").toLowerCase().includes(searchValue) ||
-        (req.contactEmail || "").toLowerCase().includes(searchValue) ||
-        (req.location || "").toLowerCase().includes(searchValue)
+        fullName.includes(searchValue) ||
+        (sub.email || "").toLowerCase().includes(searchValue) ||
+        (sub.organization || "").toLowerCase().includes(searchValue) ||
+        (sub.inquiryType || "").toLowerCase().includes(searchValue)
       );
     })
     .sort((a, b) => {
-      const valueA = a[orderBy] || "";
-      const valueB = b[orderBy] || "";
+      const valueA = getSortValue(a, orderBy);
+      const valueB = getSortValue(b, orderBy);
       if (valueA < valueB) return order === "asc" ? -1 : 1;
       if (valueA > valueB) return order === "asc" ? 1 : -1;
       return 0;
     });
 
-  // Count by status for summary chips
-  const statusCounts = requests.reduce((acc, req) => {
-    const s = req.status || "pending";
+  const statusCounts = submissions.reduce((acc, sub) => {
+    const s = sub.status || "new";
     acc[s] = (acc[s] || 0) + 1;
     return acc;
   }, {});
 
+  const statusColorMap = {
+    new: "warning",
+    responded: "success",
+  };
+
   if (!isAdmin) {
     return (
-      <AdminPage title="Hackathon Request Management" isAdmin={false}>
+      <AdminPage title="Contact Submissions" isAdmin={false}>
         <Typography>You do not have permission to view this page.</Typography>
       </AdminPage>
     );
@@ -168,7 +179,7 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
 
   return (
     <AdminPage
-      title="Hackathon Request Management"
+      title="Contact Submissions"
       snackbar={snackbar}
       onSnackbarClose={handleSnackbarClose}
       isAdmin={isAdmin}
@@ -176,25 +187,15 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
       {/* Summary chips */}
       <Box sx={{ mb: 2, display: "flex", gap: 1, flexWrap: "wrap" }}>
         <Chip
-          label={`Total: ${requests.length}`}
+          label={`Total: ${submissions.length}`}
           variant={statusFilter === "all" ? "filled" : "outlined"}
           onClick={() => setStatusFilter("all")}
         />
         {Object.entries(statusCounts).map(([status, count]) => (
           <Chip
             key={status}
-            label={`${status.replace("-", " ")}: ${count}`}
-            color={
-              status === "pending"
-                ? "warning"
-                : status === "approved"
-                ? "success"
-                : status === "rejected"
-                ? "error"
-                : status === "in-progress"
-                ? "info"
-                : "default"
-            }
+            label={`${status}: ${count}`}
+            color={statusColorMap[status] || "default"}
             variant={statusFilter === status ? "filled" : "outlined"}
             onClick={() => setStatusFilter(statusFilter === status ? "all" : status)}
             sx={{ textTransform: "capitalize" }}
@@ -205,14 +206,14 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
       <Box sx={{ mb: 3, width: "100%" }}>
         <Grid container spacing={2} alignItems="center">
           <Grid item>
-            <Button onClick={fetchRequests} variant="outlined">
+            <Button onClick={fetchSubmissions} variant="outlined">
               Refresh Data
             </Button>
           </Grid>
           <Grid item xs>
             <TextField
               fullWidth
-              label="Filter by Organization, Contact, Email, or Location"
+              label="Filter by Name, Email, Organization, or Inquiry Type"
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
             />
@@ -226,27 +227,27 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
         </Box>
       ) : (
         <Box sx={{ mt: 2 }}>
-          <HackathonRequestTable
-            requests={sortedAndFilteredRequests}
+          <ContactSubmissionTable
+            submissions={sortedAndFilteredSubmissions}
             orderBy={orderBy}
             order={order}
             onRequestSort={handleRequestSort}
-            onViewRequest={handleViewRequest}
+            onViewSubmission={handleViewSubmission}
           />
         </Box>
       )}
 
-      <HackathonRequestDetailDialog
+      <ContactSubmissionDetailDialog
         open={detailDialogOpen}
         onClose={() => setDetailDialogOpen(false)}
-        request={selectedRequest}
-        onSave={handleSaveRequest}
+        submission={selectedSubmission}
+        onSave={handleSaveSubmission}
         accessToken={accessToken}
         orgId={orgId}
-        onRefresh={fetchRequests}
+        onRefresh={fetchSubmissions}
       />
     </AdminPage>
   );
 });
 
-export default AdminHackathonRequestsPage;
+export default AdminContactPage;


### PR DESCRIPTION
## Summary
- Add reusable `AdminEmailCompose` component for sending emails and viewing email history on any Firestore document
- Create `/admin/contact` page with table, detail dialog, filtering, and status management for contact form submissions
- Integrate `AdminEmailCompose` into `HackathonRequestDetailDialog` so admins can email hackathon requestors with tracked history
- Add "Contact" entry to admin navigation

## Test plan
- [ ] Navigate to `/admin/contact` and verify contact submissions load in the table
- [ ] Open a contact submission detail dialog, change status, add notes, save
- [ ] Send a test email from the contact detail dialog, verify it sends and appears in email history after refresh
- [ ] Open a hackathon request detail dialog, verify email compose section appears
- [ ] Send a test email from hackathon request dialog, verify tracking
- [ ] Verify "Contact" nav entry appears and links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)