### PR TITLE
Migrate MUI Grid v5 → v7 API across entire codebase

### DIFF
--- a/src/components/About/Completion/ProjectCompletion.js
+++ b/src/components/About/Completion/ProjectCompletion.js
@@ -50,7 +50,7 @@ const ProjectCompletion = () => {
         </Typography>
 
         <Grid container spacing={3}>
-          <Grid item xs={12} md={8}>
+          <Grid size={{ xs: 12, md: 8 }}>
             <Typography variant="body1" style={style} paragraph>
               In software engineering, the definition of done is a checklist of
               requirements that need to be met before a project can be
@@ -88,7 +88,7 @@ const ProjectCompletion = () => {
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <InstagramEmbed
               url="https://www.instagram.com/p/CoBFS8hvcnB/"
               maxWidth={328}
@@ -104,7 +104,7 @@ const ProjectCompletion = () => {
         </Typography>
 
         <Grid container spacing={3}>
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -119,7 +119,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -147,7 +147,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -161,7 +161,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -175,7 +175,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -189,7 +189,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -204,7 +204,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -226,7 +226,7 @@ const ProjectCompletion = () => {
         </Typography>
 
         <Grid container spacing={3}>
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -241,7 +241,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -256,7 +256,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>
@@ -271,7 +271,7 @@ const ProjectCompletion = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Card sx={{ mb: 2, height: "100%" }}>
               <CardContent>
                 <Typography variant="h5" component="h3" gutterBottom>

--- a/src/components/About/components.js
+++ b/src/components/About/components.js
@@ -5,7 +5,7 @@ import { FaLinkedin } from 'react-icons/fa';
 
 export const ActionButtons = ({ gaButton }) => (
   <Grid container spacing={2}>
-    <Grid item>
+    <Grid>
       <Button 
         variant="contained" 
         onClick={() => gaButton('button_see_nonprofit_projects', 'see projects')} 
@@ -16,7 +16,7 @@ export const ActionButtons = ({ gaButton }) => (
         See Nonprofit Projects
       </Button>
     </Grid>
-    <Grid item>
+    <Grid>
       <Button 
         variant="contained" 
         onClick={() => gaButton('button_mentorship', 'Learn about mentorship')} 
@@ -27,7 +27,7 @@ export const ActionButtons = ({ gaButton }) => (
         Learn about Mentorship
       </Button>
     </Grid>
-    <Grid item>
+    <Grid>
       <Button 
         variant="contained" 
         onClick={() => gaButton('button_judging', 'Learn about judging')} 
@@ -38,7 +38,7 @@ export const ActionButtons = ({ gaButton }) => (
         Judging Information
       </Button>
     </Grid>
-    <Grid item>
+    <Grid>
       <Button 
         variant="contained" 
         onClick={() => gaButton('button_sponsorship', 'Learn about sponsorship')} 
@@ -49,7 +49,7 @@ export const ActionButtons = ({ gaButton }) => (
         Sponsor Opportunities
       </Button>
     </Grid>
-    <Grid item>
+    <Grid>
       <Button 
         variant="contained" 
         onClick={() => gaButton('button_ohack_org', 'Visit ohack.org')} 
@@ -72,7 +72,7 @@ export const FoundersSection = ({ cofounders }) => (
     </Typography>
     <Grid container spacing={2}>
       {cofounders.map((member, i) => (
-        <Grid item xs={12} sm={6} md={3} key={i}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }} key={i}>
           <Card>
             <CardContent>
               <Typography variant="h5" component="h2">
@@ -96,7 +96,7 @@ export const BoardSection = ({ board_members }) => (
     </Typography>
     <Grid container spacing={2}>
       {board_members.map((member, i) => (
-        <Grid item xs={12} sm={6} md={4} key={i}>
+        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={i}>
           <Card>
             <CardContent>
               <Typography variant="h5" component="h2">

--- a/src/components/Blog/BlogPage.js
+++ b/src/components/Blog/BlogPage.js
@@ -231,7 +231,7 @@ const BlogPage = ({ posts }) => {
             </SearchContainer>
 
             <Grid container spacing={3}>
-                <Grid item xs={12} md={8}>
+                <Grid size={{ xs: 12, md: 8 }}>
                     <Typography variant="h4" component="h2" gutterBottom>
                         {selectedTag ? `Posts tagged with #${selectedTag}` : 
                          searchTerm ? `Search results for "${searchTerm}"` : 
@@ -260,7 +260,7 @@ const BlogPage = ({ posts }) => {
                     <News newsData={filteredData} loading={loading} />
                 </Grid>
                 
-                <Grid item xs={12} md={4}>
+                <Grid size={{ xs: 12, md: 4 }}>
                     <Box position="sticky" top={20}>
                         <Paper elevation={1} sx={{ p: 3, mb: 3 }}>
                             <Typography variant="h5" component="h3" gutterBottom>

--- a/src/components/Certificate/CertInfoIndex.js
+++ b/src/components/Certificate/CertInfoIndex.js
@@ -63,7 +63,7 @@ const CertInfoIndex = () => {
             </Typography>
                     
             <Grid container spacing={0} margin={0}>        
-                <Grid item xs={12} sm={12} md={12} padding={0} margin={0}>
+                <Grid size={{ xs: 12, sm: 12, md: 12 }} padding={0} margin={0}>
                     <Typography style={style} marginTop={1}>
                         Congratulations <b>{certInfo.author_name}</b>! You've earned a certificate for your contributions. 
                         <br/>
@@ -74,7 +74,7 @@ const CertInfoIndex = () => {
         </TitleContainer>
                 
         <ProjectsContainer container style={{ marginTop: '2em'}}>                    
-            <Grid item xs={12} sm={6} md={6} style={{margin: '0.5em'}}>                            
+            <Grid size={{ xs: 12, sm: 6, md: 6 }} style={{margin: '0.5em'}}>                            
                     { certInfo && certInfo.certificate_url && <Link href={certInfo.certificate_url}><Image 
                         src={normalizeImageUrl(certInfo.certificate_url)}
                         width={1024/3}
@@ -86,7 +86,7 @@ const CertInfoIndex = () => {
             </Grid>  
             
             { certInfo && certInfo.stats && 
-            <Grid item xs={12} sm={6} md={6}>
+            <Grid size={{ xs: 12, sm: 6, md: 6 }}>
                 <Card style={{ border: '1px solid lightblue', marginBottom: '10px' }}>
                     <CardContent>
                         <Typography variant="h5" component="h3" gutterBottom>
@@ -116,7 +116,7 @@ const CertInfoIndex = () => {
             </Grid>                                
         }          
         
-        <Grid item xs={12} sm={12} md={12} style={{margin: '0.5em'}}>
+        <Grid size={{ xs: 12, sm: 12, md: 12 }} style={{margin: '0.5em'}}>
             <LoginOrRegister introText="Ready to join us?" previousPage={"/about/hearts"} />
         </Grid>
         </ProjectsContainer>

--- a/src/components/Certificate/Certificate.js
+++ b/src/components/Certificate/Certificate.js
@@ -13,7 +13,7 @@ const CertInfoIndex = ( {
 
     return (                                
              
-            <Grid item xs={5} sm={4} md={4} spacing={0.5}>
+            <Grid size={{ xs: 5, sm: 4, md: 4 }} spacing={0.5}>
                 { certInfo && certInfo.stats && <Card>
                     <CardContent>
                     { certInfo && certInfo.certificate_url && <Link href={`https://ohack.dev/cert/${certInfo.file_id}`} passHref><Image 

--- a/src/components/Countdown/Countdown.js
+++ b/src/components/Countdown/Countdown.js
@@ -48,7 +48,7 @@ export default function Countdown({ details })
 
     return(
     <Grid container direction="row" alignContent="center" alignItems="center" marginTop={"4px"}>
-        <Grid item xs={12} md={4} lg={3}>
+        <Grid size={{ xs: 12, md: 4, lg: 3 }}>
             <div style={{ display: 'flex', fontFamily: 'sans-serif', textAlign: 'center', paddingTop: '10px'}}>
                 <CountdownCircleTimer
                     {...timerProps}
@@ -114,7 +114,7 @@ export default function Countdown({ details })
             </div>          
         </Grid>
 
-        <Grid item xs={12} md={8} lg={9}>
+        <Grid size={{ xs: 12, md: 8, lg: 9 }}>
             <SectionTitle>{_name}
             {
                 isAfter(new Date(_time), new Date()) &&

--- a/src/components/Events/Events.js
+++ b/src/components/Events/Events.js
@@ -37,7 +37,7 @@ export default function Events({
       }
       
       return (
-        <Grid item key={event.id} style={{ marginTop: 10, padding: "2px" }}>
+        <Grid key={event.id} style={{ marginTop: 10, padding: "2px" }}>
 
           { isEventStartDateOlderThanToday(event) && 
             <Link href={`/hack/${event.event_id}`}>
@@ -91,7 +91,7 @@ export default function Events({
               <Grid container
               style={{ backgroundColor: "#f5f5f5" }} spacing={0} padding={1} direction="row" md={12} xs={12} marginTop={0.5} justifyContent="flex-start"  alignItems="center" alignContent="center" >
                 {
-                  <Grid item style={{  }}>
+                  <Grid style={{  }}>
                     {event.links.map((link) => {
                       return (
                        
@@ -114,7 +114,7 @@ export default function Events({
            {
             // Print constraints if they exist
             event.constraints && (
-              <Grid item direction="row" spacing={2} justifyContent="flex-start">
+              <Grid direction="row" spacing={2} justifyContent="flex-start">
                 {
                   // If constraints.max_teams_per_problem is not null, then display the max number of teams per problem
                   event.constraints.max_teams_per_problem && (

--- a/src/components/HackathonList/PreviousHackathonList.js
+++ b/src/components/HackathonList/PreviousHackathonList.js
@@ -152,7 +152,7 @@ function PreviousHackathonList() {
 
                       <Grid container spacing={1} sx={{ mt: 2 }}>
                         {event.links && event.links.length > 0 && (
-                          <Grid item xs={12}>
+                          <Grid size={{ xs: 12 }}>
                             <ToggleButton
                               color="primary"
                               variant="outlined"

--- a/src/components/HackathonRequest/HackathonRequestForm.js
+++ b/src/components/HackathonRequest/HackathonRequestForm.js
@@ -442,7 +442,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
             </Typography>
             
             <Grid container spacing={3}>
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <TextField
                   fullWidth
                   margin="normal"
@@ -456,7 +456,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 />
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <FormControl fullWidth margin="normal">
                   <FormLabel id="organization-type-label">Organization Type</FormLabel>
                   <RadioGroup
@@ -500,7 +500,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </FormControl>
               </Grid>
               
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <TextField
                   fullWidth
                   margin="normal"
@@ -514,7 +514,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 />
               </Grid>
               
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <TextField
                   fullWidth
                   margin="normal"
@@ -529,7 +529,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 />
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <TextField
                   fullWidth
                   margin="normal"
@@ -554,7 +554,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
             </Typography>
             
             <Grid container spacing={3}>
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <FormControl fullWidth margin="normal">
                   <InputLabel id="employee-count-label">Expected Participant Count</InputLabel>
                   <Select
@@ -581,7 +581,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </FormControl>
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <FormControl component="fieldset" fullWidth margin="normal" error={!!errors.participantType}>
                   <FormLabel component="legend">Who will participate in your hackathon?</FormLabel>
                   <Typography variant="body1" color="textSecondary" sx={{ mb: 2, fontWeight: 500 }}>
@@ -659,7 +659,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </FormControl>
               </Grid>
               
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <FormControl fullWidth margin="normal">
                   <FormLabel id="event-format-label">Event Format</FormLabel>
                   <RadioGroup
@@ -700,7 +700,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </FormControl>
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <FormControl fullWidth component="fieldset" margin="normal">
                   <FormLabel component="legend">What theme or focus would you like for your hackathon?</FormLabel>
                   <RadioGroup
@@ -779,7 +779,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 )}
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <Typography variant="h6" sx={{ mt: 3, mb: 2 }}>When would you like to host your hackathon?</Typography>
                 <Alert severity="info" sx={{ mb: 3 }}>
                   <Typography variant="body1" sx={{ fontWeight: 500 }}>
@@ -806,7 +806,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </LocalizationProvider>
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <Typography variant="h6" sx={{ mt: 4, mb: 2 }}>Schedule a Planning Call</Typography>
                 <Box sx={{ mb: 3, p: 2, bgcolor: 'primary.light', borderRadius: 2, border: '1px solid', borderColor: 'primary.main' }}>
                   <Typography variant="body1" sx={{ fontWeight: 500, color: 'primary.contrastText' }}>
@@ -815,7 +815,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </Box>
               </Grid>
               
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <LocalizationProvider dateAdapter={AdapterDateFns}>
                   <DatePicker
                     label="Preferred Call Date (Friday)"
@@ -837,7 +837,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </LocalizationProvider>
               </Grid>
               
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <LocalizationProvider dateAdapter={AdapterDateFns}>
                   <DatePicker
                     label="Alternate Call Date (Friday)"
@@ -858,7 +858,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </LocalizationProvider>
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <TextField
                   fullWidth
                   margin="normal"
@@ -1148,7 +1148,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
             </Typography>
             
             <Grid container spacing={2} sx={{ mb: 3 }}>
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <Paper elevation={0} sx={{ p: 2, bgcolor: '#f5f9ff' }}>
                   <Typography variant="subtitle1" component="h3" gutterBottom fontWeight={600}>
                     Event Logistics
@@ -1198,7 +1198,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </Paper>
               </Grid>
               
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <Paper elevation={0} sx={{ p: 2, bgcolor: '#f7f7ff' }}>
                   <Typography variant="subtitle1" component="h3" gutterBottom fontWeight={600}>
                     Event Personnel
@@ -1248,14 +1248,14 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </Paper>
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <Paper elevation={0} sx={{ p: 2, bgcolor: '#f5fff5' }}>
                   <Typography variant="subtitle1" component="h3" gutterBottom fontWeight={600}>
                     Participant & Nonprofit Management
                   </Typography>
                   
                   <Grid container spacing={2}>
-                    <Grid item xs={12} md={6}>
+                    <Grid size={{ xs: 12, md: 6 }}>
                       <Box sx={{ mb: { xs: 2, md: 0 } }}>
                         <Typography variant="body1" sx={{ mb: 1, fontWeight: 600 }}>Nonprofit Recruitment & Onboarding</Typography>
                         <RadioGroup
@@ -1271,7 +1271,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                       </Box>
                     </Grid>
                     
-                    <Grid item xs={12} md={6}>
+                    <Grid size={{ xs: 12, md: 6 }}>
                       <Box>
                         <Typography variant="body1" sx={{ mb: 1, fontWeight: 600 }}>Participant Recruitment</Typography>
                         <RadioGroup
@@ -1290,7 +1290,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </Paper>
               </Grid>
               
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <Paper elevation={0} sx={{ p: 2, bgcolor: '#fff5f5' }}>
                   <Typography variant="subtitle1" component="h3" gutterBottom fontWeight={600}>
                     Post-Event Support
@@ -1483,7 +1483,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                 </Typography>
                 
                 <Grid container spacing={2}>
-                  <Grid item xs={12} md={6}>
+                  <Grid size={{ xs: 12, md: 6 }}>
                     <Box sx={{ display: 'flex', mb: 1 }}>
                       <CheckCircleIcon sx={{ color: theme.palette.success.main, mr: 1, fontSize: 20 }} />
                       <Typography variant="body2">Organizer travel to your location (if needed)</Typography>
@@ -1493,7 +1493,7 @@ const HackathonRequestForm = ({ initialData, onSubmit, isEdit = false }) => {
                       <Typography variant="body2">Event coordination and planning assistance</Typography>
                     </Box>
                   </Grid>
-                  <Grid item xs={12} md={6}>
+                  <Grid size={{ xs: 12, md: 6 }}>
                     <Box sx={{ display: 'flex', mb: 1 }}>
                       <CheckCircleIcon sx={{ color: theme.palette.success.main, mr: 1, fontSize: 20 }} />
                       <Typography variant="body2">Marketing support for your event</Typography>

--- a/src/components/HeartGauge/MilestoneProgress.js
+++ b/src/components/HeartGauge/MilestoneProgress.js
@@ -217,7 +217,7 @@ const MilestoneProgress = ({ history }) => {
             const isCurrentTier = currentTier?.tier === tier;
 
             return (
-              <Grid item xs={12} sm={6} md={4} key={tier}>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }} key={tier}>
                 <Box
                   sx={{
                     p: 2,

--- a/src/components/ImpactMetrics/ImpactMetrics.js
+++ b/src/components/ImpactMetrics/ImpactMetrics.js
@@ -319,7 +319,7 @@ const ImpactMetrics = ({ event_id, eventData, compact = false, minimal = false }
 
       <Grid container spacing={compact ? 0.5 : 1.5}>
         {/* Volunteers Metric */}
-        <Grid item xs={6} sm={compact ? 6 : 3}>
+        <Grid size={{ xs: 6, sm: compact ? 6 : 3 }}>
           <MetricCard
             title="Volunteers"
             value={metrics.volunteers.total}
@@ -331,7 +331,7 @@ const ImpactMetrics = ({ event_id, eventData, compact = false, minimal = false }
         </Grid>
 
         {/* Teams Metric */}
-        <Grid item xs={6} sm={compact ? 6 : 3}>
+        <Grid size={{ xs: 6, sm: compact ? 6 : 3 }}>
           <MetricCard
             title="Teams"
             value={metrics.teams.active || metrics.teams.total}
@@ -345,7 +345,7 @@ const ImpactMetrics = ({ event_id, eventData, compact = false, minimal = false }
 
         {/* GitHub Activity Metric - Only show on larger screens or if not compact */}
         {!compact && (
-          <Grid item xs={6} sm={3}>
+          <Grid size={{ xs: 6, sm: 3 }}>
             <MetricCard
               title="Commits"
               value={metrics.github.commits}
@@ -358,7 +358,7 @@ const ImpactMetrics = ({ event_id, eventData, compact = false, minimal = false }
         )}
 
         {/* Nonprofits Metric */}
-        <Grid item xs={6} sm={compact ? 6 : 3}>
+        <Grid size={{ xs: 6, sm: compact ? 6 : 3 }}>
           <MetricCard
             title="Nonprofits"
             value={metrics.nonprofits.total}
@@ -371,7 +371,7 @@ const ImpactMetrics = ({ event_id, eventData, compact = false, minimal = false }
 
         {/* Show commits in compact mode on a second row */}
         {compact && metrics.github.commits > 0 && (
-          <Grid item xs={6} sm={6}>
+          <Grid size={{ xs: 6, sm: 6 }}>
             <MetricCard
               title="Commits"
               value={metrics.github.commits}
@@ -387,7 +387,7 @@ const ImpactMetrics = ({ event_id, eventData, compact = false, minimal = false }
       {!compact && (metrics.github.issues > 0 || metrics.github.contributors > 0) && (
         <Grid container spacing={1.5} sx={{ mt: 1, display: { xs: 'none', md: 'flex' } }}>
           {metrics.github.issues > 0 && (
-            <Grid item md={4}>
+            <Grid size={{ md: 4 }}>
               <MetricCard
                 title="Issues"
                 value={metrics.github.issues}
@@ -399,7 +399,7 @@ const ImpactMetrics = ({ event_id, eventData, compact = false, minimal = false }
             </Grid>
           )}
           {metrics.github.contributors > 0 && (
-            <Grid item md={4}>
+            <Grid size={{ md: 4 }}>
               <MetricCard
                 title="Contributors"
                 value={metrics.github.contributors}
@@ -411,7 +411,7 @@ const ImpactMetrics = ({ event_id, eventData, compact = false, minimal = false }
             </Grid>
           )}
           {metrics.hackers.total > 0 && (
-            <Grid item md={4}>
+            <Grid size={{ md: 4 }}>
               <MetricCard
                 title="Hackers"
                 value={metrics.hackers.total}

--- a/src/components/MyProfile/MyProfile.js
+++ b/src/components/MyProfile/MyProfile.js
@@ -72,7 +72,7 @@ const ProfilePage = () => {
                         />
                     </Box>
                     <Grid container spacing={2}>
-                        <Grid item xs={12} md={6}>
+                        <Grid size={{ xs: 12, md: 6 }}>
                             <StyledPaper elevation={3}>
                                 <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                                     <SkeletonAvatar size={150} />
@@ -89,7 +89,7 @@ const ProfilePage = () => {
                                 </Box>
                             </StyledPaper>
                         </Grid>
-                        <Grid item xs={12} md={6}>
+                        <Grid size={{ xs: 12, md: 6 }}>
                             <StyledPaper elevation={3}>
                                 <SkeletonText 
                                     lines={3} 
@@ -98,7 +98,7 @@ const ProfilePage = () => {
                                 />
                             </StyledPaper>
                         </Grid>
-                        <Grid item xs={12}>
+                        <Grid size={{ xs: 12 }}>
                             <StyledPaper elevation={3}>
                                 <SkeletonText 
                                     lines={0} 
@@ -107,7 +107,7 @@ const ProfilePage = () => {
                                 <SkeletonContent height={180} />
                             </StyledPaper>
                         </Grid>
-                        <Grid item xs={12}>
+                        <Grid size={{ xs: 12 }}>
                             <StyledPaper elevation={3}>
                                 <SkeletonText 
                                     lines={0} 
@@ -126,7 +126,7 @@ const ProfilePage = () => {
         <ProfileContainer>
             <Container maxWidth="lg">
                 <Grid container spacing={2}>
-                    <Grid item xs={12} md={6}>
+                    <Grid size={{ xs: 12, md: 6 }}>
                         <StyledPaper elevation={3}>
                             <ProfileHeader name={mockData.name} bio={mockData.bio} avatarUrl={mockData.avatarUrl} />
                             <CenteredContent>
@@ -134,17 +134,17 @@ const ProfilePage = () => {
                             </CenteredContent>
                         </StyledPaper>
                     </Grid>
-                    <Grid item xs={12} md={6}>
+                    <Grid size={{ xs: 12, md: 6 }}>
                         <StyledPaper elevation={3}>
                             <ProfileDetails details={mockData.details} />
                         </StyledPaper>
                     </Grid>
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                         <StyledPaper elevation={3}>
                             <ProjectList projects={mockData.projects} />
                         </StyledPaper>
                     </Grid>
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                         <StyledPaper elevation={3}>
                             <WeeklyStats stats={mockData.weeklyStats} />
                         </StyledPaper>

--- a/src/components/News/SingleNews.js
+++ b/src/components/News/SingleNews.js
@@ -89,7 +89,7 @@ function SingleNews( {newsItem} ) {
 
         <BlankContainer xs={12} md={12} lg={12}  key={newsItem.id}>
           <TitleContainer container>          
-            <Grid item xs={12} md={12} lg={12}>                          
+            <Grid size={{ xs: 12, md: 12, lg: 12 }}>                          
               {newsItem?.image && (
               <Image
                 src={normalizeImageUrl(newsItem.image)}
@@ -128,7 +128,7 @@ function SingleNews( {newsItem} ) {
               </TitleStyled>
               
             </Grid>
-            <Grid item xs={12} md={12} lg={12}>
+            <Grid size={{ xs: 12, md: 12, lg: 12 }}>
               <TextMuted>
                 <CalendarTodayIcon style={{ marginRight: '5px' }} />
                 {newsItem.slack_ts_human_readable}

--- a/src/components/NonProfit/NonProfit.js
+++ b/src/components/NonProfit/NonProfit.js
@@ -151,7 +151,7 @@ const NonProfit = React.memo(function NonProfit(props) {
     if (!nonprofit.problem_statements || nonprofit.problem_statements.length === 0) {      
       return (
         <Grid container>
-          <Grid item style={{ fontSize: "13px"}} xs={12}>
+          <Grid size={{ xs: 12 }} style={{ fontSize: "13px"}}>
             <Typography style={style}>{nonprofit_cta_text}</Typography>
             <br/>
           </Grid>
@@ -226,7 +226,7 @@ const NonProfit = React.memo(function NonProfit(props) {
       <TitleContainer container>
         {nonprofit.id ? (
           <>
-            <Grid item>
+            <Grid>
               <TitleChipContainer>
                 <TitleStyled variant='h2' style={{paddingBottom: "0"}}>
                   <Avatar
@@ -246,7 +246,7 @@ const NonProfit = React.memo(function NonProfit(props) {
               </TitleChipContainer>
             </Grid>
             
-            <Grid item>
+            <Grid>
               {description && (
                 <Typography style={{fontSize:"13px"}}>{description}</Typography>
               )}

--- a/src/components/NonProfitApply/NonProfitApplyList.js
+++ b/src/components/NonProfitApply/NonProfitApplyList.js
@@ -465,7 +465,7 @@ function NonProfitApplyList({ userClass }) {
                                             <Collapse in={expandedAppId === app.id} timeout="auto" unmountOnExit>
                                                 <Box sx={{ p: 2, backgroundColor: 'grey.50', borderTop: '1px solid', borderColor: 'divider' }}>
                                                     <Grid container spacing={2} divider={<Divider orientation="vertical" flexItem />}>
-                                                        <Grid item xs={12} md={5} sx={{ p: 2 }}>
+                                                        <Grid size={{ xs: 12, md: 5 }} sx={{ p: 2 }}>
                                                             <Typography variant="h6" gutterBottom>Application Details</Typography>
                                                             <Typography variant="body2" mt={1}><strong>Contact Email:</strong> {app.email || 'Not Provided'}</Typography>
                                                             <Typography variant="subtitle2" sx={{ mt: 2, fontWeight: 'bold' }}>Problem Statement</Typography>
@@ -473,7 +473,7 @@ function NonProfitApplyList({ userClass }) {
                                                             <Typography variant="subtitle2" sx={{ mt: 2, fontWeight: 'bold' }}>Proposed Solution / Benefits</Typography>
                                                             <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', maxHeight: 200, overflow: 'auto', p:1, border: '1px solid', borderColor: 'grey.300', borderRadius: 1 }}>{app.solutionBenefits || 'Not Provided'}</Typography>
                                                         </Grid>
-                                                        <Grid item xs={12} md={4} sx={{ p: 2 }}>
+                                                        <Grid size={{ xs: 12, md: 4 }} sx={{ p: 2 }}>
                                                             <Typography variant="h6" gutterBottom>AI-Generated Summary</Typography>
                                                             
                                                             {isSummarizing ? (
@@ -515,7 +515,7 @@ function NonProfitApplyList({ userClass }) {
                                                                 </>
                                                             )}
                                                         </Grid>
-                                                        <Grid item xs={12} md={3} sx={{ p: 2 }}>
+                                                        <Grid size={{ xs: 12, md: 3 }} sx={{ p: 2 }}>
                                                             <Typography variant="h6" gutterBottom>Similar Projects</Typography>
                                                             {isSearching ? (
                                                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}><CircularProgress size={24} /><Typography>Searching...</Typography></Box>

--- a/src/components/NonProfitList/NonProfitList.js
+++ b/src/components/NonProfitList/NonProfitList.js
@@ -229,7 +229,7 @@ function NonProfitList() {
               </Typography>
               
               <Grid container spacing={2} sx={{ mb: 3 }}>
-                <Grid item xs={12} md={6}>
+                <Grid size={{ xs: 12, md: 6 }}>
                   <Card sx={{ bgcolor: 'rgba(255,255,255,0.95)', height: '100%' }}>
                     <CardContent>
                       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
@@ -257,7 +257,7 @@ function NonProfitList() {
                     </CardContent>
                   </Card>
                 </Grid>
-                <Grid item xs={12} md={6}>
+                <Grid size={{ xs: 12, md: 6 }}>
                   <Card sx={{ bgcolor: 'rgba(255,255,255,0.95)', height: '100%' }}>
                     <CardContent>
                       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>

--- a/src/components/NonProfitListTile/NonProfitListTile.js
+++ b/src/components/NonProfitListTile/NonProfitListTile.js
@@ -210,7 +210,7 @@ export default function NonProfitListTile({
           >
             <Grid container spacing={2} marginLeft='0px' marginTop='5px'>
               <Grid container direction='row' spacing={1.5}>
-                <Grid item>
+                <Grid>
                   <Chip
                     icon={<AddAlertIcon color='warning' fontSize='medium' />}
                     color={
@@ -223,7 +223,7 @@ export default function NonProfitListTile({
                     style={{ fontSize: '1.5rem' }}
                   />
                 </Grid>
-                <Grid item>
+                <Grid>
                   <Chip
                     icon={
                       <WorkspacePremiumIcon color='success' fontSize='medium' />
@@ -238,7 +238,7 @@ export default function NonProfitListTile({
                     style={{ fontSize: '1.5rem' }}
                   />
                 </Grid>
-                <Grid item>
+                <Grid>
                   <Chip
                     icon={<DeveloperModeIcon color='info' fontSize='medium' />}
                     color='info'
@@ -250,7 +250,7 @@ export default function NonProfitListTile({
                     style={{ fontSize: '1.5rem' }}
                   />
                 </Grid>
-                <Grid item>
+                <Grid>
                   <Chip
                     icon={<SupportIcon color='info' fontSize='medium' />}
                     color='info'
@@ -263,7 +263,7 @@ export default function NonProfitListTile({
                   />
                 </Grid>
               </Grid>
-              {/* <Grid item xs={6}>
+              {/* <Grid size={{ xs: 6 }}>
                 <Badge
                   showZero
                   anchorOrigin={{
@@ -276,7 +276,7 @@ export default function NonProfitListTile({
                   <AddAlertIcon color='error' fontSize='large' />
                 </Badge> 
               </Grid> */}
-              {/* <Grid item xs={6}>
+              {/* <Grid size={{ xs: 6 }}>
                 <Badge
                   showZero
                   anchorOrigin={{
@@ -290,7 +290,7 @@ export default function NonProfitListTile({
                 </Badge>
                 Hackers
               </Grid> */}
-              {/* <Grid item xs={7}>
+              {/* <Grid size={{ xs: 7 }}>
                 <Badge
                   showZero
                   anchorOrigin={{
@@ -304,7 +304,7 @@ export default function NonProfitListTile({
                 </Badge>
                 Live
               </Grid> */}
-              {/* <Grid item xs={5}>
+              {/* <Grid size={{ xs: 5 }}>
                 <Badge
                   showZero
                   anchorOrigin={{

--- a/src/components/Onboarding/BuddySystem.js
+++ b/src/components/Onboarding/BuddySystem.js
@@ -130,7 +130,7 @@ const BuddySystem = () => {
           provide guidance, and help you navigate our community. Your buddy can:
         </Typography>
         <Grid container spacing={2}>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <Chip size="medium" label="1" color="primary" sx={{ width: 36, height: 36, fontSize: '1.2rem', fontWeight: 'bold', borderRadius: '50%', p: 0 }} />
@@ -152,7 +152,7 @@ const BuddySystem = () => {
               </Box>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <Chip size="medium" label="4" color="primary" sx={{ width: 36, height: 36, fontSize: '1.2rem', fontWeight: 'bold', borderRadius: '50%', p: 0 }} />
@@ -190,7 +190,7 @@ const BuddySystem = () => {
           
           <Grid container spacing={3}>
             {/* Buddy profile */}
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Box sx={{ textAlign: 'center', mb: 2 }}>
                 <BuddyAvatar>
                   {selectedBuddy.name.charAt(0)}
@@ -244,7 +244,7 @@ const BuddySystem = () => {
             </Grid>
             
             {/* Buddy details and request form */}
-            <Grid item xs={12} md={8}>
+            <Grid size={{ xs: 12, md: 8 }}>
               <Box sx={{ mb: 3 }}>
                 <Typography variant="h6" gutterBottom>
                   Skills
@@ -315,7 +315,7 @@ const BuddySystem = () => {
           {/* Search and filter section */}
           <Box sx={{ mb: 3 }}>
             <Grid container spacing={2} alignItems="center">
-              <Grid item xs={12} sm={8}>
+              <Grid size={{ xs: 12, sm: 8 }}>
                 <TextField
                   fullWidth
                   label={<span style={{ fontSize: '1.4rem'}}>Search Buddies</span>}
@@ -333,7 +333,7 @@ const BuddySystem = () => {
                   }}
                 />
               </Grid>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <Button
                   fullWidth
                   variant="outlined"
@@ -357,7 +357,7 @@ const BuddySystem = () => {
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container spacing={2}>
-                  <Grid item xs={12} sm={4}>
+                  <Grid size={{ xs: 12, sm: 4 }}>
                     <FormControl fullWidth>
                       <InputLabel sx={{ fontSize: '1.2rem' }}>Skills</InputLabel>
                       <Select
@@ -372,7 +372,7 @@ const BuddySystem = () => {
                       </Select>
                     </FormControl>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
+                  <Grid size={{ xs: 12, sm: 4 }}>
                     <FormControl fullWidth>
                       <InputLabel sx={{ fontSize: '1.2rem' }}>Interests</InputLabel>
                       <Select
@@ -387,7 +387,7 @@ const BuddySystem = () => {
                       </Select>
                     </FormControl>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
+                  <Grid size={{ xs: 12, sm: 4 }}>
                     <FormControl fullWidth>
                       <InputLabel sx={{ fontSize: '1.2rem' }}>Availability</InputLabel>
                       <Select
@@ -426,7 +426,7 @@ const BuddySystem = () => {
           How the Buddy System Works
         </Typography>
         <Grid container spacing={3}>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Paper sx={{ p: 2, height: '100%' }}>
               <Typography variant="h6" sx={{ fontSize: '1.3rem', fontWeight: 'bold', mb: 1 }}>
                 For New Members
@@ -440,7 +440,7 @@ const BuddySystem = () => {
               </Typography>
             </Paper>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Paper sx={{ p: 2, height: '100%' }}>
               <Typography variant="h6" sx={{ fontSize: '1.3rem', fontWeight: 'bold', mb: 1 }}>
                 Buddy Expectations

--- a/src/components/Onboarding/FeedbackSection.js
+++ b/src/components/Onboarding/FeedbackSection.js
@@ -379,7 +379,7 @@ const FeedbackSection = () => {
           <form onSubmit={handleSubmit}>
             <Grid container spacing={4}>
               {/* Overall rating */}
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <RatingContainer>
                   <Box sx={{ mr: 2 }}>
                     <Typography variant="h6" id="overall-rating-label" sx={{ fontSize: '1.4rem' }}>
@@ -407,7 +407,7 @@ const FeedbackSection = () => {
               </Grid>
 
               {/* Most useful topics */}
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <Typography variant="h6" gutterBottom sx={{ fontSize: '1.4rem' }}>
                   Most Useful Content
                 </Typography>
@@ -432,7 +432,7 @@ const FeedbackSection = () => {
               </Grid>
 
               {/* Missing topics */}
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <TextField
                   fullWidth
                   label="What topics were missing or should be covered better?"
@@ -451,7 +451,7 @@ const FeedbackSection = () => {
               </Grid>
 
               {/* Ease of understanding */}
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <FormControl component="fieldset" error={!!errors.easeOfUnderstanding}>
                   <FormLabel component="legend">
                     <Typography variant="h6" gutterBottom sx={{ fontSize: '1.4rem' }}>
@@ -467,7 +467,7 @@ const FeedbackSection = () => {
                     onChange={handleEaseChange}
                   >
                     <Grid container spacing={1}>
-                      <Grid item xs={12} sm={6}>
+                      <Grid size={{ xs: 12, sm: 6 }}>
                         <FormControlLabel 
                           value="Very easy" 
                           control={<Radio />} 
@@ -475,7 +475,7 @@ const FeedbackSection = () => {
                           sx={{ '& .MuiFormControlLabel-label': { fontSize: '1.1rem' } }}
                         />
                       </Grid>
-                      <Grid item xs={12} sm={6}>
+                      <Grid size={{ xs: 12, sm: 6 }}>
                         <FormControlLabel 
                           value="Mostly clear" 
                           control={<Radio />} 
@@ -483,7 +483,7 @@ const FeedbackSection = () => {
                           sx={{ '& .MuiFormControlLabel-label': { fontSize: '1.1rem' } }}
                         />
                       </Grid>
-                      <Grid item xs={12} sm={6}>
+                      <Grid size={{ xs: 12, sm: 6 }}>
                         <FormControlLabel 
                           value="Somewhat confusing" 
                           control={<Radio />} 
@@ -491,7 +491,7 @@ const FeedbackSection = () => {
                           sx={{ '& .MuiFormControlLabel-label': { fontSize: '1.1rem' } }}
                         />
                       </Grid>
-                      <Grid item xs={12} sm={6}>
+                      <Grid size={{ xs: 12, sm: 6 }}>
                         <FormControlLabel 
                           value="Very difficult" 
                           control={<Radio />} 
@@ -508,7 +508,7 @@ const FeedbackSection = () => {
               </Grid>
 
               {/* Suggestions for improvement */}
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <TextField
                   fullWidth
                   label="How could we improve the onboarding experience?"
@@ -529,7 +529,7 @@ const FeedbackSection = () => {
               </Grid>
 
               {/* Additional feedback */}
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <TextField
                   fullWidth
                   label="Additional Comments (Optional)"
@@ -548,7 +548,7 @@ const FeedbackSection = () => {
               </Grid>
 
               {/* Contact for follow-up */}
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <FormControlLabel
                   control={
                     <Checkbox
@@ -564,7 +564,7 @@ const FeedbackSection = () => {
                 {contactForFollowup && (
                   <Fade in={contactForFollowup}>
                     <Grid container spacing={2} sx={{ mt: 1 }}>
-                      <Grid item xs={12} sm={6}>
+                      <Grid size={{ xs: 12, sm: 6 }}>
                         <TextField
                           fullWidth
                           label="First Name"
@@ -579,7 +579,7 @@ const FeedbackSection = () => {
                           }}
                         />
                       </Grid>
-                      <Grid item xs={12} sm={6}>
+                      <Grid size={{ xs: 12, sm: 6 }}>
                         <TextField
                           fullWidth
                           label="Email"
@@ -601,7 +601,7 @@ const FeedbackSection = () => {
               </Grid>
 
               {/* Submit button */}
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <Button
                   type="submit"
                   variant="contained"
@@ -634,7 +634,7 @@ const FeedbackSection = () => {
           How We Use Your Feedback
         </Typography>
         <Grid container spacing={3}>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card sx={{ height: '100%' }}>
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
@@ -649,7 +649,7 @@ const FeedbackSection = () => {
               </CardContent>
             </Card>
           </Grid>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card sx={{ height: '100%' }}>
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
@@ -664,7 +664,7 @@ const FeedbackSection = () => {
               </CardContent>
             </Card>
           </Grid>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card sx={{ height: '100%' }}>
               <CardContent>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>

--- a/src/components/Onboarding/IntroductionPrompt.js
+++ b/src/components/Onboarding/IntroductionPrompt.js
@@ -192,7 +192,7 @@ const IntroductionPrompt = () => {
           and creates opportunities for collaboration. A good introduction can help you:
         </Typography>
         <Grid container spacing={2} sx={{ mb: 2 }}>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <IntroCard>
               <CardContent>
                 <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
@@ -204,7 +204,7 @@ const IntroductionPrompt = () => {
               </CardContent>
             </IntroCard>
           </Grid>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <IntroCard>
               <CardContent>
                 <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
@@ -216,7 +216,7 @@ const IntroductionPrompt = () => {
               </CardContent>
             </IntroCard>
           </Grid>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <IntroCard>
               <CardContent>
                 <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
@@ -228,7 +228,7 @@ const IntroductionPrompt = () => {
               </CardContent>
             </IntroCard>
           </Grid>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <IntroCard>
               <CardContent>
                 <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
@@ -253,7 +253,7 @@ const IntroductionPrompt = () => {
 
       <Grid container spacing={3}>
         {/* Left side - form inputs */}
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Stack spacing={3}>
             <TextField
               label="Your Name"
@@ -337,7 +337,7 @@ const IntroductionPrompt = () => {
         </Grid>
 
         {/* Right side - Experience Level and Skills */}
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
             <Stack spacing={3}>
                 {/* Experience Level */}
                 <Box>

--- a/src/components/Onboarding/JudgingOverview.js
+++ b/src/components/Onboarding/JudgingOverview.js
@@ -136,7 +136,7 @@ const JudgingOverview = () => {
           Judging at Opportunity Hack is a rewarding way to give back to the community while gaining valuable experience:
         </Typography>
         <Grid container spacing={2}>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
               <CheckCircleIcon color="primary" sx={{ mt: 0.5 }} />
               <Typography variant="body1" sx={{ fontSize: '1.2rem' }}>
@@ -144,7 +144,7 @@ const JudgingOverview = () => {
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
               <CheckCircleIcon color="primary" sx={{ mt: 0.5 }} />
               <Typography variant="body1" sx={{ fontSize: '1.2rem' }}>
@@ -152,7 +152,7 @@ const JudgingOverview = () => {
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
               <CheckCircleIcon color="primary" sx={{ mt: 0.5 }} />
               <Typography variant="body1" sx={{ fontSize: '1.2rem' }}>
@@ -160,7 +160,7 @@ const JudgingOverview = () => {
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
               <CheckCircleIcon color="primary" sx={{ mt: 0.5 }} />
               <Typography variant="body1" sx={{ fontSize: '1.2rem' }}>
@@ -177,7 +177,7 @@ const JudgingOverview = () => {
       </Typography>
       <Grid container spacing={3} sx={{ mb: 4 }}>
         {judgingStages.map((item, index) => (
-          <Grid item xs={12} md={6} key={index}>
+          <Grid size={{ xs: 12, md: 6 }} key={index}>
             <Paper
               elevation={2}
               sx={{
@@ -213,7 +213,7 @@ const JudgingOverview = () => {
       </Typography>
       <Grid container spacing={3} sx={{ mb: 4 }}>
         {judgingCriteria.map((criteria, index) => (
-          <Grid item xs={12} sm={6} key={index}>
+          <Grid size={{ xs: 12, sm: 6 }} key={index}>
             <CriteriaCard>
               <CardContent>
                 <Box sx={{ textAlign: 'center', mb: 2 }}>

--- a/src/components/Onboarding/MissionOverview.js
+++ b/src/components/Onboarding/MissionOverview.js
@@ -155,7 +155,7 @@ const MissionOverview = () => {
       {/* Impact numbers */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
         {impactNumbers.map((item, index) => (
-          <Grid item xs={6} sm={3} key={index}>
+          <Grid size={{ xs: 6, sm: 3 }} key={index}>
             <Paper elevation={0} sx={{ 
               p: 3, 
               textAlign: 'center',
@@ -181,7 +181,7 @@ const MissionOverview = () => {
       </Typography>
       <Grid container spacing={3} sx={{ mb: 4 }}>
         {coreValues.map((value, index) => (
-          <Grid item xs={12} sm={6} key={index}>
+          <Grid size={{ xs: 12, sm: 6 }} key={index}>
             <ValueCard>
               <CardContent>
                 <StyledAvatar>{value.title.charAt(0)}</StyledAvatar>

--- a/src/components/Onboarding/SlackTutorial.js
+++ b/src/components/Onboarding/SlackTutorial.js
@@ -165,7 +165,7 @@ const SlackTutorial = () => {
           </Typography>
           
           <Grid container spacing={3} sx={{ mb: 3 }}>
-            <Grid item xs={12} md={7}>
+            <Grid size={{ xs: 12, md: 7 }}>
               <List>
                 <ListItem alignItems="flex-start">
                   <StepNumber>1</StepNumber>
@@ -222,7 +222,7 @@ const SlackTutorial = () => {
                 </ListItem>
               </List>
             </Grid>
-            <Grid item xs={12} md={5}>
+            <Grid size={{ xs: 12, md: 5 }}>
               <Card elevation={2}>
                 <CardContent>
                   <Typography variant="h6" gutterBottom sx={{ fontSize: '1.4rem' }}>
@@ -306,7 +306,7 @@ const SlackTutorial = () => {
           </Typography>
           
           <Grid container spacing={3} sx={{ mb: 3 }}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
                 Understanding Channels
               </Typography>
@@ -392,7 +392,7 @@ const SlackTutorial = () => {
               </List>
             </Grid>
             
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
                 Direct Messages & Group DMs
               </Typography>
@@ -406,7 +406,7 @@ const SlackTutorial = () => {
                     When to use DMs vs. Channels:
                   </Typography>
                   <Grid container>
-                    <Grid item xs={6}>
+                    <Grid size={{ xs: 6 }}>
                       <Typography sx={{ fontWeight: 'bold', fontSize: '1.3rem', mb: 1 }}>
                         Use DMs for:
                       </Typography>
@@ -429,7 +429,7 @@ const SlackTutorial = () => {
                         </Box>
                       </Box>
                     </Grid>
-                    <Grid item xs={6}>
+                    <Grid size={{ xs: 6 }}>
                       <Typography sx={{ fontWeight: 'bold', fontSize: '1.3rem', mb: 1 }}>
                         Use Channels for:
                       </Typography>
@@ -504,7 +504,7 @@ const SlackTutorial = () => {
           </Typography>
           
           <Grid container spacing={3} sx={{ mb: 3 }}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
                 Types of Mentions
               </Typography>
@@ -545,7 +545,7 @@ const SlackTutorial = () => {
               </Alert>
             </Grid>
             
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
                 Configuring Notifications
               </Typography>
@@ -647,7 +647,7 @@ const SlackTutorial = () => {
           </Typography>
           
           <Grid container spacing={3} sx={{ mb: 3 }}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h6" gutterBottom sx={{ fontSize: '1.5rem' }}>
                 Communication Guidelines
               </Typography>
@@ -699,7 +699,7 @@ const SlackTutorial = () => {
                 </ListItem>
               </List>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ mb: 3 }}>
                 <CardContent>
                   <Typography variant="subtitle1" gutterBottom color="primary" sx={{ fontSize: '1.4rem' }}>
@@ -831,7 +831,7 @@ const SlackTutorial = () => {
               {praiseBotExpanded && (
                 <Box sx={{ mt: 3 }}>
                   <Grid container spacing={3}>
-                    <Grid item xs={12} md={8}>
+                    <Grid size={{ xs: 12, md: 8 }}>
                       <Typography variant="body2" paragraph sx={{ fontSize: '1.25rem' }}>
                         The Praise Bot helps you recognize and appreciate your fellow OHack community members. 
                         Use it to give public recognition for great work, helpful contributions, or just to spread positivity!
@@ -899,7 +899,7 @@ const SlackTutorial = () => {
                       </Alert>
                     </Grid>
                     
-                    <Grid item xs={12} md={4}>
+                    <Grid size={{ xs: 12, md: 4 }}>
                       <Card elevation={1}>
                         <CardContent>
                           <Typography variant="h6" gutterBottom sx={{ fontSize: '1.4rem' }}>

--- a/src/components/Onboarding/WelcomeSection.js
+++ b/src/components/Onboarding/WelcomeSection.js
@@ -92,7 +92,7 @@ const WelcomeSection = () => {
       </Typography>
       <Grid container spacing={3} sx={{ mb: 4 }}>
         {benefitItems.map((item, index) => (
-          <Grid item xs={12} sm={6} md={3} key={index}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }} key={index}>
             <BenefitCard>
               <CardIconContainer>
                 {item.icon}

--- a/src/components/ProblemStatement/ProblemStatement.js
+++ b/src/components/ProblemStatement/ProblemStatement.js
@@ -836,7 +836,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
           <CardContent sx={{ p: 4 }}>
             {/* Engagement Metrics */}
             <Grid container spacing={isMobile ? 2 : 3} sx={{ mb: 4 }}>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <Zoom in timeout={600} style={{ transitionDelay: '200ms' }}>
                   <MetricCard>
                     <Stack alignItems="center" spacing={1}>
@@ -853,7 +853,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
                   </MetricCard>
                 </Zoom>
               </Grid>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <Zoom in timeout={600} style={{ transitionDelay: '400ms' }}>
                   <MetricCard>
                     <Stack alignItems="center" spacing={1}>
@@ -870,7 +870,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
                   </MetricCard>
                 </Zoom>
               </Grid>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <Zoom in timeout={600} style={{ transitionDelay: '600ms' }}>
                   <MetricCard>
                     <Stack alignItems="center" spacing={1}>
@@ -1029,7 +1029,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
                     <Box id="github-content" sx={{ p: 3 }}>
                       <Grid container spacing={2}>
                         {problem_statement.github.map((repo, index) => (
-                          <Grid item xs={12} sm={6} key={index}>
+                          <Grid size={{ xs: 12, sm: 6 }} key={index}>
                             <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
                               <Typography variant="subtitle1" fontWeight={600} gutterBottom>
                                 {repo.name}

--- a/src/components/Profile/GitHubContribution.js
+++ b/src/components/Profile/GitHubContribution.js
@@ -76,28 +76,28 @@ const GitHubContributions = ({ githubHistory }) => {
         GitHub Contributions for @<strong>{githubHistory[0].login}</strong>
       </Typography>
       <Grid container spacing={2} sx={{ mb: 2 }}>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Chip
             icon={<Code />}
             label={`${totalCommits} Commits`}
             color="primary"
           />
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Chip
             icon={<MergeType />}
             label={`${totalPRs} Pull Requests`}
             color="secondary"
           />
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Chip
             icon={<BugReport />}
             label={`${totalIssues} Issues`}
             color="info"
           />
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Chip
             icon={<RateReview />}
             label={`${totalReviews} Reviews`}
@@ -111,13 +111,7 @@ const GitHubContributions = ({ githubHistory }) => {
       </Typography>
       <Grid container spacing={2}>
         {sortedRepos.map((repo) => (
-          <Grid
-            item
-            xs={12}
-            sm={6}
-            md={4}
-            key={`${repo.org_name}/${repo.repo_name}`}
-          >
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={`${repo.org_name}/${repo.repo_name}`}>
             <Card>
               <CardContent>
                 <Typography variant="h6" gutterBottom noWrap>

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -707,7 +707,7 @@ export default function Profile(props) {
                   </Typography>
                   
                   <Grid container spacing={3}>
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       {isLoading ? (
                         <Skeleton variant="rectangular" height={56} />
                       ) : (
@@ -733,7 +733,7 @@ export default function Profile(props) {
                       )}
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <FormControl fullWidth>            
                           <TextField
@@ -756,7 +756,7 @@ export default function Profile(props) {
                       </Box>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       {isLoading ? (
                         <Skeleton variant="rectangular" height={56} />
                       ) : (
@@ -772,7 +772,7 @@ export default function Profile(props) {
                       )}
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <FormControl fullWidth>            
                           <TextField
@@ -795,7 +795,7 @@ export default function Profile(props) {
                       </Box>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <FormControl fullWidth>            
                         <TextField
                           id="linkedin"
@@ -809,7 +809,7 @@ export default function Profile(props) {
                       </FormControl>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <FormControl fullWidth>            
                         <TextField
                           id="instagram"
@@ -823,7 +823,7 @@ export default function Profile(props) {
                       </FormControl>
                     </Grid>
                     
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
                         <FormControl fullWidth>            
                           <TextField
@@ -850,7 +850,7 @@ export default function Profile(props) {
                       </Box>
                     </Grid>
                     
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                       {isLoading ? (
                         <Skeleton variant="rectangular" height={80} />
                       ) : (
@@ -876,14 +876,14 @@ export default function Profile(props) {
                   </Typography>
                   
                   <Grid container spacing={4}>
-                    <Grid item xs={12} md={6}>
+                    <Grid size={{ xs: 12, md: 6 }}>
                       {isLoading ? (
                         <Skeleton variant="rectangular" height={180} />
                       ) : (
                         <RaffleEntries profile={profile} githubHistory={githubHistory} />
                       )}
                     </Grid>
-                    <Grid item xs={12} md={6}>
+                    <Grid size={{ xs: 12, md: 6 }}>
                       {isLoading || isGithubLoading ? (
                         <Skeleton variant="rectangular" height={180} />
                       ) : (
@@ -940,7 +940,7 @@ export default function Profile(props) {
                   </Typography>
                   
                   <Grid container spacing={3}>
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       {isLoading ? (
                         <Skeleton variant="rectangular" height={56} />
                       ) : (
@@ -956,7 +956,7 @@ export default function Profile(props) {
                       )}
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <FormControlLabel
                         control={
                           <Checkbox 
@@ -975,7 +975,7 @@ export default function Profile(props) {
                   </Typography>
                   
                   <Grid container spacing={3}>
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                       <FormControl fullWidth>
                         <TextField
                           id="street_address"
@@ -989,7 +989,7 @@ export default function Profile(props) {
                       </FormControl>
                     </Grid>
                     
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                       <FormControl fullWidth>
                         <TextField
                           id="street_address_2"
@@ -1003,7 +1003,7 @@ export default function Profile(props) {
                       </FormControl>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <FormControl fullWidth>
                         <TextField
                           id="city"
@@ -1017,7 +1017,7 @@ export default function Profile(props) {
                       </FormControl>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <FormControl fullWidth>
                         <TextField
                           id="state"
@@ -1031,7 +1031,7 @@ export default function Profile(props) {
                       </FormControl>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <FormControl fullWidth>
                         <TextField
                           id="postal_code"
@@ -1045,7 +1045,7 @@ export default function Profile(props) {
                       </FormControl>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={4}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }}>
                       <CustomSelect
                         label="Country"
                         value={country}

--- a/src/components/Profile/PublicProfile.js
+++ b/src/components/Profile/PublicProfile.js
@@ -198,7 +198,7 @@ const PublicProfile = () => {
 
       <Grid container spacing={4}>
         {/* Left Column */}
-        <Grid item xs={12} md={8}>
+        <Grid size={{ xs: 12, md: 8 }}>
           {/* Basic Information */}
           <Paper elevation={1} sx={{ mb: 4, borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
@@ -218,7 +218,7 @@ const PublicProfile = () => {
 
               <Grid container spacing={3}>
                 {/* GitHub Username */}
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography
                     variant="subtitle2"
                     color="text.secondary"
@@ -255,7 +255,7 @@ const PublicProfile = () => {
                 </Grid>
 
                 {/* Company */}
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography
                     variant="subtitle2"
                     color="text.secondary"
@@ -285,7 +285,7 @@ const PublicProfile = () => {
                 </Grid>
 
                 {/* Why are you here */}
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <Typography
                     variant="subtitle2"
                     color="text.secondary"
@@ -420,7 +420,7 @@ const PublicProfile = () => {
         </Grid>
 
         {/* Right Column - Info & Actions */}
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Paper
             elevation={1}
             sx={{ p: 3, borderRadius: 2, position: "sticky", top: 24 }}

--- a/src/components/Profile/PublicProfileDemo.js
+++ b/src/components/Profile/PublicProfileDemo.js
@@ -174,7 +174,7 @@ const PublicProfileDemo = () => {
 
       <Grid container spacing={4}>
         {/* Left Column */}
-        <Grid item xs={12} md={8}>
+        <Grid size={{ xs: 12, md: 8 }}>
           {/* Basic Information */}
           <Paper elevation={1} sx={{ mb: 4, borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
@@ -185,7 +185,7 @@ const PublicProfileDemo = () => {
               
               <Grid container spacing={3}>
                 {/* GitHub Username */}
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography variant="subtitle2" color="text.secondary" gutterBottom>
                     GitHub Profile
                   </Typography>
@@ -211,7 +211,7 @@ const PublicProfileDemo = () => {
                 </Grid>
 
                 {/* Company */}
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography variant="subtitle2" color="text.secondary" gutterBottom>
                     Company
                   </Typography>
@@ -232,7 +232,7 @@ const PublicProfileDemo = () => {
                 </Grid>
 
                 {/* Why are you here */}
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <Typography variant="subtitle2" color="text.secondary" gutterBottom>
                     Why are they here with Opportunity Hack?
                   </Typography>
@@ -385,7 +385,7 @@ const PublicProfileDemo = () => {
         </Grid>
 
         {/* Right Column - Info & Actions */}
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Paper elevation={1} sx={{ p: 3, borderRadius: 2, position: "sticky", top: 24 }}>
             <Typography variant="h6" sx={{ mb: 2, fontWeight: 500 }}>
               Connect & Engage

--- a/src/components/Profile/ShareableGitHubContributions.js
+++ b/src/components/Profile/ShareableGitHubContributions.js
@@ -97,28 +97,28 @@ const ShareableGitHubContributions = ({ githubHistory, userName }) => {
           <GitHub sx={{ mr: 1 }} />@{userName}'s GitHub Impact
         </Typography>
         <Grid container spacing={2} sx={{ mb: 2 }}>
-          <Grid item xs={3}>
+          <Grid size={{ xs: 3 }}>
             <Chip
               icon={<Code />}
               label={`${totalCommits} Commits`}
               color="primary"
             />
           </Grid>
-          <Grid item xs={3}>
+          <Grid size={{ xs: 3 }}>
             <Chip
               icon={<MergeType />}
               label={`${totalPRs} PRs`}
               color="secondary"
             />
           </Grid>
-          <Grid item xs={3}>
+          <Grid size={{ xs: 3 }}>
             <Chip
               icon={<BugReport />}
               label={`${totalIssues} Issues`}
               color="info"
             />
           </Grid>
-          <Grid item xs={3}>
+          <Grid size={{ xs: 3 }}>
             <Chip
               icon={<RateReview />}
               label={`${totalReviews} Reviews`}

--- a/src/components/ProjectList/FeaturedProjects/FeaturedProjects.js
+++ b/src/components/ProjectList/FeaturedProjects/FeaturedProjects.js
@@ -67,7 +67,7 @@ export default function FeaturedProjects({ projects }) {
   return (
     <Grid container spacing={3}>
       {projects.map((project) => (
-        <Grid item xs={12} md={4} key={project.id}>
+        <Grid size={{ xs: 12, md: 4 }} key={project.id}>
           <Card
             sx={{
               height: "100%",

--- a/src/components/ProjectList/ProjectList.js
+++ b/src/components/ProjectList/ProjectList.js
@@ -287,7 +287,7 @@ export default function ProjectList({ initialProjects, events }) {
         <>
           <Grid container spacing={3}>
             {currentProjects.map((project) => (
-              <Grid item xs={12} md={6} lg={4} key={project.id}>
+              <Grid size={{ xs: 12, md: 6, lg: 4 }} key={project.id}>
                 <ProjectCard
                   project={project}
                   hackathons={events}

--- a/src/components/TeamCreation/ConfirmationSummary.js
+++ b/src/components/TeamCreation/ConfirmationSummary.js
@@ -37,17 +37,17 @@ const ConfirmationSummary = memo(({
             <Typography variant="subtitle1" fontWeight="bold" color="primary">Team Information</Typography>
             <Divider sx={{ mb: 2 }} />
             <Grid container spacing={2}>
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <Typography variant="subtitle2" color="text.secondary">Team Name:</Typography>
                 <Typography>{teamName}</Typography>
               </Grid>
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <Typography variant="subtitle2" color="text.secondary">Slack Channel:</Typography>
                 <Typography sx={{ display: 'flex', alignItems: 'center' }}>
                   <FaSlack style={{ marginRight: 8 }} /> #{slackChannel}
                 </Typography>
               </Grid>
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <Typography variant="subtitle2" color="text.secondary">GitHub Username:</Typography>
                 <Typography sx={{ display: 'flex', alignItems: 'center' }}>
                   <FaGithub style={{ marginRight: 8 }} /> {githubUsername}

--- a/src/components/TeamCreation/NonprofitSelector.js
+++ b/src/components/TeamCreation/NonprofitSelector.js
@@ -82,7 +82,7 @@ const NonprofitSelector = memo(({
             const isSelected = selectedNonprofits.some(np => np.id === nonprofit.id);
             
             return (
-              <Grid item xs={12} md={6} key={nonprofit.id}>
+              <Grid size={{ xs: 12, md: 6 }} key={nonprofit.id}>
                 <Card 
                   sx={{
                     mb: 2,

--- a/src/components/TeamCreation/TeamStatusPanel.js
+++ b/src/components/TeamCreation/TeamStatusPanel.js
@@ -423,7 +423,7 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
         <Box sx={{ mt: 3 }}>
           <Typography variant="h6" gutterBottom>Hackathon Resources</Typography>
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <ResourceCard>
                 <CardContent>
                   <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
@@ -446,7 +446,7 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
                 </CardContent>
               </ResourceCard>
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <ResourceCard>
                 <CardContent>
                   <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
@@ -522,7 +522,7 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
           >
             <CardContent sx={{ pb: 2 }}>
               <Grid container alignItems="center" spacing={2}>
-                <Grid item>
+                <Grid>
                   <Avatar
                     sx={{
                       width: 56,
@@ -534,7 +534,7 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
                     <GroupIcon fontSize="large" />
                   </Avatar>
                 </Grid>
-                <Grid item xs>
+                <Grid size={{ xs: true }}>
                   <Box display="flex" alignItems="center" flexWrap="wrap">
                     <Typography
                       variant="h5"
@@ -1350,7 +1350,7 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
 
           {/* Quick Action Buttons */}
           <Grid container spacing={2} sx={{ mb: 3 }}>
-            <Grid item xs={12} sm={6} md={3}>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <Card sx={{ height: "100%" }}>
                 <CardContent>
                   <Typography variant="subtitle2" fontWeight="bold">
@@ -1373,7 +1373,7 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={6} md={3}>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <Card sx={{ height: "100%" }}>
                 <CardContent>
                   <Typography variant="subtitle2" fontWeight="bold">
@@ -1396,7 +1396,7 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={6} md={3}>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <Card sx={{ height: "100%" }}>
                 <CardContent>
                   <Typography variant="subtitle2" fontWeight="bold">
@@ -1419,7 +1419,7 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={6} md={3}>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <Card sx={{ height: "100%" }}>
                 <CardContent>
                   <Typography variant="subtitle2" fontWeight="bold">

--- a/src/components/admin/ApplicationEditDialog.js
+++ b/src/components/admin/ApplicationEditDialog.js
@@ -645,7 +645,7 @@ const ApplicationEditDialog = ({
           
           <Grid container spacing={2}>
             {currentStepFields.map((field) => (
-              <Grid item xs={12} sm={field.type === 'textarea' ? 12 : 6} key={field.name}>
+              <Grid size={{ xs: 12, sm: field.type === 'textarea' ? 12 : 6 }} key={field.name}>
                 {renderField(field)}
               </Grid>
             ))}
@@ -659,12 +659,12 @@ const ApplicationEditDialog = ({
             Application Metadata
           </Typography>
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Typography variant="body2" color="text.secondary">
                 Submitted: {formData.timestamp ? new Date(formData.timestamp).toLocaleString() : 'Unknown'}
               </Typography>
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Typography variant="body2" color="text.secondary">
                 Status: {formData.isSelected ? 'Approved' : 'Pending'}
               </Typography>

--- a/src/components/admin/ApplicationReviewCard.js
+++ b/src/components/admin/ApplicationReviewCard.js
@@ -360,7 +360,7 @@ const ApplicationReviewCard = ({
             if (!value) return null;
             
             return (
-              <Grid item xs={12} sm={6} key={field}>
+              <Grid size={{ xs: 12, sm: 6 }} key={field}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   {field === 'email' && <EmailIcon fontSize="small" color="action" />}
                   {field === 'schoolOrganization' && <SchoolIcon fontSize="small" color="action" />}
@@ -399,7 +399,7 @@ const ApplicationReviewCard = ({
                 const isLink = ['linkedin', 'github', 'portfolio', 'website', 'linkedinProfile'].includes(field);
                 
                 return (
-                  <Grid item xs={12} sm={6} key={field}>
+                  <Grid size={{ xs: 12, sm: 6 }} key={field}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       {(field === 'linkedin' || field === 'linkedinProfile') && <LinkedInIcon fontSize="small" color="action" />}
                       {field === 'country' && <LocationIcon fontSize="small" color="action" />}
@@ -450,7 +450,7 @@ const ApplicationReviewCard = ({
               if (!value) return null;
               
               return (
-                <Grid item xs={12} sm={6} key={field}>
+                <Grid size={{ xs: 12, sm: 6 }} key={field}>
                   <Typography variant="body2" color="text.secondary">
                     {getFieldLabel(field)}
                   </Typography>
@@ -487,7 +487,7 @@ const ApplicationReviewCard = ({
                 const isLink = ['linkedin', 'github', 'portfolio', 'website', 'linkedinProfile'].includes(field);
                 
                 return (
-                  <Grid item xs={12} key={field}>
+                  <Grid size={{ xs: 12 }} key={field}>
                     <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
                       {(field === 'linkedin' || field === 'linkedinProfile') && <LinkedInIcon fontSize="small" color="action" />}
                       {field === 'github' && <GitHubIcon fontSize="small" color="action" />}
@@ -809,7 +809,7 @@ const ApplicationReviewCard = ({
             </Typography>
             <Grid container spacing={2}>
               {application.timestamp && (
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography variant="body2" color="text.secondary">
                     Submitted
                   </Typography>
@@ -820,7 +820,7 @@ const ApplicationReviewCard = ({
                 </Grid>
               )}
               {application.event_id && (
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography variant="body2" color="text.secondary">
                     Event ID
                   </Typography>

--- a/src/components/admin/ApplicationReviewList.js
+++ b/src/components/admin/ApplicationReviewList.js
@@ -310,7 +310,7 @@ const ApplicationReviewList = ({
         </Typography>
         
         <Grid container spacing={2}>
-          <Grid item xs={12} sm={4}>
+          <Grid size={{ xs: 12, sm: 4 }}>
             <Box sx={{ textAlign: 'center' }}>
               <Typography variant="h4" color="primary">
                 {stats.total}
@@ -320,7 +320,7 @@ const ApplicationReviewList = ({
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={4}>
+          <Grid size={{ xs: 12, sm: 4 }}>
             <Box sx={{ textAlign: 'center' }}>
               <Typography variant="h4" color="success.main">
                 {stats.approved}
@@ -330,7 +330,7 @@ const ApplicationReviewList = ({
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={4}>
+          <Grid size={{ xs: 12, sm: 4 }}>
             <Box sx={{ textAlign: 'center' }}>
               <Typography variant="h4" color="warning.main">
                 {stats.pending}
@@ -346,7 +346,7 @@ const ApplicationReviewList = ({
       {/* Filters and Controls */}
       <Paper sx={{ p: 2, mb: 3 }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs={12} sm={4}>
+          <Grid size={{ xs: 12, sm: 4 }}>
             <TextField
               fullWidth
               label="Search applications"
@@ -358,7 +358,7 @@ const ApplicationReviewList = ({
             />
           </Grid>
           
-          <Grid item xs={12} sm={2}>
+          <Grid size={{ xs: 12, sm: 2 }}>
             <FormControl fullWidth size="small">
               <InputLabel>Status</InputLabel>
               <Select
@@ -382,7 +382,7 @@ const ApplicationReviewList = ({
           </Grid>
 
           {/* Checked In Filter - Show for all volunteer types */}
-          <Grid item xs={12} sm={2}>
+          <Grid size={{ xs: 12, sm: 2 }}>
             <FormControl fullWidth size="small">
               <InputLabel>Checked In</InputLabel>
               <Select
@@ -399,7 +399,7 @@ const ApplicationReviewList = ({
 
           {/* In Person Filter - Only show for judges */}
           {applicationType === 'judge' && (
-            <Grid item xs={12} sm={2}>
+            <Grid size={{ xs: 12, sm: 2 }}>
               <FormControl fullWidth size="small">
                 <InputLabel>In Person</InputLabel>
                 <Select
@@ -415,7 +415,7 @@ const ApplicationReviewList = ({
             </Grid>
           )}
 
-          <Grid item xs={12} sm={2}>
+          <Grid size={{ xs: 12, sm: 2 }}>
             <FormControl fullWidth size="small">
               <InputLabel>Sort by</InputLabel>
               <Select
@@ -431,7 +431,7 @@ const ApplicationReviewList = ({
             </FormControl>
           </Grid>
 
-          <Grid item xs={12} sm={2}>
+          <Grid size={{ xs: 12, sm: 2 }}>
             <ButtonGroup size="small" fullWidth>
               <Button
                 variant={currentSortOrder === 'asc' ? 'contained' : 'outlined'}
@@ -448,7 +448,7 @@ const ApplicationReviewList = ({
             </ButtonGroup>
           </Grid>
 
-          <Grid item xs={12} sm={2}>
+          <Grid size={{ xs: 12, sm: 2 }}>
             <FormControlLabel
               control={
                 <Checkbox

--- a/src/components/admin/BatchEmailDialog.js
+++ b/src/components/admin/BatchEmailDialog.js
@@ -351,7 +351,7 @@ const BatchEmailDialog = ({
                     </Typography>
                     <Grid container spacing={2}>
                       {category.templates.map((template) => (
-                        <Grid item xs={12} sm={6} key={template.id}>
+                        <Grid size={{ xs: 12, sm: 6 }} key={template.id}>
                           <Card 
                             variant="outlined" 
                             sx={{ 
@@ -469,7 +469,7 @@ const BatchEmailDialog = ({
                       {detectedPlaceholders.map((name) => {
                         const info = PLACEHOLDER_LABELS[name] || { label: name.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), example: '' };
                         return (
-                          <Grid item xs={12} sm={6} key={name}>
+                          <Grid size={{ xs: 12, sm: 6 }} key={name}>
                             <TextField
                               fullWidth
                               size="small"

--- a/src/components/admin/ContactSubmissionDetailDialog.js
+++ b/src/components/admin/ContactSubmissionDetailDialog.js
@@ -142,7 +142,7 @@ const ContactSubmissionDetailDialog = ({
             Admin Controls
           </Typography>
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <FormControl fullWidth size="small">
                 <InputLabel>Status</InputLabel>
                 <Select value={status} onChange={(e) => setStatus(e.target.value)} label="Status">
@@ -154,7 +154,7 @@ const ContactSubmissionDetailDialog = ({
                 </Select>
               </FormControl>
             </Grid>
-            <Grid item xs={12} sm={8}>
+            <Grid size={{ xs: 12, sm: 8 }}>
               <TextField
                 fullWidth
                 size="small"
@@ -171,16 +171,16 @@ const ContactSubmissionDetailDialog = ({
         {/* Contact Information */}
         <Section title="Contact Information">
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Name" value={fullName} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Email" value={submission.email} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Organization" value={submission.organization} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field
                 label="Inquiry Type"
                 value={
@@ -193,7 +193,7 @@ const ContactSubmissionDetailDialog = ({
                 }
               />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field
                 label="Wants Updates"
                 value={submission.receiveUpdates ? "Yes" : "No"}

--- a/src/components/admin/DonationManagement.js
+++ b/src/components/admin/DonationManagement.js
@@ -42,7 +42,7 @@ const DonationManagement = ({ initialDonationData, onDonationDataChange }) => {
         Donation Management
       </Typography>
       <Grid container spacing={3}>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Typography variant="subtitle1" gutterBottom>
             Current Donations
           </Typography>
@@ -88,7 +88,7 @@ const DonationManagement = ({ initialDonationData, onDonationDataChange }) => {
             rows={2}
           />
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Typography variant="subtitle1" gutterBottom>
             Donation Goals
           </Typography>

--- a/src/components/admin/DramaticGiveawaySelector.js
+++ b/src/components/admin/DramaticGiveawaySelector.js
@@ -380,7 +380,7 @@ const DramaticGiveawaySelector = ({
                 {/* Entry Pool Visualization */}
                 <Grid container spacing={1} sx={{ maxHeight: "300px", overflow: "auto" }}>
                   {entryPool.slice(0, 50).map((entry, index) => (
-                    <Grid item xs={6} sm={4} md={3} key={index}>
+                    <Grid size={{ xs: 6, sm: 4, md: 3 }} key={index}>
                       <EntryCard
                         isSelected={selectedIndex === index}
                         isShuffling={isShuffling}
@@ -401,7 +401,7 @@ const DramaticGiveawaySelector = ({
                     </Grid>
                   ))}
                   {entryPool.length > 50 && (
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                       <Typography textAlign="center" sx={{ opacity: 0.7 }}>
                         ... and {entryPool.length - 50} more entries
                       </Typography>

--- a/src/components/admin/HackathonRequestDetailDialog.js
+++ b/src/components/admin/HackathonRequestDetailDialog.js
@@ -169,7 +169,7 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
             Admin Controls
           </Typography>
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <FormControl fullWidth size="small">
                 <InputLabel>Status</InputLabel>
                 <Select value={status} onChange={(e) => setStatus(e.target.value)} label="Status">
@@ -181,7 +181,7 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
                 </Select>
               </FormControl>
             </Grid>
-            <Grid item xs={12} sm={8}>
+            <Grid size={{ xs: 12, sm: 8 }}>
               <TextField
                 fullWidth
                 size="small"
@@ -211,10 +211,10 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
         {/* Contact Information */}
         <Section title="Contact Information">
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Field label="Organization" value={request.companyName} />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Field
                 label="Organization Type"
                 value={
@@ -227,13 +227,13 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
                 }
               />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Contact Name" value={request.contactName} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Contact Email" value={request.contactEmail} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Contact Phone" value={request.contactPhone} />
             </Grid>
           </Grid>
@@ -242,10 +242,10 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
         {/* Event Details */}
         <Section title="Event Details">
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Expected Participants" value={request.employeeCount ? `~${request.employeeCount}` : "-"} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field
                 label="Event Format"
                 value={
@@ -258,25 +258,25 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
                 }
               />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Location" value={request.location} />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Field label="Participant Types" value={participantTypes} />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Field
                 label="Theme"
                 value={(request.hackathonTheme || "").replace(/-/g, " ") + (request.customTheme ? ` - ${request.customTheme}` : "")}
               />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Hackathon Date" value={formatDate(request.expectedHackathonDate)} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Preferred Call Date" value={formatDate(request.preferredDate)} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Alternate Call Date" value={formatDate(request.alternateDate)} />
             </Grid>
           </Grid>
@@ -285,30 +285,30 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
         {/* Nonprofit Engagement */}
         <Section title="Nonprofit Engagement">
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field
                 label="Has Nonprofit List"
                 value={request.hasNonprofitList === "yes" ? "Yes" : request.hasNonprofitList === "partial" ? "Partial" : request.hasNonprofitList === "no" ? "No" : "-"}
               />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field
                 label="Worked with Nonprofits Before"
                 value={request.hasWorkedWithNonprofitsBefore === "yes" ? "Yes" : request.hasWorkedWithNonprofitsBefore === "no" ? "No" : "-"}
               />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field
                 label="Preferred Location"
                 value={(request.preferredNonprofitLocation || "").replace(/-/g, " ") + (request.specificRegion ? ` - ${request.specificRegion}` : "")}
               />
             </Grid>
             {request.nonprofitDetails && (
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <Field label="Nonprofit Details" value={request.nonprofitDetails} />
               </Grid>
             )}
-            <Grid item xs={12}>
+            <Grid size={{ xs: 12 }}>
               <Field label="Nonprofit Sources" value={nonprofitSources} />
             </Grid>
           </Grid>
@@ -319,7 +319,7 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
           <Section title="Division of Responsibilities">
             <Grid container spacing={1}>
               {Object.entries(request.responsibilities).map(([key, value]) => (
-                <Grid item xs={12} sm={6} key={key}>
+                <Grid size={{ xs: 12, sm: 6 }} key={key}>
                   <Box sx={{ display: "flex", justifyContent: "space-between", py: 0.5 }}>
                     <Typography variant="body2" color="text.secondary">
                       {responsibilityLabels[key] || key}
@@ -335,13 +335,13 @@ const HackathonRequestDetailDialog = ({ open, onClose, request, onSave, accessTo
         {/* Budget */}
         <Section title="Budget & Support">
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Budget" value={request.budget ? `$${Number(request.budget).toLocaleString()}` : "-"} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field label="Donation Percentage" value={request.donationPercentage != null ? `${request.donationPercentage}%` : "-"} />
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid size={{ xs: 12, sm: 4 }}>
               <Field
                 label="Estimated Donation"
                 value={

--- a/src/components/admin/JudgingResults.js
+++ b/src/components/admin/JudgingResults.js
@@ -494,7 +494,7 @@ const JudgingResults = ({ orgId, hackathons, selectedHackathon, setSelectedHacka
       </Typography>
       <Grid container spacing={3} justifyContent="center">
         {winners.slice(0, 3).map((teamData, index) => (
-          <Grid item xs={12} sm={4} key={teamData.team.id}>
+          <Grid size={{ xs: 12, sm: 4 }} key={teamData.team.id}>
             <Card 
               sx={{ 
                 textAlign: 'center',
@@ -604,7 +604,7 @@ const JudgingResults = ({ orgId, hackathons, selectedHackathon, setSelectedHacka
     <Box>
       {/* Hackathon Selection */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
             <InputLabel>Select Hackathon</InputLabel>
             <Select
@@ -620,7 +620,7 @@ const JudgingResults = ({ orgId, hackathons, selectedHackathon, setSelectedHacka
             </Select>
           </FormControl>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Box sx={{ display: 'flex', gap: 1 }}>
             <Button 
               variant="outlined" 
@@ -660,7 +660,7 @@ const JudgingResults = ({ orgId, hackathons, selectedHackathon, setSelectedHacka
               <Skeleton variant="text" width={300} height={40} sx={{ mx: 'auto', mb: 4 }} />
               <Grid container spacing={3} justifyContent="center">
                 {[1, 2, 3].map((item) => (
-                  <Grid item xs={12} sm={4} key={item}>
+                  <Grid size={{ xs: 12, sm: 4 }} key={item}>
                     <Card>
                       <CardContent sx={{ textAlign: 'center' }}>
                         <Skeleton variant="circular" width={80} height={80} sx={{ mx: 'auto', mb: 2 }} />
@@ -873,7 +873,7 @@ const JudgingResults = ({ orgId, hackathons, selectedHackathon, setSelectedHacka
                   Team Overview
                 </Typography>
                 <Grid container spacing={2}>
-                  <Grid item xs={12} sm={3}>
+                  <Grid size={{ xs: 12, sm: 3 }}>
                     <Card variant="outlined">
                       <CardContent sx={{ textAlign: 'center' }}>
                         <Typography variant="h4" color="primary">
@@ -883,7 +883,7 @@ const JudgingResults = ({ orgId, hackathons, selectedHackathon, setSelectedHacka
                       </CardContent>
                     </Card>
                   </Grid>
-                  <Grid item xs={12} sm={3}>
+                  <Grid size={{ xs: 12, sm: 3 }}>
                     <Card variant="outlined">
                       <CardContent sx={{ textAlign: 'center' }}>
                         <Typography variant="h4" color="secondary">
@@ -893,7 +893,7 @@ const JudgingResults = ({ orgId, hackathons, selectedHackathon, setSelectedHacka
                       </CardContent>
                     </Card>
                   </Grid>
-                  <Grid item xs={12} sm={3}>
+                  <Grid size={{ xs: 12, sm: 3 }}>
                     <Card variant="outlined">
                       <CardContent sx={{ textAlign: 'center' }}>
                         <Typography variant="h4" color="success.main">
@@ -903,7 +903,7 @@ const JudgingResults = ({ orgId, hackathons, selectedHackathon, setSelectedHacka
                       </CardContent>
                     </Card>
                   </Grid>
-                  <Grid item xs={12} sm={3}>
+                  <Grid size={{ xs: 12, sm: 3 }}>
                     <Card variant="outlined">
                       <CardContent sx={{ textAlign: 'center' }}>
                         <Typography variant="h4" color="warning.main">

--- a/src/components/admin/JudgingRound1.js
+++ b/src/components/admin/JudgingRound1.js
@@ -626,13 +626,13 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
 
   const ControlsSkeleton = () => (
     <Grid container spacing={3} sx={{ mb: 4 }}>
-      <Grid item xs={12} md={4}>
+      <Grid size={{ xs: 12, md: 4 }}>
         <Skeleton variant="rectangular" height={56} sx={{ borderRadius: 1 }} />
       </Grid>
-      <Grid item xs={12} md={4}>
+      <Grid size={{ xs: 12, md: 4 }}>
         <Skeleton variant="rectangular" height={36} sx={{ borderRadius: 1 }} />
       </Grid>
-      <Grid item xs={12} md={4}>
+      <Grid size={{ xs: 12, md: 4 }}>
         <Skeleton variant="rectangular" height={36} sx={{ borderRadius: 1 }} />
       </Grid>
     </Grid>
@@ -641,7 +641,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
   const StatsSkeleton = () => (
     <Grid container spacing={2} sx={{ mb: 4 }}>
       {[1, 2, 3, 4].map((item) => (
-        <Grid item xs={12} sm={3} key={item}>
+        <Grid size={{ xs: 12, sm: 3 }} key={item}>
           <StatsCardSkeleton />
         </Grid>
       ))}
@@ -904,7 +904,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
         <ControlsSkeleton />
       ) : (
         <Grid container spacing={3} sx={{ mb: 4 }}>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth>
               <InputLabel>Select Hackathon</InputLabel>
               <Select
@@ -920,7 +920,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
               </Select>
             </FormControl>
           </Grid>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Button
               variant="contained"
               startIcon={<AddIcon />}
@@ -930,7 +930,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
               Add Judge Panel
             </Button>
           </Grid>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Button
               variant="contained"
               color="success"
@@ -977,7 +977,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
             <StatsSkeleton />
           ) : (
             <Grid container spacing={2} sx={{ mb: 4 }}>
-              <Grid item xs={12} sm={3}>
+              <Grid size={{ xs: 12, sm: 3 }}>
                 <Card>
                   <CardContent sx={{ textAlign: 'center' }}>
                     <PersonIcon color="primary" sx={{ fontSize: 40 }} />
@@ -992,7 +992,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                   </CardContent>
                 </Card>
               </Grid>
-              <Grid item xs={12} sm={3}>
+              <Grid size={{ xs: 12, sm: 3 }}>
                 <Card>
                   <CardContent sx={{ textAlign: 'center' }}>
                     <GroupsIcon color="secondary" sx={{ fontSize: 40 }} />
@@ -1007,7 +1007,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                   </CardContent>
                 </Card>
               </Grid>
-              <Grid item xs={12} sm={3}>
+              <Grid size={{ xs: 12, sm: 3 }}>
                 <Card>
                   <CardContent sx={{ textAlign: 'center' }}>
                     <AssignIcon color="success" sx={{ fontSize: 40 }} />
@@ -1022,7 +1022,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                   </CardContent>
                 </Card>
               </Grid>
-              <Grid item xs={12} sm={3}>
+              <Grid size={{ xs: 12, sm: 3 }}>
                 <Card>
                   <CardContent sx={{ textAlign: 'center' }}>
                     <LocationIcon color="info" sx={{ fontSize: 40 }} />
@@ -1051,7 +1051,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
               </Box>
               
               <Grid container spacing={3} alignItems="center">
-                <Grid item xs={12} sm={3}>
+                <Grid size={{ xs: 12, sm: 3 }}>
                   <TextField
                     label="Demo Duration (minutes)"
                     type="number"
@@ -1066,9 +1066,9 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                   />
                 </Grid>
                 
-                <Grid item xs={12} sm={9}>
+                <Grid size={{ xs: 12, sm: 9 }}>
                   <Grid container spacing={2}>
-                    <Grid item xs={12} sm={3}>
+                    <Grid size={{ xs: 12, sm: 3 }}>
                       <Paper variant="outlined" sx={{ p: 2, textAlign: 'center', bgcolor: 'background.paper' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 1 }}>
                           <GroupsIcon color="secondary" sx={{ fontSize: 20, mr: 0.5 }} />
@@ -1082,7 +1082,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                       </Paper>
                     </Grid>
                     
-                    <Grid item xs={12} sm={3}>
+                    <Grid size={{ xs: 12, sm: 3 }}>
                       <Paper variant="outlined" sx={{ p: 2, textAlign: 'center', bgcolor: 'background.paper' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 1 }}>
                           <TimerIcon color="warning" sx={{ fontSize: 20, mr: 0.5 }} />
@@ -1096,7 +1096,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                       </Paper>
                     </Grid>
                     
-                    <Grid item xs={12} sm={3}>
+                    <Grid size={{ xs: 12, sm: 3 }}>
                       <Paper variant="outlined" sx={{ p: 2, textAlign: 'center', bgcolor: 'background.paper' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 1 }}>
                           <AssignIcon color="info" sx={{ fontSize: 20, mr: 0.5 }} />
@@ -1110,7 +1110,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                       </Paper>
                     </Grid>
                     
-                    <Grid item xs={12} sm={3}>
+                    <Grid size={{ xs: 12, sm: 3 }}>
                       <Paper variant="outlined" sx={{ p: 2, textAlign: 'center', bgcolor: timeEstimate.totalPanels > 0 ? 'success.50' : 'grey.50' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 1 }}>
                           <ScheduleIcon color={timeEstimate.totalPanels > 0 ? 'success' : 'disabled'} sx={{ fontSize: 20, mr: 0.5 }} />
@@ -1206,7 +1206,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
               <AccordionDetails>
                 <Grid container spacing={3}>
                   {/* Assigned Judges */}
-                  <Grid item xs={12} md={6}>
+                  <Grid size={{ xs: 12, md: 6 }}>
                     <Typography variant="subtitle1" gutterBottom>
                       Assigned Judges ({group.judges.length})
                       {loadingPanels && <CircularProgress size={16} sx={{ ml: 1 }} />}
@@ -1250,7 +1250,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                   </Grid>
 
                   {/* Assigned Teams */}
-                  <Grid item xs={12} md={6}>
+                  <Grid size={{ xs: 12, md: 6 }}>
                     <Typography variant="subtitle1" gutterBottom>
                       Assigned Teams ({group.teams.length})
                     </Typography>
@@ -1293,7 +1293,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
 
           {/* Unassigned Resources */}
           <Grid container spacing={3} sx={{ mt: 4 }}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h6" gutterBottom>
                 Unassigned Judges {loadingJudges ? (
                   <Skeleton variant="text" width={40} component="span" />
@@ -1359,7 +1359,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
               )}
             </Grid>
 
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h6" gutterBottom>
                 Unassigned Teams {loadingTeams ? (
                   <Skeleton variant="text" width={40} component="span" />

--- a/src/components/admin/JudgingRound2.js
+++ b/src/components/admin/JudgingRound2.js
@@ -972,7 +972,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
     <Box>
       {/* Hackathon Selection */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
             <InputLabel>Select Hackathon</InputLabel>
             <Select
@@ -988,7 +988,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
             </Select>
           </FormControl>
         </Grid>
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Button
             variant="contained"
             startIcon={<ScheduleIcon />}
@@ -998,7 +998,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
             Configure Session Settings
           </Button>
         </Grid>
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Button
             variant="contained"
             color="success"
@@ -1018,7 +1018,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
         <>
           {/* Summary Stats */}
           <Grid container spacing={2} sx={{ mb: 4 }}>
-            <Grid item xs={12} sm={3}>
+            <Grid size={{ xs: 12, sm: 3 }}>
               <Card>
                 <CardContent sx={{ textAlign: 'center' }}>
                   <PersonIcon color="primary" sx={{ fontSize: 40 }} />
@@ -1027,7 +1027,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={3}>
+            <Grid size={{ xs: 12, sm: 3 }}>
               <Card>
                 <CardContent sx={{ textAlign: 'center' }}>
                   <TrophyIcon color="warning" sx={{ fontSize: 40 }} />
@@ -1036,7 +1036,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={3}>
+            <Grid size={{ xs: 12, sm: 3 }}>
               <Card>
                 <CardContent sx={{ textAlign: 'center' }}>
                   <ScheduleIcon color="info" sx={{ fontSize: 40 }} />
@@ -1045,7 +1045,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={3}>
+            <Grid size={{ xs: 12, sm: 3 }}>
               <Card>
                 <CardContent sx={{ textAlign: 'center' }}>
                   <LocationIcon color="success" sx={{ fontSize: 40 }} />
@@ -1357,7 +1357,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
               {Object.keys(topTeamsByCategory).length > 0 ? (
                 <Grid container spacing={3}>
                   {Object.entries(topTeamsByCategory).map(([categoryName, teams]) => (
-                    <Grid item xs={12} md={6} key={categoryName}>
+                    <Grid size={{ xs: 12, md: 6 }} key={categoryName}>
                       <Card variant="outlined" sx={{ height: '100%' }}>
                         <CardContent>
                           <Typography variant="h6" gutterBottom sx={{ 
@@ -1511,7 +1511,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
 
                 <Grid container spacing={3}>
                   {Object.entries(topTeamsBySpecialCategory).map(([categoryName, teams]) => (
-                    <Grid item xs={12} key={categoryName}>
+                    <Grid size={{ xs: 12 }} key={categoryName}>
                       <Card variant="outlined">
                         <CardContent>
                           <Typography variant="h6" gutterBottom sx={{
@@ -1768,7 +1768,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
         <DialogTitle>Round 2 Session Settings</DialogTitle>
         <DialogContent sx={{ pt: 3 }}>
           <Grid container spacing={3}>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <TextField
                 label="Session Duration (minutes)"
                 type="number"
@@ -1783,7 +1783,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                 sx={{ mt: 1 }}
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <TextField
                 label="Break Duration (minutes)"
                 type="number"
@@ -1798,7 +1798,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                 sx={{ mt: 1 }}
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <TextField
                 label="Start Time"
                 type="time"
@@ -1812,7 +1812,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
               />
             </Grid>
             {isInPerson && (
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <TextField
                   label="Room/Location"
                   fullWidth
@@ -1890,7 +1890,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                   Team Overview
                 </Typography>
                 <Grid container spacing={2}>
-                  <Grid item xs={12} sm={4}>
+                  <Grid size={{ xs: 12, sm: 4 }}>
                     <Card variant="outlined">
                       <CardContent sx={{ textAlign: 'center' }}>
                         <Typography variant="h4" color="primary">
@@ -1900,7 +1900,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                       </CardContent>
                     </Card>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
+                  <Grid size={{ xs: 12, sm: 4 }}>
                     <Card variant="outlined">
                       <CardContent sx={{ textAlign: 'center' }}>
                         <Typography variant="h4" color="secondary">
@@ -1910,7 +1910,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
                       </CardContent>
                     </Card>
                   </Grid>
-                  <Grid item xs={12} sm={4}>
+                  <Grid size={{ xs: 12, sm: 4 }}>
                     <Card variant="outlined">
                       <CardContent sx={{ textAlign: 'center' }}>
                         <Typography variant="h4" color="success.main">

--- a/src/components/admin/NonprofitApplicationEditDialog.js
+++ b/src/components/admin/NonprofitApplicationEditDialog.js
@@ -55,7 +55,7 @@ const NonprofitApplicationEditDialog = ({
       <DialogContent>
         <Grid container spacing={2}>
           {fields.map((field) => (
-            <Grid item xs={12} key={field.name}>
+            <Grid size={{ xs: 12 }} key={field.name}>
               {field.type === "checkbox" ? (
                 <FormControlLabel
                   control={

--- a/src/components/admin/NonprofitManagement.js
+++ b/src/components/admin/NonprofitManagement.js
@@ -325,7 +325,7 @@ const NonprofitManagement = memo(({
           Add Nonprofit to Hackathon
         </Typography>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs={8}>
+          <Grid size={{ xs: 8 }}>
             <FormControl fullWidth>
               <InputLabel id="nonprofit-select-label">Select Nonprofit</InputLabel>
               <Select
@@ -345,7 +345,7 @@ const NonprofitManagement = memo(({
               </Select>
             </FormControl>
           </Grid>
-          <Grid item xs={4}>
+          <Grid size={{ xs: 4 }}>
             <Button
               variant="contained"
               color="primary"

--- a/src/components/admin/ProblemStatementManagement.js
+++ b/src/components/admin/ProblemStatementManagement.js
@@ -201,7 +201,7 @@ const ProblemStatementManagement = ({
           Add Problem Statement to Nonprofit
         </Typography>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs={8}>
+          <Grid size={{ xs: 8 }}>
             <FormControl fullWidth>
               <InputLabel id="problem-statement-select-label">Select Problem Statement</InputLabel>
               <Select
@@ -221,7 +221,7 @@ const ProblemStatementManagement = ({
               </Select>
             </FormControl>
           </Grid>
-          <Grid item xs={4}>
+          <Grid size={{ xs: 4 }}>
             <Button
               variant="contained"
               color="primary"

--- a/src/components/admin/SocialMediaManagement.js
+++ b/src/components/admin/SocialMediaManagement.js
@@ -537,7 +537,7 @@ const SocialMediaManagement = ({ onSnackbar }) => {
         
         <Grid container spacing={2}>
           {Object.entries(platformStatus).map(([platform, status]) => (
-            <Grid item xs={12} sm={6} md={4} key={platform}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} key={platform}>
               <Card>
                 <CardContent>
                   <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
@@ -672,7 +672,7 @@ const SocialMediaManagement = ({ onSnackbar }) => {
         ) : (
           <Grid container spacing={2}>
             {newsItems.map((item) => (
-              <Grid item xs={12} md={6} key={item.id}>
+              <Grid size={{ xs: 12, md: 6 }} key={item.id}>
                 <Card>
                   <CardContent>
                     <Typography variant="h6" gutterBottom>
@@ -1056,7 +1056,7 @@ const SocialMediaManagement = ({ onSnackbar }) => {
 
           <Grid container spacing={2}>
             {/* Email Input Section */}
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="subtitle2" gutterBottom>
                 Copy/Paste Emails
               </Typography>
@@ -1077,7 +1077,7 @@ user@domain.org; admin@site.net"
             </Grid>
 
             {/* CSV Upload Section */}
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="subtitle2" gutterBottom>
                 Upload CSV File
               </Typography>
@@ -1159,7 +1159,7 @@ user@domain.org; admin@site.net"
               <Box sx={{ maxHeight: '200px', overflow: 'auto' }}>
                 <Grid container spacing={1}>
                   {additionalEmails.map((user, index) => (
-                    <Grid item key={user.id}>
+                    <Grid key={user.id}>
                       <Chip
                         label={user.email}
                         size="small"

--- a/src/components/admin/TeamAssignments.js
+++ b/src/components/admin/TeamAssignments.js
@@ -508,7 +508,7 @@ const TeamAssignments = ({ orgId }) => {
 
     return (
       <Grid container spacing={3}>
-        <Grid item xs={12}>
+        <Grid size={{ xs: 12 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
             <Typography variant="h6">
               Assigned Teams ({teamsByAssignment.assigned.length})
@@ -616,7 +616,7 @@ const TeamAssignments = ({ orgId }) => {
           </TableContainer>
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid size={{ xs: 12 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
             <Typography variant="h6">
               Unassigned Teams ({teamsByAssignment.unassigned.length})
@@ -763,7 +763,7 @@ const TeamAssignments = ({ orgId }) => {
     return (
       <Box sx={{ mb: 4 }}>
         <Grid container spacing={3}>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card elevation={2} sx={{ height: '100%' }}>
               <CardHeader title="Nonprofit Assignment Status" />
               <Divider />
@@ -807,7 +807,7 @@ const TeamAssignments = ({ orgId }) => {
             </Card>
           </Grid>
           
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card elevation={2} sx={{ height: '100%' }}>
               <CardHeader title="Team Assignment Status" />
               <Divider />
@@ -850,7 +850,7 @@ const TeamAssignments = ({ orgId }) => {
             </Card>
           </Grid>
           
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card elevation={2} sx={{ height: '100%' }}>
               <CardHeader title="Assignment Suggestions" />
               <Divider />
@@ -929,7 +929,7 @@ const TeamAssignments = ({ orgId }) => {
 
       <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth>
               <InputLabel id="hackathon-select-label">
                 Select Hackathon
@@ -953,7 +953,7 @@ const TeamAssignments = ({ orgId }) => {
               </Select>
             </FormControl>
           </Grid>
-          <Grid item xs={12} md={8}>
+          <Grid size={{ xs: 12, md: 8 }}>
             <TextField
               fullWidth
               placeholder="Search nonprofits, teams, or descriptions..."
@@ -1029,7 +1029,7 @@ const TeamAssignments = ({ orgId }) => {
                 </Typography>
                 <Paper variant="outlined" sx={{ p: 2 }}>
                   <Grid container spacing={2}>
-                    <Grid item xs={12} md={6}>
+                    <Grid size={{ xs: 12, md: 6 }}>
                       <Typography variant="body2" color="text.secondary">
                         Name:
                       </Typography>
@@ -1037,12 +1037,12 @@ const TeamAssignments = ({ orgId }) => {
                         {selectedNonprofit.name}
                       </Typography>
                     </Grid>
-                    <Grid item xs={12} md={6}>
+                    <Grid size={{ xs: 12, md: 6 }}>
                       <Typography variant="body2" color="text.secondary">
                         Project Type:
                       </Typography>                      
                     </Grid>
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                       <Typography variant="body2" color="text.secondary">
                         Description:
                       </Typography>

--- a/src/components/admin/TeamManagement.js
+++ b/src/components/admin/TeamManagement.js
@@ -1282,7 +1282,7 @@ const TeamManagement = ({ orgId }) => {
 
     return (
       <Grid container spacing={3}>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card elevation={1} sx={{ mb: 3, height: "100%" }}>
             <CardHeader title="Team Information" />
             <Divider />
@@ -1360,7 +1360,7 @@ const TeamManagement = ({ orgId }) => {
           </Card>
         </Grid>
 
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card elevation={1} sx={{ mb: 3, height: "100%" }}>
             <CardHeader title="Additional Information" />
             <Divider />
@@ -1943,7 +1943,7 @@ const TeamManagement = ({ orgId }) => {
 
       <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth>
               <InputLabel id="hackathon-select-label">
                 Select Hackathon
@@ -1967,7 +1967,7 @@ const TeamManagement = ({ orgId }) => {
               </Select>
             </FormControl>
           </Grid>
-          <Grid item xs={12} md={8}>
+          <Grid size={{ xs: 12, md: 8 }}>
             <TextField
               fullWidth
               placeholder="Search teams, members, or slack channels..."
@@ -2284,7 +2284,7 @@ const TeamManagement = ({ orgId }) => {
                     </Typography>
                     <Grid container spacing={2}>
                       {category.templates.map((template) => (
-                        <Grid item xs={12} sm={6} key={template.id}>
+                        <Grid size={{ xs: 12, sm: 6 }} key={template.id}>
                           <Card 
                             variant="outlined" 
                             sx={{ 
@@ -2499,7 +2499,7 @@ const TeamManagement = ({ orgId }) => {
                 </Typography>
                 <Grid container spacing={2}>
                   {teamData.github_links.map((repo, index) => (
-                    <Grid item xs={12} sm={6} key={index}>
+                    <Grid size={{ xs: 12, sm: 6 }} key={index}>
                       <Card 
                         variant="outlined" 
                         sx={{ 
@@ -2542,7 +2542,7 @@ const TeamManagement = ({ orgId }) => {
                 
                 <Grid container spacing={2}>
                   {Object.entries(getGithubIssueTemplates(selectedHackathon)).map(([templateKey, template]) => (
-                    <Grid item xs={12} sm={6} key={templateKey}>
+                    <Grid size={{ xs: 12, sm: 6 }} key={templateKey}>
                       <Card 
                         variant="outlined" 
                         sx={{ 

--- a/src/components/admin/TimeTrackingDetailDialog.js
+++ b/src/components/admin/TimeTrackingDetailDialog.js
@@ -121,7 +121,7 @@ const TimeTrackingDetailDialog = ({ open, onClose, userData }) => {
       </DialogTitle>
       <DialogContent>
         <Grid container spacing={3}>
-          <Grid item xs={12}>
+          <Grid size={{ xs: 12 }}>
             <Box sx={{ mb: 3 }}>
               <Typography variant="subtitle1">
                 Email: {userData.email}
@@ -149,7 +149,7 @@ const TimeTrackingDetailDialog = ({ open, onClose, userData }) => {
             </Box>
           </Grid>
           
-          <Grid item xs={12}>
+          <Grid size={{ xs: 12 }}>
             <Divider sx={{ mb: 3 }} />
             <Typography variant="h6" gutterBottom>
               Time Tracking History
@@ -157,7 +157,7 @@ const TimeTrackingDetailDialog = ({ open, onClose, userData }) => {
             
             <LocalizationProvider dateAdapter={AdapterDateFns}>
               <Grid container spacing={2} alignItems="center" sx={{ mb: 3 }}>
-                <Grid item xs={12} sm={4}>
+                <Grid size={{ xs: 12, sm: 4 }}>
                   <DatePicker
                     label="Start Date"
                     value={startDate}
@@ -165,7 +165,7 @@ const TimeTrackingDetailDialog = ({ open, onClose, userData }) => {
                     renderInput={(params) => <TextField {...params} fullWidth />}
                   />
                 </Grid>
-                <Grid item xs={12} sm={4}>
+                <Grid size={{ xs: 12, sm: 4 }}>
                   <DatePicker
                     label="End Date"
                     value={endDate}
@@ -173,7 +173,7 @@ const TimeTrackingDetailDialog = ({ open, onClose, userData }) => {
                     renderInput={(params) => <TextField {...params} fullWidth />}
                   />
                 </Grid>
-                <Grid item xs={12} sm={4}>
+                <Grid size={{ xs: 12, sm: 4 }}>
                   <FormControl fullWidth>
                     <InputLabel>Filter by Reason</InputLabel>
                     <Select

--- a/src/components/admin/TimeTrackingSummary.js
+++ b/src/components/admin/TimeTrackingSummary.js
@@ -117,10 +117,10 @@ const TimeTrackingSummary = ({ timeTrackingData }) => {
       </Typography>
       
       <Grid container spacing={3}>
-        <Grid item xs={12} md={8}>
+        <Grid size={{ xs: 12, md: 8 }}>
           <Paper elevation={2} sx={{ p: 3 }}>
             <Grid container spacing={3}>
-              <Grid item xs={12} sm={6} md={3}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Card variant="outlined">
                   <CardContent>
                     <Typography color="textSecondary" gutterBottom>
@@ -136,7 +136,7 @@ const TimeTrackingSummary = ({ timeTrackingData }) => {
                 </Card>
               </Grid>
               
-              <Grid item xs={12} sm={6} md={3}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Card variant="outlined">
                   <CardContent>
                     <Typography color="textSecondary" gutterBottom>
@@ -152,7 +152,7 @@ const TimeTrackingSummary = ({ timeTrackingData }) => {
                 </Card>
               </Grid>
               
-              <Grid item xs={12} sm={6} md={3}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Card variant="outlined">
                   <CardContent>
                     <Typography color="textSecondary" gutterBottom>
@@ -168,7 +168,7 @@ const TimeTrackingSummary = ({ timeTrackingData }) => {
                 </Card>
               </Grid>
               
-              <Grid item xs={12} sm={6} md={3}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Card variant="outlined">
                   <CardContent>
                     <Typography color="textSecondary" gutterBottom>
@@ -192,7 +192,7 @@ const TimeTrackingSummary = ({ timeTrackingData }) => {
             </Typography>
             
             <Grid container spacing={2}>
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <Box sx={{ height: 300 }}>
                   <ResponsiveContainer width="100%" height="100%">
                     <PieChart>
@@ -224,7 +224,7 @@ const TimeTrackingSummary = ({ timeTrackingData }) => {
                 </Box>
               </Grid>
               
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <Typography variant="subtitle1" gutterBottom>
                   Hours by Activity Type
                 </Typography>
@@ -263,7 +263,7 @@ const TimeTrackingSummary = ({ timeTrackingData }) => {
           </Paper>
         </Grid>
         
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Paper elevation={2} sx={{ p: 3, height: '100%' }}>
             <Typography variant="h6" gutterBottom>
               Activity Insights

--- a/src/components/admin/UserSearchDialog.js
+++ b/src/components/admin/UserSearchDialog.js
@@ -445,25 +445,25 @@ const UserSearchDialog = ({
             </Typography>
             <Grid container spacing={2}>
               {selectedUser.role && (
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography variant="body2" color="text.secondary">Role:</Typography>
                   <Typography variant="body1">{selectedUser.role}</Typography>
                 </Grid>
               )}
               {selectedUser.company && (
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography variant="body2" color="text.secondary">Company:</Typography>
                   <Typography variant="body1">{selectedUser.company}</Typography>
                 </Grid>
               )}
               {selectedUser.education && (
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography variant="body2" color="text.secondary">Education:</Typography>
                   <Typography variant="body1">{selectedUser.education}</Typography>
                 </Grid>
               )}
               {selectedUser.expertise && selectedUser.expertise.length > 0 && (
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <Typography variant="body2" color="text.secondary">Expertise:</Typography>
                   {renderExpertiseChips(selectedUser.expertise)}
                 </Grid>

--- a/src/components/admin/VolunteerCommunication.js
+++ b/src/components/admin/VolunteerCommunication.js
@@ -256,7 +256,7 @@ const VolunteerCommunication = ({
                     </Typography>
                     <Grid container spacing={2}>
                       {category.templates.map((template) => (
-                        <Grid item xs={12} sm={6} key={template.id}>
+                        <Grid size={{ xs: 12, sm: 6 }} key={template.id}>
                           <Card 
                             variant="outlined" 
                             sx={{ 
@@ -359,7 +359,7 @@ const VolunteerCommunication = ({
                       {detectedPlaceholders.map((name) => {
                         const info = PLACEHOLDER_LABELS[name] || { label: name.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), example: '' };
                         return (
-                          <Grid item xs={12} sm={6} key={name}>
+                          <Grid size={{ xs: 12, sm: 6 }} key={name}>
                             <TextField
                               fullWidth
                               size="small"
@@ -489,7 +489,7 @@ const VolunteerCommunication = ({
                     </Typography>
                     <Grid container spacing={2}>
                       {category.templates.map((template) => (
-                        <Grid item xs={12} sm={6} key={template.id}>
+                        <Grid size={{ xs: 12, sm: 6 }} key={template.id}>
                           <Card 
                             variant="outlined" 
                             sx={{ 
@@ -592,7 +592,7 @@ const VolunteerCommunication = ({
                       {detectedPlaceholders.map((name) => {
                         const info = PLACEHOLDER_LABELS[name] || { label: name.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), example: '' };
                         return (
-                          <Grid item xs={12} sm={6} key={name}>
+                          <Grid size={{ xs: 12, sm: 6 }} key={name}>
                             <TextField
                               fullWidth
                               size="small"

--- a/src/components/content/InternshipContent.js
+++ b/src/components/content/InternshipContent.js
@@ -66,7 +66,7 @@ const InternshipContent = () => (
 
     <Grid container spacing={4} sx={{ my: 4 }}>
       {benefitCards.map((benefit, index) => (
-        <Grid item xs={12} sm={6} key={index}>
+        <Grid size={{ xs: 12, sm: 6 }} key={index}>
           <BenefitCard {...benefit} />
         </Grid>
       ))}

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -304,7 +304,7 @@ export default function AboutUsPage() {
           </Typography>
           <Grid container spacing={3}>
             {impactStats.map((stat, index) => (
-              <Grid item xs={6} md={3} key={index}>
+              <Grid size={{ xs: 6, md: 3 }} key={index}>
                 <Card sx={{ textAlign: "center", height: "100%", bgcolor: "white", color: "text.primary" }}>
                   <CardContent>
                     <Box sx={{ mb: 2, color: "primary.main" }}>
@@ -367,7 +367,7 @@ export default function AboutUsPage() {
 
           <Grid container spacing={3}>
             {whyChooseUs.map((reason, index) => (
-              <Grid item xs={12} md={6} key={index}>
+              <Grid size={{ xs: 12, md: 6 }} key={index}>
                 <Card 
                   sx={{ 
                     height: "100%", 
@@ -420,7 +420,7 @@ export default function AboutUsPage() {
           </Typography>
           
           <Grid container spacing={2} sx={{ maxWidth: "600px", mx: "auto" }}>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Button
                 variant="contained"
                 size="large"
@@ -440,7 +440,7 @@ export default function AboutUsPage() {
                 Get Involved
               </Button>
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Button
                 variant="outlined"
                 size="large"
@@ -556,7 +556,7 @@ const EnhancedFoundersSection = ({ cofounders }) => (
     </Typography>
     <Grid container spacing={4} justifyContent="center">
       {cofounders.map((member, i) => (
-        <Grid item xs={12} sm={6} lg={3} key={i}>
+        <Grid size={{ xs: 12, sm: 6, lg: 3 }} key={i}>
           <Card 
             sx={{ 
               textAlign: "center",
@@ -671,7 +671,7 @@ const EnhancedBoardSection = ({ board_members }) => (
         const isFounder = member.role.toLowerCase().includes('co-founder');
         
         return (
-          <Grid item xs={12} md={6} lg={4} key={i}>
+          <Grid size={{ xs: 12, md: 6, lg: 4 }} key={i}>
             <Card 
               sx={{ 
                 height: "100%",
@@ -829,7 +829,7 @@ const EnhancedPledgeSection = ({ pledge }) => (
         const color = colors[i % colors.length];
         
         return (
-          <Grid item xs={12} md={6} key={i}>
+          <Grid size={{ xs: 12, md: 6 }} key={i}>
             <Card 
               sx={{ 
                 height: "100%",
@@ -945,7 +945,7 @@ const PayPalSocialProofSection = () => (
       </Typography>
       
       <Grid container spacing={4} alignItems="center">
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Box
             sx={{
               position: "relative",
@@ -973,7 +973,7 @@ const PayPalSocialProofSection = () => (
           </Box>
         </Grid>
         
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Box sx={{ textAlign: { xs: "center", md: "left" } }}>
             <Typography 
               variant="h5" 

--- a/src/pages/about/judges/index.js
+++ b/src/pages/about/judges/index.js
@@ -367,7 +367,7 @@ const AboutJudges = () => {
           spacing={2}
           sx={{ maxWidth: "600px", mx: "auto", mb: 4 }}
         >
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="contained"
               color="primary"
@@ -386,7 +386,7 @@ const AboutJudges = () => {
               Find Events to Judge
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="outlined"
               color="primary"
@@ -485,7 +485,7 @@ const AboutJudges = () => {
           ) : upcomingEvents && upcomingEvents.length > 0 ? (
             <Grid container spacing={3}>
               {upcomingEvents.map((event) => (
-                <Grid item xs={12} md={6} key={event.event_id}>
+                <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
                   <Card
                     sx={{
                       bgcolor: "white",
@@ -604,7 +604,7 @@ const AboutJudges = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <BalanceRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -616,7 +616,7 @@ const AboutJudges = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <TrendingUpRounded
                   color="secondary"
@@ -631,7 +631,7 @@ const AboutJudges = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <GroupsRounded color="success" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -745,7 +745,7 @@ const AboutJudges = () => {
           </Paper>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <MovieRounded color="primary" sx={{ mr: 2 }} />
@@ -764,7 +764,7 @@ const AboutJudges = () => {
                 />
               </Card>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <LiveTvRounded color="secondary" sx={{ mr: 2 }} />

--- a/src/pages/about/judges/overview.js
+++ b/src/pages/about/judges/overview.js
@@ -65,7 +65,7 @@ const SectionHeader = memo(({ variant = "h3", component = "h2", children, sectio
 SectionHeader.displayName = 'SectionHeader';
 
 const VideoHighlightCard = memo(({ icon: Icon, title, description, chipLabel, chipColor }) => (
-  <Grid item xs={12} md={4}>
+  <Grid size={{ xs: 12, md: 4 }}>
     <Card sx={{ 
       height: "100%", 
       display: 'flex',
@@ -100,7 +100,7 @@ const VideoHighlightCard = memo(({ icon: Icon, title, description, chipLabel, ch
 VideoHighlightCard.displayName = 'VideoHighlightCard';
 
 const ResourceButton = memo(({ href, icon: Icon, label, onClick, trackingLabel }) => (
-  <Grid item xs={12} sm={6} md={3}>
+  <Grid size={{ xs: 12, sm: 6, md: 3 }}>
     <Button
       variant="outlined"
       fullWidth

--- a/src/pages/about/locations/asu-tempe-arizona/index.js
+++ b/src/pages/about/locations/asu-tempe-arizona/index.js
@@ -461,7 +461,7 @@ const EventLocationPage = () => {
             {Object.entries(LOCATIONS).map(([slug, loc]) => {
               const isActive = slug === locationSlug;
               return (
-                <Grid item xs={12} sm={6} key={slug}>
+                <Grid size={{ xs: 12, sm: 6 }} key={slug}>
                   <Paper
                     elevation={isActive ? 4 : 0}
                     onClick={() => handleLocationChange(slug)}
@@ -547,28 +547,28 @@ const EventLocationPage = () => {
 
         {/* Quick Info Cards */}
         <Grid container spacing={3} sx={{ mb: 6 }}>
-          <Grid item xs={12} md={3}>
+          <Grid size={{ xs: 12, md: 3 }}>
             <Card sx={{ textAlign: "center", p: 2, height: "100%" }}>
               <FlightRounded color="primary" sx={{ fontSize: 40, mb: 1 }} />
               <Typography variant="h6" gutterBottom>Airport</Typography>
               <Typography variant="body2">10 min from PHX</Typography>
             </Card>
           </Grid>
-          <Grid item xs={12} md={3}>
+          <Grid size={{ xs: 12, md: 3 }}>
             <Card sx={{ textAlign: "center", p: 2, height: "100%" }}>
               <LocalParkingRounded color="primary" sx={{ fontSize: 40, mb: 1 }} />
               <Typography variant="h6" gutterBottom>Parking</Typography>
               <Typography variant="body2">5 options available</Typography>
             </Card>
           </Grid>
-          <Grid item xs={12} md={3}>
+          <Grid size={{ xs: 12, md: 3 }}>
             <Card sx={{ textAlign: "center", p: 2, height: "100%" }}>
               <HotelRounded color="primary" sx={{ fontSize: 40, mb: 1 }} />
               <Typography variant="h6" gutterBottom>Hotels</Typography>
               <Typography variant="body2">4+ nearby options</Typography>
             </Card>
           </Grid>
-          <Grid item xs={12} md={3}>
+          <Grid size={{ xs: 12, md: 3 }}>
             <Card sx={{ textAlign: "center", p: 2, height: "100%" }}>
               <AccessTimeRounded color="primary" sx={{ fontSize: 40, mb: 1 }} />
               <Typography variant="h6" gutterBottom>Transit</Typography>
@@ -634,7 +634,7 @@ const EventLocationPage = () => {
               </Box>
 
               <Grid container spacing={2}>
-                <Grid item>
+                <Grid>
                   <Button
                     variant="contained"
                     startIcon={<NavigationRounded />}
@@ -643,7 +643,7 @@ const EventLocationPage = () => {
                     Get Directions
                   </Button>
                 </Grid>
-                <Grid item>
+                <Grid>
                   <Button
                     variant="outlined"
                     startIcon={<ShareRounded />}
@@ -653,7 +653,7 @@ const EventLocationPage = () => {
                   </Button>
                 </Grid>
                 {activeLocation.tourUrl && (
-                  <Grid item>
+                  <Grid>
                     <Button
                       variant="outlined"
                       startIcon={<LinkRounded />}
@@ -718,7 +718,7 @@ const EventLocationPage = () => {
               {activeLocation.gallery.length > 0 && (
                 <Grid container spacing={3}>
                   {activeLocation.gallery.map((photo, index) => (
-                    <Grid item xs={12} sm={6} md={4} key={index}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }} key={index}>
                       <Card
                         sx={{
                           height: "100%",
@@ -774,7 +774,7 @@ const EventLocationPage = () => {
 
           <Grid container spacing={4}>
             {transportationOptions.map((transport, index) => (
-              <Grid item xs={12} md={6} key={index}>
+              <Grid size={{ xs: 12, md: 6 }} key={index}>
                 <Card sx={{ height: "100%", p: 2 }}>
                   <CardContent>
                     <Typography variant="h5" gutterBottom sx={{ display: "flex", alignItems: "center", gap: 1 }}>
@@ -818,7 +818,7 @@ const EventLocationPage = () => {
 
           <Grid container spacing={3}>
             {parkingOptions.map((parking, index) => (
-              <Grid item xs={12} md={6} key={index}>
+              <Grid size={{ xs: 12, md: 6 }} key={index}>
                 <Card 
                   sx={{ 
                     height: "100%", 
@@ -893,7 +893,7 @@ const EventLocationPage = () => {
 
           <Grid container spacing={3}>
             {hotels.map((hotel, index) => (
-              <Grid item xs={12} md={6} key={index}>
+              <Grid size={{ xs: 12, md: 6 }} key={index}>
                 <Card sx={{ height: "100%" }}>
                   <CardContent>
                     <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 2 }}>
@@ -942,7 +942,7 @@ const EventLocationPage = () => {
                     </Box>
 
                     <Grid container spacing={1}>
-                      <Grid item xs={6}>
+                      <Grid size={{ xs: 6 }}>
                         <Button
                           variant="outlined"
                           size="small"
@@ -953,7 +953,7 @@ const EventLocationPage = () => {
                           Directions
                         </Button>
                       </Grid>
-                      <Grid item xs={6}>
+                      <Grid size={{ xs: 6 }}>
                         <Button
                           variant="outlined"
                           size="small"
@@ -988,7 +988,7 @@ const EventLocationPage = () => {
           </Box>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", p: 3, height: "100%" }}>
                 <RestaurantRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h6" gutterBottom>Dining Options</Typography>
@@ -997,7 +997,7 @@ const EventLocationPage = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", p: 3, height: "100%" }}>
                 <LocalGasStationRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h6" gutterBottom>Gas & Services</Typography>
@@ -1006,7 +1006,7 @@ const EventLocationPage = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", p: 3, height: "100%" }}>
                 <InfoRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h6" gutterBottom>Campus Resources</Typography>
@@ -1027,7 +1027,7 @@ const EventLocationPage = () => {
             Join us at ASU Tempe for an amazing hackathon experience! Check out our upcoming events and get involved.
           </Typography>
           <Grid container spacing={2} justifyContent="center">
-            <Grid item>
+            <Grid>
               <Button
                 variant="contained"
                 size="large"
@@ -1041,7 +1041,7 @@ const EventLocationPage = () => {
                 Find Events
               </Button>
             </Grid>
-            <Grid item>
+            <Grid>
               <Button
                 variant="outlined"
                 size="large"

--- a/src/pages/about/process.js
+++ b/src/pages/about/process.js
@@ -201,7 +201,7 @@ export default function OpportunityHackProcess() {
               icon: <TimelineIcon fontSize="large" />,
             },
           ].map((section, index) => (
-            <Grid item xs={12} md={6} key={index}>
+            <Grid size={{ xs: 12, md: 6 }} key={index}>
               <StyledPaper>
                 <IconWrapper>
                   {section.icon}

--- a/src/pages/about/style-guide/index.js
+++ b/src/pages/about/style-guide/index.js
@@ -112,7 +112,7 @@ export default function StyleGuide(){
           </Typography>
           <Grid container spacing={2}>
             {Object.entries(colors).map(([name, value]) => (
-              <Grid item key={name} xs={6} sm={3}>
+              <Grid size={{ xs: 6, sm: 3 }} key={name}>
                 <Box
                   sx={{
                     width: "100%",
@@ -171,17 +171,17 @@ export default function StyleGuide(){
             these consistently in your UX designs:
           </Typography>
           <Grid container spacing={2}>
-            <Grid item>
+            <Grid>
               <Button variant="contained" color="primary">
                 Primary Button
               </Button>
             </Grid>
-            <Grid item>
+            <Grid>
               <Button variant="contained" color="secondary">
                 Secondary Button
               </Button>
             </Grid>
-            <Grid item>
+            <Grid>
               <Button variant="outlined" color="primary">
                 Outlined Button
               </Button>
@@ -208,7 +208,7 @@ export default function StyleGuide(){
               <Typography variant="h4">{color.replace("_", " ")}</Typography>
               <Grid container spacing={2}>
                 {logoVariants.map((variant) => (
-                  <Grid item xs={12} sm={4} key={variant.name}>
+                  <Grid size={{ xs: 12, sm: 4 }} key={variant.name}>
                     <Box
                       sx={{
                         width: "100%",
@@ -272,7 +272,7 @@ export default function StyleGuide(){
 
           <Grid container spacing={2}>
             {twoLetterLogoColors.map((color) => (
-              <Grid item xs={12} sm={4} key={color}>
+              <Grid size={{ xs: 12, sm: 4 }} key={color}>
                 <Box
                   sx={{
                     width: 100,

--- a/src/pages/about/success-stories/index.js
+++ b/src/pages/about/success-stories/index.js
@@ -346,7 +346,7 @@ export default function SuccessStories() {
 
         <Grid container spacing={4} marginTop={4}>
           {successStories.map((story, index) => (
-            <Grid item key={index} xs={12} sm={6} md={4} id={`${story.key}`}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} key={index} id={`${story.key}`}>
               <StyledCard>
                 <StyledCardMedia image={story.image} title={story.title} />
                 <StyledCardContent>
@@ -491,7 +491,7 @@ export default function SuccessStories() {
           </Typography>
           
           <Grid container spacing={3} justifyContent="center" marginTop={3}>
-            <Grid item>
+            <Grid>
               <Link href="/nonprofits/apply" passHref>
                 <Button 
                   variant="contained" 
@@ -518,14 +518,14 @@ export default function SuccessStories() {
         </Box>
 
         <Grid container spacing={4} justifyContent="center" marginTop={4}>
-          <Grid item>
+          <Grid>
             <Link href="/about/hackers" passHref>
               <Button variant="outlined" color="secondary" size="large">
                 Tech Volunteers: Apply Your Skills
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/sponsor" passHref>
               <Button variant="outlined" color="info" size="large">
                 Sponsors: Empower Innovation

--- a/src/pages/about/success-stories/matthews-crossing-data-automation.js
+++ b/src/pages/about/success-stories/matthews-crossing-data-automation.js
@@ -53,7 +53,7 @@ export default function MatthewsCrossingSuccessStory() {
 
         <StyledPaper>
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h2" gutterBottom>
                 Project Overview
               </Typography>
@@ -70,7 +70,7 @@ export default function MatthewsCrossingSuccessStory() {
                 <CodeIcon /> <strong>Technologies Used:</strong> PHP, Python, JavaScript, HTML/CSS, CSV data processing, Excel report generation, Data visualization tools, Two-factor authentication
               </Typography>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h2" gutterBottom>
                 The Challenge
               </Typography>
@@ -178,21 +178,21 @@ export default function MatthewsCrossingSuccessStory() {
         </StyledPaper>
 
         <Grid container spacing={4} justifyContent="center" marginTop={4} marginBottom={4}>
-          <Grid item>
+          <Grid>
             <Link href="/nonprofits/apply" passHref>
               <Button variant="contained" color="primary" size="large">
                 Nonprofits: Submit Your Challenge
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/hack" passHref>
               <Button variant="contained" color="secondary" size="large">
                 Tech Volunteers: Apply Your Skills
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/sponsor" passHref>
               <Button variant="contained" color="info" size="large">
                 Sponsors: Empower Innovation

--- a/src/pages/about/success-stories/saving-one-life-adoption-innovation.js
+++ b/src/pages/about/success-stories/saving-one-life-adoption-innovation.js
@@ -70,7 +70,7 @@ export default function SavingOneLifeSuccessStory() {
 
         <StyledPaper>
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h2" gutterBottom>
                 Project Overview
               </Typography>
@@ -88,7 +88,7 @@ export default function SavingOneLifeSuccessStory() {
                 <CodeIcon /> <strong>Technologies Used:</strong> Python, Flask, MongoDB, Machine Learning algorithms, Social Media APIs, Data Analysis tools
               </Typography>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h2" gutterBottom>
                 The Challenge
               </Typography>
@@ -165,21 +165,21 @@ export default function SavingOneLifeSuccessStory() {
         </StyledPaper>
 
         <Grid container spacing={4} justifyContent="center" marginTop={4} marginBottom={4}>
-          <Grid item>
+          <Grid>
             <Link href="/nonprofits/apply" passHref>
               <Button variant="contained" color="primary" size="large">
                 Nonprofits: Submit Your Challenge
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/hack" passHref>
               <Button variant="contained" color="secondary" size="large">
                 Tech Volunteers: Apply Your Skills
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/sponsor" passHref>
               <Button variant="contained" color="info" size="large">
                 Sponsors: Empower Innovation

--- a/src/pages/about/success-stories/vidyodaya-website-modernization.js
+++ b/src/pages/about/success-stories/vidyodaya-website-modernization.js
@@ -108,7 +108,7 @@ export default function VidyodayaSuccessStory() {
 
         <StyledPaper>
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h2" gutterBottom>
                 Project Overview
               </Typography>
@@ -129,7 +129,7 @@ export default function VidyodayaSuccessStory() {
                 Cloudinary
               </Typography>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h2" gutterBottom>
                 The Challenge
               </Typography>
@@ -249,21 +249,21 @@ export default function VidyodayaSuccessStory() {
           marginTop={4}
           marginBottom={4}
         >
-          <Grid item>
+          <Grid>
             <Link href="/nonprofits/apply" passHref>
               <Button variant="contained" color="primary" size="large">
                 Nonprofits: Submit Your Challenge
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/hack" passHref>
               <Button variant="contained" color="secondary" size="large">
                 Tech Volunteers: Apply Your Skills
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/sponsor" passHref>
               <Button variant="contained" color="info" size="large">
                 Sponsors: Empower Innovation

--- a/src/pages/about/success-stories/zuris-circle-event-management.js
+++ b/src/pages/about/success-stories/zuris-circle-event-management.js
@@ -48,7 +48,7 @@ export default function ZurisCircleSuccessStory() {
 
         <StyledPaper>
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h2" gutterBottom>
                 Project Overview
               </Typography>
@@ -65,7 +65,7 @@ export default function ZurisCircleSuccessStory() {
                 <CodeIcon /> <strong>Technologies Used:</strong> ASP.NET Core 3.0, ML.NET, MongoDB, React, Redux, Material UI, Chart.js, Azure, Heroku
               </Typography>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h2" gutterBottom>
                 The Challenge
               </Typography>
@@ -147,21 +147,21 @@ export default function ZurisCircleSuccessStory() {
         </StyledPaper>
 
         <Grid container spacing={4} justifyContent="center" marginTop={4} marginBottom={4}>
-          <Grid item>
+          <Grid>
             <Link href="/nonprofits/apply" passHref>
               <Button variant="contained" color="primary" size="large">
                 Nonprofits: Submit Your Challenge
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/hack" passHref>
               <Button variant="contained" color="secondary" size="large">
                 Tech Volunteers: Apply Your Skills
               </Button>
             </Link>
           </Grid>
-          <Grid item>
+          <Grid>
             <Link href="/sponsor" passHref>
               <Button variant="contained" color="info" size="large">
                 Sponsors: Empower Innovation

--- a/src/pages/about/why/index.js
+++ b/src/pages/about/why/index.js
@@ -288,7 +288,7 @@ export default function WhyIndex() {
         <ProjectsContainer>
           <Grid container spacing={4} mb={6}>
             {careerPathContent.map((content, index) => (
-              <Grid item xs={12} md={4} key={index}>
+              <Grid size={{ xs: 12, md: 4 }} key={index}>
                 <CareerPathCard {...content} />
               </Grid>
             ))}

--- a/src/pages/admin/certificates/index.js
+++ b/src/pages/admin/certificates/index.js
@@ -532,7 +532,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
 
             <Box component="form" onSubmit={handleHeartsSubmit}>
               <Grid container spacing={3}>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Autocomplete
                     multiple
                     fullWidth
@@ -587,7 +587,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
                     disabled={loadingSlackUsers}
                   />
                 </Grid>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <FormControl fullWidth>
                     <InputLabel>Heart Types</InputLabel>
                     <Select
@@ -604,7 +604,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
                     </Select>
                   </FormControl>
                 </Grid>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <TextField
                     fullWidth
                     type="number"
@@ -615,7 +615,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
                     required
                   />
                 </Grid>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Button
                     type="submit"
                     variant="contained"
@@ -645,7 +645,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
                 {(selectedUsers.length > 0 ||
                   selectedHearts.length > 0 ||
                   heartCount !== 0.5) && (
-                  <Grid item xs={12}>
+                  <Grid size={{ xs: 12 }}>
                     <Alert severity="info" sx={{ mt: 2 }}>
                       <Typography variant="h6" gutterBottom>
                         Award Summary
@@ -712,7 +712,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
 
             <Box component="form" onSubmit={handleGitHubCertificateSubmit}>
               <Grid container spacing={3}>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <TextField
                     fullWidth
                     label="GitHub Username"
@@ -723,7 +723,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
                     helperText="GitHub username (not email)"
                   />
                 </Grid>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <TextField
                     fullWidth
                     label="Repository URL"
@@ -734,7 +734,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
                     helperText="Full GitHub repository URL"
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <Button
                     type="submit"
                     variant="contained"
@@ -773,7 +773,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
               }
             }}>
               <Grid container spacing={3}>
-                <Grid item xs={12} sm={8}>
+                <Grid size={{ xs: 12, sm: 8 }}>
                   <TextField
                     fullWidth
                     label="Slack Channel"
@@ -784,7 +784,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
                     helperText="Enter the Slack channel name (without #)"
                   />
                 </Grid>
-                <Grid item xs={12} sm={4}>
+                <Grid size={{ xs: 12, sm: 4 }}>
                   <Button
                     type="submit"
                     variant="contained"
@@ -818,7 +818,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
             📊 Hearts Leaderboard
           </Typography>
           <Grid container spacing={2} alignItems="center">
-            <Grid item>
+            <Grid>
               <Button
                 onClick={() => {
                   fetchUsersHearts();
@@ -830,7 +830,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
                 {loading || loadingSlackUsers ? "Refreshing..." : "Refresh Data"}
               </Button>
             </Grid>
-            <Grid item xs>
+            <Grid size={{ xs: true }}>
               <TextField
                 fullWidth
                 label="Filter by Slack Username"
@@ -937,7 +937,7 @@ const AdminCertificatesPage = withRequiredAuthInfo(({ userClass }) => {
             📜 Recent Certificates
           </Typography>
           <Grid container spacing={2} alignItems="center" sx={{ mb: 3 }}>
-            <Grid item>
+            <Grid>
               <Button
                 onClick={fetchRecentCertificates}
                 variant="outlined"

--- a/src/pages/admin/check-in/index.js
+++ b/src/pages/admin/check-in/index.js
@@ -459,7 +459,7 @@ const AdminCheckInPage = withRequiredAuthInfo(({ userClass }) => {
       {/* Event Selection and Check-in Counts */}
       <Box sx={{ mb: 3 }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <FormControl fullWidth>
               <InputLabel id="hackathon-select-label">
                 Hackathon Event
@@ -499,7 +499,7 @@ const AdminCheckInPage = withRequiredAuthInfo(({ userClass }) => {
               </Typography>
             )}
           </Grid>
-          <Grid item xs={12} md={8}>
+          <Grid size={{ xs: 12, md: 8 }}>
             {selectedEventId && (
               <Paper elevation={1} sx={{ p: 2, bgcolor: 'background.paper' }}>
                 <Typography variant="h6" gutterBottom>
@@ -513,7 +513,7 @@ const AdminCheckInPage = withRequiredAuthInfo(({ userClass }) => {
                     { key: 'hacker', label: 'Hackers', color: 'info' },
                     { key: 'sponsor', label: 'Sponsors', color: 'warning' }
                   ].map(({ key, label, color }) => (
-                    <Grid item xs={6} sm={4} md={2.4} key={key}>
+                    <Grid size={{ xs: 6, sm: 4, md: 2.4 }} key={key}>
                       <Card sx={{ textAlign: 'center', minHeight: 80 }}>
                         <CardContent sx={{ pb: 1, '&:last-child': { pb: 1 } }}>
                           <Typography variant="h4" color={`${color}.main`} fontWeight="bold">
@@ -538,7 +538,7 @@ const AdminCheckInPage = withRequiredAuthInfo(({ userClass }) => {
 
       <Grid container spacing={3}>
         {/* Scanner Section */}
-        <Grid item xs={12} md={8}>
+        <Grid size={{ xs: 12, md: 8 }}>
           <Paper elevation={2} sx={{ p: 3 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
               <QrCodeScannerIcon sx={{ mr: 1 }} />
@@ -642,7 +642,7 @@ const AdminCheckInPage = withRequiredAuthInfo(({ userClass }) => {
         </Grid>
 
         {/* All Checked-In People */}
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Paper elevation={2} sx={{ p: 3 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
               <PersonIcon sx={{ mr: 1 }} />

--- a/src/pages/admin/contact/index.js
+++ b/src/pages/admin/contact/index.js
@@ -205,12 +205,12 @@ const AdminContactPage = withRequiredAuthInfo(({ userClass }) => {
 
       <Box sx={{ mb: 3, width: "100%" }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item>
+          <Grid>
             <Button onClick={fetchSubmissions} variant="outlined">
               Refresh Data
             </Button>
           </Grid>
-          <Grid item xs>
+          <Grid size={{ xs: true }}>
             <TextField
               fullWidth
               label="Filter by Name, Email, Organization, or Inquiry Type"

--- a/src/pages/admin/giveaways/index.js
+++ b/src/pages/admin/giveaways/index.js
@@ -187,12 +187,12 @@ const AdminGiveawaysPage = withRequiredAuthInfo(({ userClass }) => {
           Manage and conduct fair, transparent giveaway selections. The dramatic selection process shows exactly how winners are chosen using a seeded random number generator for full transparency.
         </Typography>
         <Grid container spacing={2} alignItems="center">
-          <Grid item>
+          <Grid>
             <Button onClick={fetchGiveaways} variant="outlined">
               Refresh Data
             </Button>
           </Grid>
-          <Grid item xs>
+          <Grid size={{ xs: true }}>
             <TextField
               fullWidth
               label="Filter by Name, Nickname, or GitHub"
@@ -205,7 +205,7 @@ const AdminGiveawaysPage = withRequiredAuthInfo(({ userClass }) => {
 
       {/* Statistics Cards */}
       <Grid container spacing={3} sx={{ mb: 3 }}>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Card>
             <CardContent>
               <Typography color="text.secondary" gutterBottom>
@@ -217,7 +217,7 @@ const AdminGiveawaysPage = withRequiredAuthInfo(({ userClass }) => {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Card>
             <CardContent>
               <Typography color="text.secondary" gutterBottom>
@@ -229,7 +229,7 @@ const AdminGiveawaysPage = withRequiredAuthInfo(({ userClass }) => {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Card>
             <CardContent>
               <Typography color="text.secondary" gutterBottom>
@@ -241,7 +241,7 @@ const AdminGiveawaysPage = withRequiredAuthInfo(({ userClass }) => {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Card>
             <CardContent>
               <Typography color="text.secondary" gutterBottom>
@@ -263,7 +263,7 @@ const AdminGiveawaysPage = withRequiredAuthInfo(({ userClass }) => {
 
       <Box sx={{ mb: 3, width: "100%" }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs={12} sm={6} md={4}>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
             <TextField
               fullWidth
               label="Random Seed (for fair & transparent selection)"
@@ -274,7 +274,7 @@ const AdminGiveawaysPage = withRequiredAuthInfo(({ userClass }) => {
               placeholder="e.g., 12345"
             />
           </Grid>
-          <Grid item xs={12} sm={6} md={4}>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
             <Button
               variant="outlined"
               onClick={() => setRandomSeed(Date.now().toString())}
@@ -283,7 +283,7 @@ const AdminGiveawaysPage = withRequiredAuthInfo(({ userClass }) => {
               Generate Random Seed
             </Button>
           </Grid>
-          <Grid item xs={12}>
+          <Grid size={{ xs: 12 }}>
             <DramaticGiveawaySelector
               giveaways={sortedGiveaways}
               randomSeed={randomSeed}

--- a/src/pages/admin/hackathon-requests/index.js
+++ b/src/pages/admin/hackathon-requests/index.js
@@ -204,12 +204,12 @@ const AdminHackathonRequestsPage = withRequiredAuthInfo(({ userClass }) => {
 
       <Box sx={{ mb: 3, width: "100%" }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item>
+          <Grid>
             <Button onClick={fetchRequests} variant="outlined">
               Refresh Data
             </Button>
           </Grid>
-          <Grid item xs>
+          <Grid size={{ xs: true }}>
             <TextField
               fullWidth
               label="Filter by Organization, Contact, Email, or Location"

--- a/src/pages/admin/hackathons/index.js
+++ b/src/pages/admin/hackathons/index.js
@@ -384,7 +384,7 @@ const AdminHackathonPage = () => {
     >
       <Box sx={{ mb: 3, width: "100%" }}>
         <Grid container spacing={2} alignItems="center" justifyContent="flex-end">
-          <Grid item>
+          <Grid>
             <Button
               onClick={handleAddHackathon}
               variant="contained"
@@ -402,7 +402,7 @@ const AdminHackathonPage = () => {
       ) : (
         <Grid container spacing={3}>
           {hackathons.map((hackathon) => (
-            <Grid item xs={12} lg={6} key={hackathon.id}>
+            <Grid size={{ xs: 12, lg: 6 }} key={hackathon.id}>
               <Card elevation={3} sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
                 <CardContent sx={{ flexGrow: 1 }}>
                   {/* Header */}

--- a/src/pages/admin/hearts/index.js
+++ b/src/pages/admin/hearts/index.js
@@ -323,7 +323,7 @@ const AdminHeartsPage = withRequiredAuthInfo(({ userClass }) => {
 
         <Box component="form" onSubmit={handleSubmit}>
           <Grid container spacing={3}>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Autocomplete
                 multiple
                 fullWidth
@@ -378,7 +378,7 @@ const AdminHeartsPage = withRequiredAuthInfo(({ userClass }) => {
                 disabled={loadingSlackUsers}
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <FormControl fullWidth>
                 <InputLabel>Heart Types</InputLabel>
                 <Select
@@ -395,7 +395,7 @@ const AdminHeartsPage = withRequiredAuthInfo(({ userClass }) => {
                 </Select>
               </FormControl>
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <TextField
                 fullWidth
                 type="number"
@@ -406,7 +406,7 @@ const AdminHeartsPage = withRequiredAuthInfo(({ userClass }) => {
                 required
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Button
                 type="submit"
                 variant="contained"
@@ -437,7 +437,7 @@ const AdminHeartsPage = withRequiredAuthInfo(({ userClass }) => {
             {(selectedUsers.length > 0 ||
               selectedHearts.length > 0 ||
               heartCount !== 0.5) && (
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <Alert severity="info" sx={{ mt: 2 }}>
                   <Typography variant="h6" gutterBottom>
                     Award Summary
@@ -496,7 +496,7 @@ const AdminHeartsPage = withRequiredAuthInfo(({ userClass }) => {
           📊 Hearts Leaderboard
         </Typography>
         <Grid container spacing={2} alignItems="center">
-          <Grid item>
+          <Grid>
             <Button
               onClick={() => {
                 fetchUsersHearts();
@@ -508,7 +508,7 @@ const AdminHeartsPage = withRequiredAuthInfo(({ userClass }) => {
               {loading || loadingSlackUsers ? "Refreshing..." : "Refresh Data"}
             </Button>
           </Grid>
-          <Grid item xs>
+          <Grid size={{ xs: true }}>
             <TextField
               fullWidth
               label="Filter by Slack Username"

--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -173,7 +173,7 @@ const AdminDashboard = () => {
 
         <Grid container spacing={isMobile ? 2 : 3}>
           {adminPages.map((page) => (
-            <Grid item xs={12} sm={6} md={4} lg={3} key={page.path}>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={page.path}>
               <NextLink href={page.path} passHref legacyBehavior>
                 <Box component="a" sx={{ textDecoration: "none", display: "block" }}>
                   <StyledCard>

--- a/src/pages/admin/nonprofit/application.js
+++ b/src/pages/admin/nonprofit/application.js
@@ -155,12 +155,12 @@ const AdminNonprofitPage = withRequiredAuthInfo(({ userClass }) => {
     >
       <Box sx={{ mb: 3, width: "100%" }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item>
+          <Grid>
             <Button onClick={fetchApplications} variant="outlined">
               Refresh Data
             </Button>
           </Grid>
-          <Grid item xs>
+          <Grid size={{ xs: true }}>
             <TextField
               fullWidth
               label="Filter by Name, Organization, or Email"

--- a/src/pages/admin/nonprofit/index.js
+++ b/src/pages/admin/nonprofit/index.js
@@ -198,12 +198,12 @@ const AdminNonprofitPage = withRequiredAuthInfo(({ userClass }) => {
     >
       <Box sx={{ mb: 3, width: "100%" }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item>
+          <Grid>
             <Button onClick={fetchNonprofits} variant="outlined">
               Refresh Data
             </Button>
           </Grid>
-          <Grid item>
+          <Grid>
             <Button
               onClick={handleAddNonprofit}
               variant="contained"
@@ -212,7 +212,7 @@ const AdminNonprofitPage = withRequiredAuthInfo(({ userClass }) => {
               Add Nonprofit
             </Button>
           </Grid>
-          <Grid item xs>
+          <Grid size={{ xs: true }}>
             <TextField
               fullWidth
               label="Filter by Name or Description"

--- a/src/pages/admin/problems/index.js
+++ b/src/pages/admin/problems/index.js
@@ -456,7 +456,7 @@ const AdminProblemsPage = () => {
       <AdminPage title="Problem Statement Management" isAdmin={isAdmin}>
         <Box sx={{ mb: 3 }}>
           <Grid container spacing={2} alignItems="center">
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <TextField
                 fullWidth
                 label="Search Problem Statements"
@@ -467,7 +467,7 @@ const AdminProblemsPage = () => {
                 size="medium"
               />
             </Grid>
-            <Grid item xs={12} md={6} sx={{ display: 'flex', justifyContent: { xs: 'flex-start', md: 'flex-end' } }}>
+            <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex', justifyContent: { xs: 'flex-start', md: 'flex-end' } }}>
               <Button
                 variant="contained"
                 color="primary"
@@ -1204,7 +1204,7 @@ const AdminProblemsPage = () => {
                     Link to New Event
                   </Typography>
                   <Grid container spacing={2} alignItems="center">
-                    <Grid item xs={12} md={8}>
+                    <Grid size={{ xs: 12, md: 8 }}>
                       <FormControl fullWidth>
                         <InputLabel>Select Hackathon Event</InputLabel>
                         <Select
@@ -1227,7 +1227,7 @@ const AdminProblemsPage = () => {
                         </Select>
                       </FormControl>
                     </Grid>
-                    <Grid item xs={12} md={4}>
+                    <Grid size={{ xs: 12, md: 4 }}>
                       <Button
                         onClick={handleAddHackathonEvent}
                         disabled={!selectedHackathonId}
@@ -1290,7 +1290,7 @@ const AdminProblemsPage = () => {
                   Associated Nonprofit
                 </Typography>
                 <Grid container spacing={2}>
-                  <Grid item xs={12}>
+                  <Grid size={{ xs: 12 }}>
                     <FormControl fullWidth>
                       <InputLabel id="nonprofit-select-label">Link to Nonprofit</InputLabel>
                       <Select
@@ -1316,7 +1316,7 @@ const AdminProblemsPage = () => {
                     </FormControl>
                   </Grid>
                   {nonprofits.length > 10 && (
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                       <TextField
                         label="Search Nonprofits"
                         variant="outlined"
@@ -1330,7 +1330,7 @@ const AdminProblemsPage = () => {
                   
                   {/* Display selected nonprofit details */}
                   {selectedNonprofitId && (
-                    <Grid item xs={12}>
+                    <Grid size={{ xs: 12 }}>
                       <Paper 
                         variant="outlined" 
                         sx={{ 

--- a/src/pages/admin/profile/index.js
+++ b/src/pages/admin/profile/index.js
@@ -285,7 +285,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
       {/* Header Stats */}
       <Paper sx={{ p: 3, mb: 3 }}>
         <Grid container spacing={3}>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <Box sx={{ textAlign: "center" }}>
               <Typography variant="h3" color="primary">
                 {profiles.length}
@@ -295,7 +295,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <Box sx={{ textAlign: "center" }}>
               <Typography variant="h3" color="success.main">
                 {profiles.filter((p) => calculateProfileCompleteness(p) >= 6).length}
@@ -305,7 +305,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <Box sx={{ textAlign: "center" }}>
               <Typography variant="h3" color="info.main">
                 {profiles.filter((p) => Array.isArray(p.badges) && p.badges.length > 0).length}
@@ -315,7 +315,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
               </Typography>
             </Box>
           </Grid>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <Box sx={{ textAlign: "center" }}>
               <Typography variant="h3" color="secondary.main">
                 {profiles.filter((p) => Array.isArray(p.teams) && p.teams.length > 0).length}
@@ -331,7 +331,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
       {/* Filters and Controls */}
       <Paper sx={{ p: 2, mb: 3 }}>
         <Grid container spacing={2} alignItems="center">
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <TextField
               fullWidth
               label="Search profiles"
@@ -346,7 +346,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
             />
           </Grid>
 
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <FormControl fullWidth size="small">
               <InputLabel>Sort By</InputLabel>
               <Select
@@ -364,7 +364,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
             </FormControl>
           </Grid>
 
-          <Grid item xs={12} sm={6} md={2}>
+          <Grid size={{ xs: 12, sm: 6, md: 2 }}>
             <FormControl fullWidth size="small">
               <InputLabel>Order</InputLabel>
               <Select
@@ -378,7 +378,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
             </FormControl>
           </Grid>
 
-          <Grid item xs={12} md={3} sx={{ display: "flex", gap: 1 }}>
+          <Grid size={{ xs: 12, md: 3 }} sx={{ display: "flex", gap: 1 }}>
             <Button
               onClick={fetchProfiles}
               variant="outlined"
@@ -442,7 +442,7 @@ const AdminProfilePage = withRequiredAuthInfo(({ userClass }) => {
             const teamCount = Array.isArray(profile.teams) ? profile.teams.length : 0;
 
             return (
-              <Grid item xs={12} sm={6} lg={4} key={profile.id || profile.email_address}>
+              <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={profile.id || profile.email_address}>
                 <StyledCard completeness={completeness}>
                   <CardActionArea onClick={() => handleProfileClick(profile.id)}>
                     <CardContent>

--- a/src/pages/admin/time-tracking/index.js
+++ b/src/pages/admin/time-tracking/index.js
@@ -180,7 +180,7 @@ const AdminTimeTrackingPage = () => {
         <Paper sx={{ p: 3, mb: 3 }}>
           <LocalizationProvider dateAdapter={AdapterDateFns}>
             <Grid container spacing={2} alignItems="center">
-              <Grid item xs={12} sm={6} md={3}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <DatePicker
                   label="Start Date"
                   value={startDate}
@@ -188,7 +188,7 @@ const AdminTimeTrackingPage = () => {
                   renderInput={(params) => <TextField {...params} fullWidth />}
                 />
               </Grid>
-              <Grid item xs={12} sm={6} md={3}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <DatePicker
                   label="End Date"
                   value={endDate}
@@ -196,7 +196,7 @@ const AdminTimeTrackingPage = () => {
                   renderInput={(params) => <TextField {...params} fullWidth />}
                 />
               </Grid>
-              <Grid item xs={12} sm={6} md={3}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <FormControl fullWidth>
                   <InputLabel>Filter by Reason</InputLabel>
                   <Select
@@ -213,7 +213,7 @@ const AdminTimeTrackingPage = () => {
                   </Select>
                 </FormControl>
               </Grid>
-              <Grid item xs={12} sm={6} md={3}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Button
                   variant="contained"
                   onClick={fetchTimeTrackingData}
@@ -223,7 +223,7 @@ const AdminTimeTrackingPage = () => {
                   {loading ? <CircularProgress size={24} /> : "Fetch Data"}
                 </Button>
               </Grid>
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <TextField
                   fullWidth
                   label="Search by Name or Email"

--- a/src/pages/admin/volunteer/index.js
+++ b/src/pages/admin/volunteer/index.js
@@ -1275,7 +1275,7 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
         ) : (
           // Desktop layout - horizontal
           <Grid container spacing={2} alignItems="center">
-            <Grid item>
+            <Grid>
               <Button
                 onClick={() => {
                   dataLoadedRef.current = false;
@@ -1287,7 +1287,7 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
                 Refresh Data
               </Button>
             </Grid>
-            <Grid item>
+            <Grid>
               <Button
                 onClick={handleAddSingleVolunteer}
                 variant="outlined"
@@ -1296,7 +1296,7 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
                 Add Single Volunteer
               </Button>
             </Grid>
-            <Grid item>
+            <Grid>
               <ToggleButtonGroup
                 value={viewMode}
                 exclusive
@@ -1316,7 +1316,7 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
                 </ToggleButton>
               </ToggleButtonGroup>
             </Grid>
-            <Grid item xs={3}>
+            <Grid size={{ xs: 3 }}>
               <FormControl fullWidth>
                 <InputLabel id="hackathon-select-label">
                   Hackathon Event
@@ -1342,7 +1342,7 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
                 </Select>
               </FormControl>
             </Grid>
-            <Grid item>
+            <Grid>
               <Tooltip title="Share link to this hackathon">
                 <IconButton
                   onClick={handleShareLink}
@@ -1354,7 +1354,7 @@ const AdminVolunteerPage = withRequiredAuthInfo(({ userClass }) => {
               </Tooltip>
             </Grid>
             {viewMode === "table" && (
-              <Grid item xs>
+              <Grid size={{ xs: true }}>
                 <TextField
                   fullWidth
                   label={(() => {

--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -283,7 +283,7 @@ const ContactPage = () => {
           {/* Main content area */}
           <Grid container spacing={4} sx={{ mt: 4 }}>
             {/* Contact form */}
-            <Grid item xs={12} md={8}>
+            <Grid size={{ xs: 12, md: 8 }}>
               <Paper
                 elevation={3}
                 sx={{
@@ -336,7 +336,7 @@ const ContactPage = () => {
                 ) : (
                   <form onSubmit={handleSubmit}>
                     <Grid container spacing={3}>
-                      <Grid item xs={12} sm={6}>
+                      <Grid size={{ xs: 12, sm: 6 }}>
                         <TextField
                           label="First Name"
                           name="firstName"
@@ -349,7 +349,7 @@ const ContactPage = () => {
                           disabled={isSubmitting}
                         />
                       </Grid>
-                      <Grid item xs={12} sm={6}>
+                      <Grid size={{ xs: 12, sm: 6 }}>
                         <TextField
                           label="Last Name"
                           name="lastName"
@@ -359,7 +359,7 @@ const ContactPage = () => {
                           disabled={isSubmitting}
                         />
                       </Grid>
-                      <Grid item xs={12}>
+                      <Grid size={{ xs: 12 }}>
                         <TextField
                           label="Email Address"
                           name="email"
@@ -380,7 +380,7 @@ const ContactPage = () => {
                           }}
                         />
                       </Grid>
-                      <Grid item xs={12}>
+                      <Grid size={{ xs: 12 }}>
                         <TextField
                           label="Organization/Company (Optional)"
                           name="organization"
@@ -391,7 +391,7 @@ const ContactPage = () => {
                           disabled={isSubmitting}
                         />
                       </Grid>
-                      <Grid item xs={12}>
+                      <Grid size={{ xs: 12 }}>
                         <TextField
                           select
                           label="What are you contacting us about?"
@@ -420,7 +420,7 @@ const ContactPage = () => {
 
                       {/* Conditional information based on inquiry type */}
                       {selectedInquiryType && selectedInquiryType.link && (
-                        <Grid item xs={12}>
+                        <Grid size={{ xs: 12 }}>
                           <Alert
                             severity="info"
                             icon={false}
@@ -451,7 +451,7 @@ const ContactPage = () => {
                       {/* Special alert for reward claims */}
                       {selectedInquiryType &&
                         selectedInquiryType.value === "claim_reward" && (
-                          <Grid item xs={12}>
+                          <Grid size={{ xs: 12 }}>
                             <Alert
                               severity="success"
                               icon={<FaTrophy />}
@@ -485,7 +485,7 @@ const ContactPage = () => {
                           </Grid>
                         )}
 
-                      <Grid item xs={12}>
+                      <Grid size={{ xs: 12 }}>
                         <TextField
                           label="Message"
                           name="message"
@@ -504,7 +504,7 @@ const ContactPage = () => {
                           placeholder="How can we help you?"
                         />
                       </Grid>
-                      <Grid item xs={12}>
+                      <Grid size={{ xs: 12 }}>
                         <FormControlLabel
                           control={
                             <Checkbox
@@ -519,16 +519,16 @@ const ContactPage = () => {
                         />
                       </Grid>
                       {submitError && (
-                        <Grid item xs={12}>
+                        <Grid size={{ xs: 12 }}>
                           <Alert severity="error">{submitError}</Alert>
                         </Grid>
                       )}
                       {recaptchaError && (
-                        <Grid item xs={12}>
+                        <Grid size={{ xs: 12 }}>
                           <Alert severity="error">{recaptchaError}</Alert>
                         </Grid>
                       )}
-                      <Grid item xs={12}>
+                      <Grid size={{ xs: 12 }}>
                         <Box
                           sx={{ display: "flex", justifyContent: "flex-end" }}
                         >
@@ -557,7 +557,7 @@ const ContactPage = () => {
             </Grid>
 
             {/* Contact info sidebar */}
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Box sx={{ position: "sticky", top: 100 }}>
                 <Card elevation={2} sx={{ mb: 3, borderRadius: 2 }}>
                   <CardContent>

--- a/src/pages/feedback/index.js
+++ b/src/pages/feedback/index.js
@@ -124,7 +124,7 @@ export default function FeedbackPage() {
               Accessing and Providing Feedback
             </Typography>
             <Grid container spacing={2}>
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <Typography variant="h4" gutterBottom>
                   <Visibility sx={{ verticalAlign: "middle", mr: 1 }} />
                   View Your Feedback
@@ -137,7 +137,7 @@ export default function FeedbackPage() {
                   Your Feedback
                 </Button>
               </Grid>
-              <Grid item xs={12} sm={6}>
+              <Grid size={{ xs: 12, sm: 6 }}>
                 <Typography variant="h4" gutterBottom>
                   <Send sx={{ verticalAlign: "middle", mr: 1 }} />
                   Send Feedback

--- a/src/pages/hack/[event_id]/agenda.js
+++ b/src/pages/hack/[event_id]/agenda.js
@@ -253,7 +253,7 @@ const AgendaPage = ({ eventData }) => {
           </Typography>
 
           <Grid container spacing={2} justifyContent="center" sx={{ mt: 2 }}>
-            <Grid item>
+            <Grid>
               <Chip
                 icon={<LocationOnIcon />}
                 label={eventLocation}
@@ -266,7 +266,7 @@ const AgendaPage = ({ eventData }) => {
               />
             </Grid>
             {eventStartDate && (
-              <Grid item>
+              <Grid>
                 <Chip
                   icon={<CalendarTodayIcon />}
                   label={`${format(eventStartDate, 'MMM dd')}${eventEndDate ? ` - ${format(eventEndDate, 'MMM dd, yyyy')}` : ''}`}
@@ -316,7 +316,7 @@ const AgendaPage = ({ eventData }) => {
 
         <Grid container spacing={3}>
           {/* Event Information */}
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Paper sx={{
               p: 2,
               height: 'fit-content',
@@ -384,7 +384,7 @@ const AgendaPage = ({ eventData }) => {
           </Grid>
 
           {/* Schedule/Timeline */}
-          <Grid item xs={12} md={8}>
+          <Grid size={{ xs: 12, md: 8 }}>
             <Paper sx={{
               p: 2,
               '@media print': {

--- a/src/pages/hack/[event_id]/census.js
+++ b/src/pages/hack/[event_id]/census.js
@@ -775,7 +775,7 @@ export default function CensusPage() {
               <FormGroup>
                 <Grid container spacing={1}>
                   {timeSlots.map((timeSlot) => (
-                    <Grid item xs={12} sm={6} md={4} key={timeSlot}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }} key={timeSlot}>
                       <FormControlLabel
                         control={
                           <Checkbox
@@ -807,7 +807,7 @@ export default function CensusPage() {
         ) : (
           <Grid container spacing={3}>
             {/* Mentors Table */}
-            <Grid item xs={12}>
+            <Grid size={{ xs: 12 }}>
               <RoleTable
                 role="mentors"
                 people={getFilteredData('mentors')}
@@ -820,7 +820,7 @@ export default function CensusPage() {
             </Grid>
 
             {/* Volunteers Table */}
-            <Grid item xs={12}>
+            <Grid size={{ xs: 12 }}>
               <RoleTable
                 role="volunteers"
                 people={getFilteredData('volunteers')}
@@ -834,7 +834,7 @@ export default function CensusPage() {
 
             {/* Judges Table - Smart Visibility */}
             {getFilteredTimeSlots().some(slot => isJudgeTimeSlot(slot)) && (
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <RoleTable
                   role="judges"
                   people={getFilteredData('judges')}
@@ -849,7 +849,7 @@ export default function CensusPage() {
             )}
 
             {/* Hackers Table - Always Show */}
-            <Grid item xs={12}>
+            <Grid size={{ xs: 12 }}>
               <Box sx={{ mb: 3 }}>
                 <Typography variant="h6" gutterBottom sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                   <GroupIcon sx={{ mr: 1, color: 'info.main' }} />

--- a/src/pages/hack/[event_id]/findteam.js
+++ b/src/pages/hack/[event_id]/findteam.js
@@ -793,7 +793,7 @@ const FindTeamPage = () => {
       {!isCheckingApplication && myProfile?.application?.isSelected !== false && myProfile?.application && (
         <Grid container spacing={4}>
         {/* Left sidebar - Your profile */}
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <StyledPaper>
             <Typography variant="h5" gutterBottom>
               Your Profile
@@ -992,7 +992,7 @@ const FindTeamPage = () => {
         </Grid>
 
         {/* Right content area - Potential teammates */}
-        <Grid item xs={12} md={8}>
+        <Grid size={{ xs: 12, md: 8 }}>
           <StyledPaper>
             <Tabs
               value={selectedTab}
@@ -1077,7 +1077,7 @@ const FindTeamPage = () => {
                 {currentList.map((teammate) => {
                   const matchScore = calculateMatchScore(teammate);
                   return (
-                    <Grid item xs={12} sm={6} key={teammate.user_id}>
+                    <Grid size={{ xs: 12, sm: 6 }} key={teammate.user_id}>
                       <ProfileCard>
                         <CardContent sx={{ position: 'relative', flexGrow: 1 }}>
                           <MatchScore score={matchScore}>

--- a/src/pages/hack/[event_id]/mentor-checkin.js
+++ b/src/pages/hack/[event_id]/mentor-checkin.js
@@ -862,7 +862,7 @@ const MentorCheckinPage = () => {
 
         <Paper elevation={3} sx={{ p: 4, mb: 4 }}>
           <Grid container spacing={4}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h5" component="h3" gutterBottom>
                 Mentor Status
               </Typography>
@@ -936,7 +936,7 @@ const MentorCheckinPage = () => {
               {renderMentorProfile(mentorData)}
             </Grid>
 
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h5" component="h3" gutterBottom>
                 Your Availability
               </Typography>
@@ -1150,7 +1150,7 @@ const MentorCheckinPage = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Box>
                 <Typography variant="h6" gutterBottom>
                   Do:
@@ -1167,7 +1167,7 @@ const MentorCheckinPage = () => {
               </Box>
             </Grid>
 
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Box>
                 <Typography variant="h6" gutterBottom>
                   Don't:
@@ -1193,7 +1193,7 @@ const MentorCheckinPage = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Paper elevation={1} sx={{ p: 3, bgcolor: 'primary.light', color: 'primary.contrastText' }}>
                 <Typography variant="h6" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   <SlackIcon />
@@ -1209,7 +1209,7 @@ const MentorCheckinPage = () => {
               </Paper>
             </Grid>
 
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Paper elevation={1} sx={{ p: 3, bgcolor: 'secondary.light', color: 'secondary.contrastText' }}>
                 <Typography variant="h6" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   <InfoIcon />

--- a/src/pages/hack/[event_id]/sponsor-application.js
+++ b/src/pages/hack/[event_id]/sponsor-application.js
@@ -835,7 +835,7 @@ const SponsorApplicationComponent = () => {
         </Typography>
 
         <Grid container spacing={3}>
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <TextField
               label="Email Address"
               name="email"
@@ -848,7 +848,7 @@ const SponsorApplicationComponent = () => {
             />
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <TextField
               label="Phone Number (Optional)"
               name="phoneNumber"
@@ -871,7 +871,7 @@ const SponsorApplicationComponent = () => {
             />
           </Grid>
 
-          <Grid item xs={12}>
+          <Grid size={{ xs: 12 }}>
             <TextField
               label="Company Name"
               name="company"
@@ -883,7 +883,7 @@ const SponsorApplicationComponent = () => {
             />
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <TextField
               label="Your Name"
               name="name"
@@ -895,7 +895,7 @@ const SponsorApplicationComponent = () => {
             />
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <TextField
               label="Your Title"
               name="title"
@@ -906,7 +906,7 @@ const SponsorApplicationComponent = () => {
             />
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <FormControl fullWidth>
               <InputLabel>Preferred Contact Method</InputLabel>
               <Select
@@ -921,7 +921,7 @@ const SponsorApplicationComponent = () => {
             </FormControl>
           </Grid>
 
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <TextField
               label="How did you hear about us?"
               name="howHeard"
@@ -932,7 +932,7 @@ const SponsorApplicationComponent = () => {
             />
           </Grid>
 
-          <Grid item xs={12}>
+          <Grid size={{ xs: 12 }}>
             <Box sx={{ mt: 2, mb: 1 }}>
               <Typography variant="subtitle1" gutterBottom>
                 Company Logo (Optional)
@@ -1017,7 +1017,7 @@ const SponsorApplicationComponent = () => {
             const isCustom = tier.name === "Custom Sponsorship";
 
             return (
-              <Grid item xs={12} md={isCustom ? 12 : 6} key={tier.name}>
+              <Grid size={{ xs: 12, md: isCustom ? 12 : 6 }} key={tier.name}>
                 <Card
                   raised={isSelected}
                   sx={{
@@ -1323,7 +1323,7 @@ const SponsorApplicationComponent = () => {
         </Box>
 
         <Grid container spacing={3}>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
               label="How many people do you expect to volunteer?"
               name="volunteerCount"
@@ -1347,7 +1347,7 @@ const SponsorApplicationComponent = () => {
             />
           </Grid>
 
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
               label="How many hours total do you expect to volunteer?"
               name="volunteerHours"
@@ -1394,56 +1394,56 @@ const SponsorApplicationComponent = () => {
           </Typography>
 
           <Grid container spacing={2}>
-            <Grid item xs={4}>
+            <Grid size={{ xs: 4 }}>
               <Typography variant="body2" color="text.secondary">
                 Company:
               </Typography>
             </Grid>
-            <Grid item xs={8}>
+            <Grid size={{ xs: 8 }}>
               <Typography variant="body2">
                 {formData.company || "Not provided"}
               </Typography>
             </Grid>
 
-            <Grid item xs={4}>
+            <Grid size={{ xs: 4 }}>
               <Typography variant="body2" color="text.secondary">
                 Contact:
               </Typography>
             </Grid>
-            <Grid item xs={8}>
+            <Grid size={{ xs: 8 }}>
               <Typography variant="body2">
                 {formData.name || "Not provided"}
               </Typography>
             </Grid>
 
-            <Grid item xs={4}>
+            <Grid size={{ xs: 4 }}>
               <Typography variant="body2" color="text.secondary">
                 Title:
               </Typography>
             </Grid>
-            <Grid item xs={8}>
+            <Grid size={{ xs: 8 }}>
               <Typography variant="body2">
                 {formData.title || "Not provided"}
               </Typography>
             </Grid>
 
-            <Grid item xs={4}>
+            <Grid size={{ xs: 4 }}>
               <Typography variant="body2" color="text.secondary">
                 Email:
               </Typography>
             </Grid>
-            <Grid item xs={8}>
+            <Grid size={{ xs: 8 }}>
               <Typography variant="body2">
                 {formData.email || "Not provided"}
               </Typography>
             </Grid>
 
-            <Grid item xs={4}>
+            <Grid size={{ xs: 4 }}>
               <Typography variant="body2" color="text.secondary">
                 Phone:
               </Typography>
             </Grid>
-            <Grid item xs={8}>
+            <Grid size={{ xs: 8 }}>
               <Typography variant="body2">
                 {formData.phoneNumber || "Not provided"}
               </Typography>
@@ -1461,12 +1461,12 @@ const SponsorApplicationComponent = () => {
           </Typography>
 
           <Grid container spacing={2}>
-            <Grid item xs={4}>
+            <Grid size={{ xs: 4 }}>
               <Typography variant="body2" color="text.secondary">
                 Sponsorship Tier:
               </Typography>
             </Grid>
-            <Grid item xs={8}>
+            <Grid size={{ xs: 8 }}>
               <Typography variant="body2">
                 {formData.sponsorshipTier || "Not selected"}
               </Typography>
@@ -1474,12 +1474,12 @@ const SponsorApplicationComponent = () => {
 
             {formData.sponsorshipTier === "Custom Sponsorship" && (
               <>
-                <Grid item xs={4}>
+                <Grid size={{ xs: 4 }}>
                   <Typography variant="body2" color="text.secondary">
                     Custom Details:
                   </Typography>
                 </Grid>
-                <Grid item xs={8}>
+                <Grid size={{ xs: 8 }}>
                   <Typography variant="body2">
                     {formData.customSponsorship || "Not provided"}
                   </Typography>
@@ -1489,12 +1489,12 @@ const SponsorApplicationComponent = () => {
 
             {formData.sponsorshipDetails && (
               <>
-                <Grid item xs={4}>
+                <Grid size={{ xs: 4 }}>
                   <Typography variant="body2" color="text.secondary">
                     Additional Details:
                   </Typography>
                 </Grid>
-                <Grid item xs={8}>
+                <Grid size={{ xs: 8 }}>
                   <Typography variant="body2">
                     {formData.sponsorshipDetails}
                   </Typography>
@@ -1502,12 +1502,12 @@ const SponsorApplicationComponent = () => {
               </>
             )}
 
-            <Grid item xs={4}>
+            <Grid size={{ xs: 4 }}>
               <Typography variant="body2" color="text.secondary">
                 Logo Usage:
               </Typography>
             </Grid>
-            <Grid item xs={8}>
+            <Grid size={{ xs: 8 }}>
               <Typography variant="body2">
                 {formData.useLogo || "Not specified"}
               </Typography>
@@ -1530,12 +1530,12 @@ const SponsorApplicationComponent = () => {
             <Grid container spacing={2}>
               {formData.volunteerRoles?.length > 0 && (
                 <>
-                  <Grid item xs={4}>
+                  <Grid size={{ xs: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       Volunteer Roles:
                     </Typography>
                   </Grid>
-                  <Grid item xs={8}>
+                  <Grid size={{ xs: 8 }}>
                     <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
                       {formData.volunteerRoles.map((role) => (
                         <Chip
@@ -1558,12 +1558,12 @@ const SponsorApplicationComponent = () => {
 
               {formData.volunteerCount && (
                 <>
-                  <Grid item xs={4}>
+                  <Grid size={{ xs: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       Volunteer Count:
                     </Typography>
                   </Grid>
-                  <Grid item xs={8}>
+                  <Grid size={{ xs: 8 }}>
                     <Typography variant="body2">
                       {formData.volunteerCount} people
                     </Typography>
@@ -1573,12 +1573,12 @@ const SponsorApplicationComponent = () => {
 
               {formData.volunteerHours && (
                 <>
-                  <Grid item xs={4}>
+                  <Grid size={{ xs: 4 }}>
                     <Typography variant="body2" color="text.secondary">
                       Volunteer Hours:
                     </Typography>
                   </Grid>
-                  <Grid item xs={8}>
+                  <Grid size={{ xs: 8 }}>
                     <Typography variant="body2">
                       {formData.volunteerHours} hours
                     </Typography>

--- a/src/pages/hack/[event_id]/upload.js
+++ b/src/pages/hack/[event_id]/upload.js
@@ -137,7 +137,7 @@ export default function EventUpload() {
 
         <Grid container spacing={2}>
           {files.map((file) => (
-            <Grid item xs={12} sm={6} md={4} key={file.name}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} key={file.name}>
               <Paper elevation={2} sx={{ p: 2 }}>
                 <Typography variant="body2" noWrap>
                   {file.name}

--- a/src/pages/hack/flier.js
+++ b/src/pages/hack/flier.js
@@ -71,7 +71,7 @@ const FlierComponent = () => {
           </Typography>
 
           <Grid container spacing={2} sx={{ mb: 2 }}>
-            <Grid item xs={6}>
+            <Grid size={{ xs: 6 }}>
               <Typography variant="h5" sx={{ fontSize: "19px" }}>
                 📅 Date: October 12-13, 2024
               </Typography>
@@ -79,7 +79,7 @@ const FlierComponent = () => {
                 📍 Location: Tempe, Arizona
               </Typography>
             </Grid>
-            <Grid item xs={6}>
+            <Grid size={{ xs: 6 }}>
               <Typography variant="h5" sx={{ fontSize: "19px" }}>
                 💻 48-hour hackathon
               </Typography>

--- a/src/pages/hack/index.js
+++ b/src/pages/hack/index.js
@@ -80,7 +80,7 @@ const HackathonIndex = () => {
         </Typography>
 
         <Grid container spacing={2} sx={{ maxWidth: '600px', mx: 'auto', mb: 3 }}>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="contained"
               color="primary"
@@ -96,7 +96,7 @@ const HackathonIndex = () => {
               View Upcoming Events
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="outlined"
               color="primary"
@@ -115,12 +115,12 @@ const HackathonIndex = () => {
         {/* Why Join Section with Image - Moved to top for better UX flow */}
         <Paper sx={{ p: 4, mb: 5, bgcolor: 'grey.50' }}>
           <Grid container spacing={4} sx={{ alignItems: 'center' }}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="h3" component="h2" gutterBottom>
                 Why Join Opportunity Hack?
               </Typography>
               <Grid container spacing={2}>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
                     <Code color="primary" sx={{ mr: 2, mt: 0.5 }} />
                     <Box>
@@ -133,7 +133,7 @@ const HackathonIndex = () => {
                     </Box>
                   </Box>
                 </Grid>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
                     <Group color="primary" sx={{ mr: 2, mt: 0.5 }} />
                     <Box>
@@ -146,7 +146,7 @@ const HackathonIndex = () => {
                     </Box>
                   </Box>
                 </Grid>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
                     <EmojiEvents color="primary" sx={{ mr: 2, mt: 0.5 }} />
                     <Box>
@@ -159,7 +159,7 @@ const HackathonIndex = () => {
                     </Box>
                   </Box>
                 </Grid>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
                     <EventAvailable color="primary" sx={{ mr: 2, mt: 0.5 }} />
                     <Box>
@@ -174,7 +174,7 @@ const HackathonIndex = () => {
                 </Grid>
               </Grid>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
                 <Box sx={{ textAlign: 'center', maxWidth: '100%' }}>
                   <Image
@@ -224,7 +224,7 @@ const HackathonIndex = () => {
         </Typography>
         
         <Grid container spacing={3} sx={{ maxWidth: '900px', mx: 'auto' }}>
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card sx={{ height: '100%', textAlign: 'center', '&:hover': { boxShadow: 3 }, transition: 'box-shadow 0.3s' }}>
               <CardContent>
                 <Policy color="primary" sx={{ fontSize: 40, mb: 2 }} />
@@ -247,7 +247,7 @@ const HackathonIndex = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card sx={{ height: '100%', textAlign: 'center', '&:hover': { boxShadow: 3 }, transition: 'box-shadow 0.3s' }}>
               <CardContent>
                 <Gavel color="action" sx={{ fontSize: 40, mb: 2 }} />
@@ -270,7 +270,7 @@ const HackathonIndex = () => {
             </Card>
           </Grid>
 
-          <Grid item xs={12} md={4}>
+          <Grid size={{ xs: 12, md: 4 }}>
             <Card sx={{ height: '100%', textAlign: 'center', '&:hover': { boxShadow: 3 }, transition: 'box-shadow 0.3s' }}>
               <CardContent>
                 <CameraAlt color="action" sx={{ fontSize: 40, mb: 2 }} />

--- a/src/pages/hack/request/index.js
+++ b/src/pages/hack/request/index.js
@@ -69,7 +69,7 @@ export default function CreateHackathon() {
       <Container maxWidth="lg">
         <Box mt={8} mb={6}>
           <Grid container spacing={4}>
-            <Grid item xs={12} md={7}>
+            <Grid size={{ xs: 12, md: 7 }}>
               <Typography 
                 variant="h2" 
                 component="h1" 
@@ -158,7 +158,7 @@ export default function CreateHackathon() {
                 </Paper>
               </Box>
             </Grid>
-            <Grid item xs={12} md={5}>
+            <Grid size={{ xs: 12, md: 5 }}>
               <Paper 
                 elevation={3}
                 sx={{ 
@@ -228,7 +228,7 @@ export default function CreateHackathon() {
           </Typography>
           
           <Grid container spacing={4}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Paper 
                 elevation={1}
                 sx={{ 
@@ -252,7 +252,7 @@ export default function CreateHackathon() {
               </Paper>
             </Grid>
             
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Paper 
                 elevation={1}
                 sx={{ 
@@ -276,7 +276,7 @@ export default function CreateHackathon() {
               </Paper>
             </Grid>
             
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Paper 
                 elevation={1}
                 sx={{ 

--- a/src/pages/hackathon-judge-opportunities.js
+++ b/src/pages/hackathon-judge-opportunities.js
@@ -228,7 +228,7 @@ const HackathonJudgeOpportunities = () => {
           spacing={2}
           sx={{ maxWidth: "600px", mx: "auto", mb: 4 }}
         >
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="contained"
               color="primary"
@@ -247,7 +247,7 @@ const HackathonJudgeOpportunities = () => {
               View Judge Opportunities
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="outlined"
               color="primary"
@@ -319,7 +319,7 @@ const HackathonJudgeOpportunities = () => {
           ) : upcomingEvents && upcomingEvents.length > 0 ? (
             <Grid container spacing={3}>
               {upcomingEvents.map((event) => (
-                <Grid item xs={12} md={6} key={event.event_id}>
+                <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
                   <Card
                     sx={{
                       bgcolor: "white",
@@ -436,7 +436,7 @@ const HackathonJudgeOpportunities = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <BalanceRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -448,7 +448,7 @@ const HackathonJudgeOpportunities = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <TrendingUpRounded
                   color="secondary"
@@ -463,7 +463,7 @@ const HackathonJudgeOpportunities = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <GroupsRounded color="success" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -499,7 +499,7 @@ const HackathonJudgeOpportunities = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <MovieRounded color="primary" sx={{ mr: 2 }} />
@@ -516,7 +516,7 @@ const HackathonJudgeOpportunities = () => {
                 />
               </Card>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <LiveTvRounded color="secondary" sx={{ mr: 2 }} />

--- a/src/pages/hackathon-judge.js
+++ b/src/pages/hackathon-judge.js
@@ -229,7 +229,7 @@ const HackathonJudge = () => {
           spacing={2}
           sx={{ maxWidth: "600px", mx: "auto", mb: 4 }}
         >
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="contained"
               color="primary"
@@ -248,7 +248,7 @@ const HackathonJudge = () => {
               Apply as Judge
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="outlined"
               color="primary"
@@ -320,7 +320,7 @@ const HackathonJudge = () => {
           ) : upcomingEvents && upcomingEvents.length > 0 ? (
             <Grid container spacing={3}>
               {upcomingEvents.map((event) => (
-                <Grid item xs={12} md={6} key={event.event_id}>
+                <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
                   <Card
                     sx={{
                       bgcolor: "white",
@@ -437,7 +437,7 @@ const HackathonJudge = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <BalanceRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -449,7 +449,7 @@ const HackathonJudge = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <TrendingUpRounded
                   color="secondary"
@@ -464,7 +464,7 @@ const HackathonJudge = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <GroupsRounded color="success" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -500,7 +500,7 @@ const HackathonJudge = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <MovieRounded color="primary" sx={{ mr: 2 }} />
@@ -517,7 +517,7 @@ const HackathonJudge = () => {
                 />
               </Card>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <LiveTvRounded color="secondary" sx={{ mr: 2 }} />

--- a/src/pages/hackathon-judging-opportunities.js
+++ b/src/pages/hackathon-judging-opportunities.js
@@ -228,7 +228,7 @@ const HackathonJudgingOpportunities = () => {
           spacing={2}
           sx={{ maxWidth: "600px", mx: "auto", mb: 4 }}
         >
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="contained"
               color="primary"
@@ -247,7 +247,7 @@ const HackathonJudgingOpportunities = () => {
               Find Judging Roles
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="outlined"
               color="primary"
@@ -319,7 +319,7 @@ const HackathonJudgingOpportunities = () => {
           ) : upcomingEvents && upcomingEvents.length > 0 ? (
             <Grid container spacing={3}>
               {upcomingEvents.map((event) => (
-                <Grid item xs={12} md={6} key={event.event_id}>
+                <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
                   <Card
                     sx={{
                       bgcolor: "white",
@@ -436,7 +436,7 @@ const HackathonJudgingOpportunities = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <BalanceRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -448,7 +448,7 @@ const HackathonJudgingOpportunities = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <TrendingUpRounded
                   color="secondary"
@@ -463,7 +463,7 @@ const HackathonJudgingOpportunities = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <GroupsRounded color="success" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -499,7 +499,7 @@ const HackathonJudgingOpportunities = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <MovieRounded color="primary" sx={{ mr: 2 }} />
@@ -516,7 +516,7 @@ const HackathonJudgingOpportunities = () => {
                 />
               </Card>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <LiveTvRounded color="secondary" sx={{ mr: 2 }} />

--- a/src/pages/hackathon-judging.js
+++ b/src/pages/hackathon-judging.js
@@ -229,7 +229,7 @@ const HackathonJudging = () => {
           spacing={2}
           sx={{ maxWidth: "600px", mx: "auto", mb: 4 }}
         >
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="contained"
               color="primary"
@@ -248,7 +248,7 @@ const HackathonJudging = () => {
               Start Hackathon Judging
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="outlined"
               color="primary"
@@ -319,7 +319,7 @@ const HackathonJudging = () => {
           ) : upcomingEvents && upcomingEvents.length > 0 ? (
             <Grid container spacing={3}>
               {upcomingEvents.map((event) => (
-                <Grid item xs={12} md={6} key={event.event_id}>
+                <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
                   <Card
                     sx={{
                       bgcolor: "white",
@@ -436,7 +436,7 @@ const HackathonJudging = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <BalanceRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -448,7 +448,7 @@ const HackathonJudging = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <TrendingUpRounded
                   color="secondary"
@@ -463,7 +463,7 @@ const HackathonJudging = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <GroupsRounded color="success" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -499,7 +499,7 @@ const HackathonJudging = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <MovieRounded color="primary" sx={{ mr: 2 }} />
@@ -516,7 +516,7 @@ const HackathonJudging = () => {
                 />
               </Card>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <LiveTvRounded color="secondary" sx={{ mr: 2 }} />

--- a/src/pages/judge-a-hackathon.js
+++ b/src/pages/judge-a-hackathon.js
@@ -230,7 +230,7 @@ const JudgeAHackathon = () => {
           spacing={2}
           sx={{ maxWidth: "600px", mx: "auto", mb: 4 }}
         >
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="contained"
               color="primary"
@@ -249,7 +249,7 @@ const JudgeAHackathon = () => {
               Judge a Hackathon
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="outlined"
               color="primary"
@@ -321,7 +321,7 @@ const JudgeAHackathon = () => {
           ) : upcomingEvents && upcomingEvents.length > 0 ? (
             <Grid container spacing={3}>
               {upcomingEvents.map((event) => (
-                <Grid item xs={12} md={6} key={event.event_id}>
+                <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
                   <Card
                     sx={{
                       bgcolor: "white",
@@ -438,7 +438,7 @@ const JudgeAHackathon = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <BalanceRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -450,7 +450,7 @@ const JudgeAHackathon = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <TrendingUpRounded
                   color="secondary"
@@ -465,7 +465,7 @@ const JudgeAHackathon = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <GroupsRounded color="success" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -501,7 +501,7 @@ const JudgeAHackathon = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <MovieRounded color="primary" sx={{ mr: 2 }} />
@@ -518,7 +518,7 @@ const JudgeAHackathon = () => {
                 />
               </Card>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <LiveTvRounded color="secondary" sx={{ mr: 2 }} />

--- a/src/pages/judge-hackathon.js
+++ b/src/pages/judge-hackathon.js
@@ -229,7 +229,7 @@ const JudgeHackathon = () => {
           spacing={2}
           sx={{ maxWidth: "600px", mx: "auto", mb: 4 }}
         >
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="contained"
               color="primary"
@@ -248,7 +248,7 @@ const JudgeHackathon = () => {
               Judge Hackathon Events
             </Button>
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Button
               variant="outlined"
               color="primary"
@@ -320,7 +320,7 @@ const JudgeHackathon = () => {
           ) : upcomingEvents && upcomingEvents.length > 0 ? (
             <Grid container spacing={3}>
               {upcomingEvents.map((event) => (
-                <Grid item xs={12} md={6} key={event.event_id}>
+                <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
                   <Card
                     sx={{
                       bgcolor: "white",
@@ -437,7 +437,7 @@ const JudgeHackathon = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <BalanceRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -449,7 +449,7 @@ const JudgeHackathon = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <TrendingUpRounded
                   color="secondary"
@@ -464,7 +464,7 @@ const JudgeHackathon = () => {
                 </Typography>
               </Card>
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid size={{ xs: 12, md: 4 }}>
               <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
                 <GroupsRounded color="success" sx={{ fontSize: 48, mb: 2 }} />
                 <Typography variant="h5" gutterBottom>
@@ -500,7 +500,7 @@ const JudgeHackathon = () => {
           </Typography>
 
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <MovieRounded color="primary" sx={{ mr: 2 }} />
@@ -517,7 +517,7 @@ const JudgeHackathon = () => {
                 />
               </Card>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ height: "100%", p: 3 }}>
                 <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                   <LiveTvRounded color="secondary" sx={{ mr: 2 }} />

--- a/src/pages/judge/[event_id].js
+++ b/src/pages/judge/[event_id].js
@@ -102,7 +102,7 @@ const HackathonJudgePage = withRequiredAuthInfo(({ userClass }) => {
   };
 
   const TeamCard = ({ team, round, showDemoTime = false }) => (
-    <Grid item xs={12} md={6} key={`${round}_${team.id}`}>
+    <Grid size={{ xs: 12, md: 6 }} key={`${round}_${team.id}`}>
       <Card sx={{ 
         height: '100%',
         border: team.judged ? '2px solid' : '1px solid',
@@ -403,7 +403,7 @@ const HackathonJudgePage = withRequiredAuthInfo(({ userClass }) => {
           {/* Summary Stats */}
           <Paper elevation={2} sx={{ p: 3, mb: 4 }}>
             <Grid container spacing={3}>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <Box sx={{ textAlign: 'center' }}>
                   <Typography variant="h3" color="primary">
                     {round1Teams.length}
@@ -413,7 +413,7 @@ const HackathonJudgePage = withRequiredAuthInfo(({ userClass }) => {
                   </Typography>
                 </Box>
               </Grid>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <Box sx={{ textAlign: 'center' }}>
                   <Typography variant="h3" color="secondary">
                     {round2Teams.length}
@@ -423,7 +423,7 @@ const HackathonJudgePage = withRequiredAuthInfo(({ userClass }) => {
                   </Typography>
                 </Box>
               </Grid>
-              <Grid item xs={12} sm={4}>
+              <Grid size={{ xs: 12, sm: 4 }}>
                 <Box sx={{ textAlign: 'center' }}>
                   <Typography variant="h3" color="success.main">
                     {round1Completed + round2Completed}

--- a/src/pages/judge/[event_id]/team/[team_id].js
+++ b/src/pages/judge/[event_id]/team/[team_id].js
@@ -494,7 +494,7 @@ const TeamScoringPage = withRequiredAuthInfo(({ userClass }) => {
 
           <Grid container spacing={3}>
             {/* Team Information Panel Skeleton */}
-            <Grid item xs={12} lg={4}>
+            <Grid size={{ xs: 12, lg: 4 }}>
               <Paper elevation={2} sx={{ p: 3 }}>
                 <Skeleton variant="text" width="70%" height={32} sx={{ mb: 2 }} />
                 
@@ -557,7 +557,7 @@ const TeamScoringPage = withRequiredAuthInfo(({ userClass }) => {
             </Grid>
 
             {/* Scoring Panel Skeleton */}
-            <Grid item xs={12} lg={8}>
+            <Grid size={{ xs: 12, lg: 8 }}>
               <Skeleton variant="text" width="40%" height={40} sx={{ mb: 1 }} />
               <Skeleton variant="text" width="80%" height={20} sx={{ mb: 3 }} />
 
@@ -664,7 +664,7 @@ const TeamScoringPage = withRequiredAuthInfo(({ userClass }) => {
 
           <Grid container spacing={3}>
             {/* Team Information Panel */}
-            <Grid item xs={12} lg={4}>
+            <Grid size={{ xs: 12, lg: 4 }}>
               <Paper elevation={2} sx={{ p: 3, position: 'sticky', top: 20 }}>
                 <Typography variant="h6" gutterBottom>
                   Team Information
@@ -906,7 +906,7 @@ const TeamScoringPage = withRequiredAuthInfo(({ userClass }) => {
             </Grid>
 
             {/* Scoring Panel */}
-            <Grid item xs={12} lg={8}>
+            <Grid size={{ xs: 12, lg: 8 }}>
               <Typography variant="h5" gutterBottom>
                 Scoring Criteria
               </Typography>

--- a/src/pages/judge/index.js
+++ b/src/pages/judge/index.js
@@ -140,7 +140,7 @@ const JudgeDashboard = withRequiredAuthInfo(({ userClass }) => {
                 );
                 
                 return (
-                  <Grid item xs={12} md={6} key={hackathon.event_id}>
+                  <Grid size={{ xs: 12, md: 6 }} key={hackathon.event_id}>
                     <Card sx={{ height: '100%', position: 'relative' }}>
                       <CardContent sx={{ p: 3 }}>
                         {/* Hackathon Header */}

--- a/src/pages/judge/overview.js
+++ b/src/pages/judge/overview.js
@@ -68,7 +68,7 @@ const SectionHeader = memo(({ variant = "h3", component = "h2", children, sectio
 SectionHeader.displayName = 'SectionHeader';
 
 const VideoHighlightCard = memo(({ icon: Icon, title, description, chipLabel, chipColor }) => (
-  <Grid item xs={12} md={4}>
+  <Grid size={{ xs: 12, md: 4 }}>
     <Card sx={{ 
       height: "100%", 
       display: 'flex',
@@ -103,7 +103,7 @@ const VideoHighlightCard = memo(({ icon: Icon, title, description, chipLabel, ch
 VideoHighlightCard.displayName = 'VideoHighlightCard';
 
 const ResourceButton = memo(({ href, icon: Icon, label, onClick, trackingLabel }) => (
-  <Grid item xs={12} sm={6} md={3}>
+  <Grid size={{ xs: 12, sm: 6, md: 3 }}>
     <Button
       variant="outlined"
       fullWidth
@@ -507,7 +507,7 @@ const JudgeDashboardOverview = () => {
             Quick Reference: Judging Process
           </Typography>
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Box>
                 <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                   <EventRounded sx={{ mr: 1, color: 'primary.main' }} />
@@ -518,7 +518,7 @@ const JudgeDashboardOverview = () => {
                 </Typography>
               </Box>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Box>
                 <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                   <GroupsRounded sx={{ mr: 1, color: 'secondary.main' }} />

--- a/src/pages/myfeedback.js
+++ b/src/pages/myfeedback.js
@@ -38,7 +38,7 @@ const FeedbackCategory = ({ title, data, tooltips }) => (
     <AccordionDetails>
       <Grid container spacing={2}>
         {Object.entries(data).map(([key, value]) => (
-          <Grid item xs={12} sm={6} key={key}>
+          <Grid size={{ xs: 12, sm: 6 }} key={key}>
             <Box display="flex" alignItems="center">
               <Typography variant="subtitle1">{key}</Typography>
               <Tooltip

--- a/src/pages/nonprofit-grants/index.js
+++ b/src/pages/nonprofit-grants/index.js
@@ -102,7 +102,7 @@ const NonprofitGrants = () => {
                   </Typography>
                   
                   <Grid container spacing={3} sx={{ mt: 1 }}>
-                    <Grid item xs={12} sm={6} md={3}>
+                    <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                       <Card elevation={0} sx={{ bgcolor: 'primary.light', p: 2, height: '100%' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                           <AttachMoneyIcon color="primary" sx={{ mr: 1 }} />
@@ -112,7 +112,7 @@ const NonprofitGrants = () => {
                       </Card>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={3}>
+                    <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                       <Card elevation={0} sx={{ bgcolor: 'success.light', p: 2, height: '100%' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                           <MonetizationOnIcon color="success" sx={{ mr: 1 }} />
@@ -122,7 +122,7 @@ const NonprofitGrants = () => {
                       </Card>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={3}>
+                    <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                       <Card elevation={0} sx={{ bgcolor: 'info.light', p: 2, height: '100%' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                           <VolunteerActivismIcon color="info" sx={{ mr: 1 }} />
@@ -132,7 +132,7 @@ const NonprofitGrants = () => {
                       </Card>
                     </Grid>
                     
-                    <Grid item xs={12} sm={6} md={3}>
+                    <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                       <Card elevation={0} sx={{ bgcolor: 'warning.light', p: 2, height: '100%' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                           <EventAvailableIcon color="warning" sx={{ mr: 1 }} />
@@ -152,7 +152,7 @@ const NonprofitGrants = () => {
                   </Typography>
                   <Grid container spacing={2} sx={{ mt: 1 }}>
                     {topNonprofitSectors.map(({ sector, count }) => (
-                      <Grid item xs={6} md={2.4} key={sector}>
+                      <Grid size={{ xs: 6, md: 2.4 }} key={sector}>
                         <Box sx={{ textAlign: 'center', p: 1 }}>
                           <Typography variant="h4" color="primary">{count}</Typography>
                           <Typography variant="body2" sx={{ textTransform: 'capitalize' }}>{sector}</Typography>
@@ -177,7 +177,7 @@ const NonprofitGrants = () => {
           </Box>
 
           <Grid container spacing={3} sx={{ mb: 4 }}>
-            <Grid item xs={12}>
+            <Grid size={{ xs: 12 }}>
               <TextField
                 fullWidth
                 variant="outlined"
@@ -201,7 +201,7 @@ const NonprofitGrants = () => {
 
           <Grid container spacing={3}>
             {filteredGrants.map((grant, index) => (
-              <Grid item xs={12} key={index}>
+              <Grid size={{ xs: 12 }} key={index}>
                 <Card sx={{ 
                   height: '100%', 
                   display: 'flex', 
@@ -231,7 +231,7 @@ const NonprofitGrants = () => {
                     
                     <Grid container spacing={2}>
                       {grant.funding_amount && (
-                        <Grid item xs={12} sm={4}>
+                        <Grid size={{ xs: 12, sm: 4 }}>
                           <Box sx={{ display: 'flex', alignItems: 'center' }}>
                             <MonetizationOnIcon color="primary" sx={{ mr: 1 }} />
                             <Typography variant="body2">
@@ -243,7 +243,7 @@ const NonprofitGrants = () => {
                       )}
                       
                       {grant.deadline && (
-                        <Grid item xs={12} sm={4}>
+                        <Grid size={{ xs: 12, sm: 4 }}>
                           <Box sx={{ display: 'flex', alignItems: 'center' }}>
                             <CalendarTodayIcon color="primary" sx={{ mr: 1 }} />
                             <Typography variant="body2">
@@ -254,7 +254,7 @@ const NonprofitGrants = () => {
                       )}
                       
                       {grant.application_url && (
-                        <Grid item xs={12} sm={4}>
+                        <Grid size={{ xs: 12, sm: 4 }}>
                           <Button 
                             variant="outlined" 
                             color="primary" 

--- a/src/pages/nonprofits/apply/index.js
+++ b/src/pages/nonprofits/apply/index.js
@@ -578,7 +578,7 @@ export default function Apply({ title, description, openGraphData }) {
               { number: '$500K+', label: 'Value Delivered', icon: <MonetizationOnIcon fontSize="large" /> },
               { number: '10+', label: 'Years of Impact', icon: <TrendingUpIcon fontSize="large" /> },
             ].map((stat, index) => (
-              <Grid item xs={6} md={3} key={index}>
+              <Grid size={{ xs: 6, md: 3 }} key={index}>
                 <StatsCard elevation={2}>
                   <Box sx={{ color: 'primary.main', mb: 1 }}>{stat.icon}</Box>
                   <Typography variant="h3" component="div" sx={{ fontWeight: 'bold', color: 'primary.main' }}>
@@ -640,7 +640,7 @@ export default function Apply({ title, description, openGraphData }) {
                 color: '#fa709a'
               },
             ].map((benefit, index) => (
-              <Grid item xs={12} md={4} key={index}>
+              <Grid size={{ xs: 12, md: 4 }} key={index}>
                 <BenefitCard elevation={3}>
                   <CardContent sx={{ flexGrow: 1 }}>
                     <Box sx={{ color: benefit.color, mb: 2 }}>
@@ -665,7 +665,7 @@ export default function Apply({ title, description, openGraphData }) {
             Real Nonprofits, Real Results
           </Typography>
           <Grid container spacing={3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <TestimonialCard elevation={0}>
                 <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
                   <FormatQuoteIcon sx={{ fontSize: 40, color: 'primary.main', mr: 2 }} />
@@ -688,7 +688,7 @@ export default function Apply({ title, description, openGraphData }) {
                 </Box>
               </TestimonialCard>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <TestimonialCard elevation={0}>
                 <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
                   <FormatQuoteIcon sx={{ fontSize: 40, color: 'primary.main', mr: 2 }} />
@@ -767,7 +767,7 @@ export default function Apply({ title, description, openGraphData }) {
                 icon: <TrendingUpIcon sx={{ fontSize: 40 }} />
               },
             ].map((process, index) => (
-              <Grid item xs={12} sm={6} md={3} key={index}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }} key={index}>
                 <ProcessStep elevation={2}>
                   <Box sx={{ color: 'primary.main', mb: 2 }}>
                     {process.icon}
@@ -855,7 +855,7 @@ export default function Apply({ title, description, openGraphData }) {
               { icon: <SecurityIcon />, text: 'Secure & Confidential' },
               { icon: <StarIcon />, text: '10+ Years of Service' },
             ].map((trust, index) => (
-              <Grid item key={index}>
+              <Grid key={index}>
                 <Chip
                   icon={trust.icon}
                   label={trust.text}
@@ -911,7 +911,7 @@ export default function Apply({ title, description, openGraphData }) {
               )}
 
               <Grid container spacing={3}>
-                <Grid item xs={12} md={6}>
+                <Grid size={{ xs: 12, md: 6 }}>
                   <TextField
                     fullWidth
                     label="Your Name *"
@@ -925,7 +925,7 @@ export default function Apply({ title, description, openGraphData }) {
                     onFocus={() => trackFormField('name', formData.name, 'focus')}
                   />
                 </Grid>
-                <Grid item xs={12} md={6}>
+                <Grid size={{ xs: 12, md: 6 }}>
                   <TextField
                     fullWidth
                     label="Email Address *"
@@ -940,7 +940,7 @@ export default function Apply({ title, description, openGraphData }) {
                     onFocus={() => trackFormField('email', formData.email, 'focus')}
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <TextField
                     fullWidth
                     label="Organization Name"
@@ -953,7 +953,7 @@ export default function Apply({ title, description, openGraphData }) {
                     onFocus={() => trackFormField('organization', formData.organization, 'focus')}
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <TextField
                     fullWidth
                     label="Your Project Idea or Problem to Solve *"
@@ -972,7 +972,7 @@ export default function Apply({ title, description, openGraphData }) {
                     onFocus={() => trackFormField('idea', formData.idea, 'focus')}
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <FormControlLabel
                     control={
                       <Checkbox
@@ -985,7 +985,7 @@ export default function Apply({ title, description, openGraphData }) {
                     label="I represent a registered 501(c)(3) nonprofit organization (Optional - we accept all social good projects!)"
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <CTAButton
                     variant="contained"
                     color="primary"

--- a/src/pages/signup/index.js
+++ b/src/pages/signup/index.js
@@ -105,7 +105,7 @@ export default function Signup() {
       </Head>
       <StyledBox>
         <Grid container mt={10} spacing={4} alignItems="center">
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <StyledHeading variant="h2">Join Opportunity Hack</StyledHeading>
             <StyledSubheading variant="h2">
               Connect, Collaborate, and Code for Good
@@ -129,7 +129,7 @@ export default function Signup() {
               </Typography>
             )}
           </Grid>
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <Box
               sx={{
                 borderRadius: theme.shape.borderRadius,

--- a/src/pages/sponsor/index.js
+++ b/src/pages/sponsor/index.js
@@ -177,12 +177,12 @@ export default function SponsorIndexList() {
       <Grid container spacing={isMobile ? 2 : 3}>
         {levelSponsors.length > 0 ? (
           levelSponsors.map((sponsor) => (
-            <Grid item key={sponsor.name} xs={12}>
+            <Grid size={{ xs: 12 }} key={sponsor.name}>
               <SponsorCard sponsor={sponsor} level={level} />
             </Grid>
           ))
         ) : (
-          <Grid item xs={12}>
+          <Grid size={{ xs: 12 }}>
             <Paper
               sx={{
                 p: 3,
@@ -250,7 +250,7 @@ export default function SponsorIndexList() {
           </Typography>
           <Grid container spacing={3}>
             {[1, 2].map((index) => (
-              <Grid item xs={12} md={6} key={index}>
+              <Grid size={{ xs: 12, md: 6 }} key={index}>
                 <Skeleton variant="rectangular" height={200} />
               </Grid>
             ))}
@@ -320,7 +320,7 @@ export default function SponsorIndexList() {
             });
             
             return (
-              <Grid item xs={12} md={6} key={event.event_id}>
+              <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
                 <Card 
                   sx={{ 
                     height: '100%',
@@ -544,7 +544,7 @@ export default function SponsorIndexList() {
             About Opportunity Hack
           </Typography>
           <Grid container spacing={isMobile ? 2 : 3}>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Typography variant="body1" paragraph style={style}>
                 Opportunity Hack is a premier hackathon that brings together
                 talented students and professionals to create innovative
@@ -572,7 +572,7 @@ export default function SponsorIndexList() {
                 </ul>
               </Typography>
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid size={{ xs: 12, md: 6 }}>
               <Box
                 sx={{
                   position: "relative",
@@ -620,7 +620,7 @@ export default function SponsorIndexList() {
             mentors, including professionals from:
           </Typography>
           <Grid container spacing={isMobile ? 1 : 2}>
-            <Grid item xs={12} sm={6} md={4}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }}>
               <Card>
                 <CardContent>
                   <Typography variant="h6" style={style}>
@@ -632,7 +632,7 @@ export default function SponsorIndexList() {
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={6} md={4}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }}>
               <Card>
                 <CardContent>
                   <Typography variant="h6" style={style}>
@@ -644,7 +644,7 @@ export default function SponsorIndexList() {
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={6} md={4}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }}>
               <Card>
                 <CardContent>
                   <Typography variant="h6" style={style}>
@@ -686,7 +686,7 @@ export default function SponsorIndexList() {
         </Typography>
         <Grid container spacing={isMobile ? 2 : 3}>
           {sponsorLevels.map((level, index) => (
-            <Grid item xs={12} sm={6} md={3} key={level.name}>
+            <Grid size={{ xs: 12, sm: 6, md: 3 }} key={level.name}>
               <Card sx={{ height: "100%", backgroundColor: level.color }}>
                 <CardContent>
                   <Typography
@@ -811,7 +811,7 @@ export default function SponsorIndexList() {
             Why Sponsor Opportunity Hack?
           </Typography>
           <Grid container spacing={isMobile ? 2 : 3}>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Typography
                 variant="h5"
                 component="h4"
@@ -825,7 +825,7 @@ export default function SponsorIndexList() {
                 faced by nonprofits, amplifying their impact in communities.
               </Typography>
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Typography
                 variant="h5"
                 component="h4"
@@ -839,7 +839,7 @@ export default function SponsorIndexList() {
                 to using technology for social good.
               </Typography>
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Typography
                 variant="h5"
                 component="h4"
@@ -853,7 +853,7 @@ export default function SponsorIndexList() {
                 technology-driven solutions for nonprofits.
               </Typography>
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid size={{ xs: 12, sm: 6 }}>
               <Typography
                 variant="h5"
                 component="h4"
@@ -884,7 +884,7 @@ export default function SponsorIndexList() {
             how your sponsorship can make a real difference:
           </Typography>
           <Grid container spacing={isMobile ? 2 : 3}>
-            <Grid item xs={12} sm={6} md={4}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }}>
               <Card>
                 <CardContent>
                   <Typography
@@ -911,7 +911,7 @@ export default function SponsorIndexList() {
                 </CardActions>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={6} md={4}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }}>
               <Card>
                 <CardContent>
                   <Typography
@@ -938,7 +938,7 @@ export default function SponsorIndexList() {
                 </CardActions>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={6} md={4}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }}>
               <Card>
                 <CardContent>
                   <Typography
@@ -1006,7 +1006,7 @@ export default function SponsorIndexList() {
                   "Create a custom challenge for participants using your technologies, with dedicated prizes for the best solutions.",
               },
             ].map((item, index) => (
-              <Grid item xs={12} sm={6} md={4} key={index}>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }} key={index}>
                 <Card
                   sx={{
                     height: "100%",


### PR DESCRIPTION
## Summary
- Replaces all deprecated `<Grid item xs={N} md={N}>` usage with MUI v7's `<Grid size={{ xs: N, md: N }}>` prop syntax
- Fixes layout regression where cards and form fields stack vertically instead of using column layouts after the MUI v7 upgrade
- **109 files changed, 685 instances migrated** via automated codemod script

## Transformation applied
| Old (v5) | New (v7) |
|----------|----------|
| `<Grid item xs={12} md={6}>` | `<Grid size={{ xs: 12, md: 6 }}>` |
| `<Grid item xs={12} sm={6} md={4} lg={3}>` | `<Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>` |
| `<Grid item xs={12} md={6} key={expr}>` | `<Grid size={{ xs: 12, md: 6 }} key={expr}>` |

## Test plan
- [x] Zero remaining `<Grid item` instances in codebase (`grep` confirms 0 matches)
- [x] Build compiles successfully (`npm run build` — no syntax errors)
- [ ] Spot-check key pages: `/sponsor`, `/contact`, `/hack`, `/admin/certificates`
- [ ] Verify column layouts render correctly (cards side-by-side, not stacked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)