### PR TITLE
Redesign volunteer page + add event tracking across top pages

### DIFF
--- a/src/components/LeadForm/LeadForm.js
+++ b/src/components/LeadForm/LeadForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
@@ -13,6 +13,7 @@ import MailOutlineIcon from "@mui/icons-material/MailOutline";
 import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
 import CircularProgress from "@mui/material/CircularProgress";
 import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
+import { initFacebookPixel, trackEvent, trackForm } from '../../lib/ga';
 
 // Utility functions for bot detection
 const isValidEmail = (email) => {
@@ -57,6 +58,8 @@ const isValidName = (name) => {
 
 const LeadForm = () => {
   const { executeRecaptcha } = useGoogleReCaptcha();
+
+  useEffect(() => { initFacebookPixel(); }, []);
   const [email, setEmail] = useState("");
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
@@ -79,6 +82,7 @@ const LeadForm = () => {
     // Start tracking interaction time when user first interacts
     if (!formStartTimeRef.current) {
       formStartTimeRef.current = Date.now();
+      trackForm('lead_form', 'start');
     }
   };
 
@@ -128,6 +132,7 @@ const LeadForm = () => {
     }
 
     // Open the dialog to collect the name
+    trackForm('lead_form', 'email_entered');
     setOpen(true);
   };
 
@@ -184,6 +189,7 @@ const LeadForm = () => {
       }
 
       setSubmitted(true);
+      trackEvent({ action: 'lead_form_submit', params: { event_label: 'success', page: 'home' } });
       // Reset form on success
       setEmail("");
       setName("");
@@ -192,6 +198,7 @@ const LeadForm = () => {
       console.error("Error:", error);
       setSubmitted(false);
       setError(error.message || "An error occurred. Please try again.");
+      trackEvent({ action: 'lead_form_error', params: { event_label: error.message, page: 'home' } });
     } finally {
       setIsLoading(false);
       setOpen(false);

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -196,7 +196,9 @@ export default function Profile(props) {
   // Handle tab change
   const handleTabChange = (event, newValue) => {
     setActiveTab(newValue);
-    
+    const tabNames = ['basic', 'impact', 'github', 'swag', 'volunteer', 'giveaways'];
+    trackEvent({ action: 'profile_tab_change', params: { event_label: tabNames[newValue], page: 'profile' } });
+
     // Update URL hash based on tab
     const tabHashMap = {
       0: 'basic',

--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { initFacebookPixel, trackEvent } from '../../lib/ga';
 import {
   Container,
   Typography,
@@ -134,6 +135,8 @@ const ContactPage = () => {
     error: recaptchaError,
   } = useRecaptcha();
 
+  useEffect(() => { initFacebookPixel(); }, []);
+
   // Form state
   const [formState, setFormState] = useState(initialFormState);
   const [formErrors, setFormErrors] = useState({});
@@ -240,11 +243,13 @@ const ContactPage = () => {
 
       // Set success state
       setSubmitSuccess(true);
+      trackEvent({ action: 'contact_form_submit', params: { event_label: formState.inquiryType, page: 'contact' } });
 
       // Reset form after submission
       setFormState(initialFormState);
     } catch (error) {
       console.error("Error submitting contact form:", error);
+      trackEvent({ action: 'contact_form_error', params: { event_label: error.message, page: 'contact' } });
       setSubmitError("Failed to submit your message. Please try again later.");
     } finally {
       setIsSubmitting(false);

--- a/src/pages/hack/[event_id]/hacker-application.js
+++ b/src/pages/hack/[event_id]/hacker-application.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
+import { initFacebookPixel, trackEvent } from '../../../lib/ga';
 import {
   useAuthInfo,
   RequiredAuthProvider,
@@ -449,6 +450,8 @@ const HackerApplicationComponent = () => {
   ];
 
   // Set up form with event_id
+  useEffect(() => { initFacebookPixel(); }, []);
+
   useEffect(() => {
     if (event_id && !formInitializedRef.current) {
       formInitializedRef.current = true;
@@ -1110,6 +1113,7 @@ const HackerApplicationComponent = () => {
       handleSubmit();
     } else {
       setActiveStep((prev) => prev + 1);
+      trackEvent({ action: 'hacker_app_step', params: { event_label: steps[activeStep + 1], step: activeStep + 2, event_id, page: 'hacker_application' } });
       // Scroll to top of form for better UX
       if (formRef?.current) {
         formRef.current.scrollIntoView({
@@ -1122,6 +1126,7 @@ const HackerApplicationComponent = () => {
 
   const handleBack = () => {
     setActiveStep((prev) => prev - 1);
+    trackEvent({ action: 'hacker_app_step_back', params: { event_label: steps[activeStep - 1], step: activeStep, event_id, page: 'hacker_application' } });
     // Save progress when moving between steps
     handleManualSave();
     // Scroll to top of form for better UX
@@ -1272,6 +1277,7 @@ const HackerApplicationComponent = () => {
       }
 
       setSuccess(true);
+      trackEvent({ action: 'hacker_app_submit', params: { event_label: 'success', event_id, page: 'hacker_application' } });
       // Scroll to top of form to show "Application Submitted!" message
       if (formRef?.current) {
         formRef.current.scrollIntoView({
@@ -1281,6 +1287,7 @@ const HackerApplicationComponent = () => {
       }
     } catch (err) {
       console.error("Error submitting application:", err);
+      trackEvent({ action: 'hacker_app_submit_error', params: { event_label: err.message, event_id, page: 'hacker_application' } });
       setError("Failed to submit your application. Please try again.");
     } finally {
       setSubmitting(false);

--- a/src/pages/hack/[event_id]/judge-application.js
+++ b/src/pages/hack/[event_id]/judge-application.js
@@ -6,6 +6,7 @@ import React, {
   useMemo,
 } from "react";
 import { useRouter } from "next/router";
+import { initFacebookPixel, trackEvent } from '../../../lib/ga';
 import {
   useAuthInfo,
   RequiredAuthProvider,
@@ -308,6 +309,7 @@ const JudgeApplicationComponent = () => {
 
   // fetch event data from the backend API
   useEffect(() => {
+    initFacebookPixel();
     // Initialize reCAPTCHA when component mounts
     initializeRecaptcha();
 
@@ -1071,6 +1073,7 @@ const JudgeApplicationComponent = () => {
       handleSubmit();
     } else {
       setActiveStep((prev) => prev + 1);
+      trackEvent({ action: 'judge_app_step', params: { event_label: steps[activeStep + 1], step: activeStep + 2, event_id, page: 'judge_application' } });
       // Scroll to top of form for better UX
       if (formRef?.current) {
         formRef.current.scrollIntoView({
@@ -1083,6 +1086,7 @@ const JudgeApplicationComponent = () => {
 
   const handleBack = () => {
     setActiveStep((prev) => prev - 1);
+    trackEvent({ action: 'judge_app_step_back', params: { event_label: steps[activeStep - 1], step: activeStep, event_id, page: 'judge_application' } });
     // Scroll to top of form for better UX
     if (formRef?.current) {
       formRef.current.scrollIntoView({
@@ -1287,6 +1291,7 @@ const JudgeApplicationComponent = () => {
       }
 
       setSuccess(true);
+      trackEvent({ action: 'judge_app_submit', params: { event_label: 'success', event_id, page: 'judge_application' } });
       // Scroll to top of form to show "Application Submitted!" message
       if (formRef?.current) {
         formRef.current.scrollIntoView({
@@ -1296,6 +1301,7 @@ const JudgeApplicationComponent = () => {
       }
     } catch (err) {
       console.error("Error submitting application:", err);
+      trackEvent({ action: 'judge_app_submit_error', params: { event_label: err.message, event_id, page: 'judge_application' } });
       setError(
         `Failed to submit your application. ${err.message || "Please try again."}`,
       );

--- a/src/pages/hack/[event_id]/mentor-application.js
+++ b/src/pages/hack/[event_id]/mentor-application.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
+import { initFacebookPixel, trackEvent } from '../../../lib/ga';
 import {
   useAuthInfo,
   RequiredAuthProvider,
@@ -275,6 +276,7 @@ const MentorApplicationComponent = () => {
 
   // fetch event data from the backend API and initialize reCAPTCHA
   useEffect(() => {
+    initFacebookPixel();
     // Initialize reCAPTCHA when component mounts
     initializeRecaptcha();
 
@@ -673,6 +675,7 @@ const MentorApplicationComponent = () => {
       handleSubmit();
     } else {
       setActiveStep((prev) => prev + 1);
+      trackEvent({ action: 'mentor_app_step', params: { event_label: steps[activeStep + 1], step: activeStep + 2, event_id, page: 'mentor_application' } });
       // Scroll to top of form for better UX
       if (formRef?.current) {
         formRef.current.scrollIntoView({
@@ -685,6 +688,7 @@ const MentorApplicationComponent = () => {
 
   const handleBack = () => {
     setActiveStep((prev) => prev - 1);
+    trackEvent({ action: 'mentor_app_step_back', params: { event_label: steps[activeStep - 1], step: activeStep, event_id, page: 'mentor_application' } });
     // Scroll to top of form for better UX
     if (formRef?.current) {
       formRef.current.scrollIntoView({
@@ -969,6 +973,7 @@ const MentorApplicationComponent = () => {
       }
 
       setSuccess(true);
+      trackEvent({ action: 'mentor_app_submit', params: { event_label: 'success', event_id, page: 'mentor_application' } });
       // Scroll to top of form to show "Application Submitted!" message
       if (formRef?.current) {
         formRef.current.scrollIntoView({
@@ -978,6 +983,7 @@ const MentorApplicationComponent = () => {
       }
     } catch (err) {
       console.error("Error submitting application:", err);
+      trackEvent({ action: 'mentor_app_submit_error', params: { event_label: err.message, event_id, page: 'mentor_application' } });
       setError(
         err.message || "Failed to submit your application. Please try again.",
       );

--- a/src/pages/hack/[event_id]/volunteer-application.js
+++ b/src/pages/hack/[event_id]/volunteer-application.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
+import { initFacebookPixel, trackEvent } from '../../../lib/ga';
 import {
   useAuthInfo,
   RequiredAuthProvider,
@@ -246,6 +247,8 @@ const VolunteerApplicationComponent = () => {
   ];
 
   // Set up form with event_id
+  useEffect(() => { initFacebookPixel(); }, []);
+
   useEffect(() => {
     if (event_id && !formInitializedRef.current) {
       formInitializedRef.current = true;
@@ -1284,6 +1287,7 @@ const VolunteerApplicationComponent = () => {
       handleSubmit();
     } else {
       setActiveStep((prev) => prev + 1);
+      trackEvent({ action: 'volunteer_app_step', params: { event_label: steps[activeStep + 1], step: activeStep + 2, event_id, page: 'volunteer_application' } });
       // Scroll to top of form for better UX
       if (formRef?.current) {
         formRef.current.scrollIntoView({
@@ -1296,6 +1300,7 @@ const VolunteerApplicationComponent = () => {
 
   const handleBack = () => {
     setActiveStep((prev) => prev - 1);
+    trackEvent({ action: 'volunteer_app_step_back', params: { event_label: steps[activeStep - 1], step: activeStep, event_id, page: 'volunteer_application' } });
     // Save progress when moving between steps
     handleManualSave();
     // Scroll to top of form for better UX
@@ -1425,6 +1430,7 @@ const VolunteerApplicationComponent = () => {
       }
 
       setSuccess(true);
+      trackEvent({ action: 'volunteer_app_submit', params: { event_label: 'success', event_id, page: 'volunteer_application' } });
       // Scroll to top of form to show "Application Submitted!" message
       if (formRef?.current) {
         formRef.current.scrollIntoView({
@@ -1434,6 +1440,7 @@ const VolunteerApplicationComponent = () => {
       }
     } catch (err) {
       console.error("Error submitting application:", err);
+      trackEvent({ action: 'volunteer_app_submit_error', params: { event_label: err.message, event_id, page: 'volunteer_application' } });
       setError("Failed to submit your application. Please try again.");
     } finally {
       setSubmitting(false);

--- a/src/pages/hack/index.js
+++ b/src/pages/hack/index.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Head from 'next/head';
 import Image from 'next/image';
 import { Typography, Box, Button, Grid, Container, Divider, Alert, Paper, Card, CardContent } from '@mui/material';
+import { initFacebookPixel, trackEvent } from '../../lib/ga';
 import { TitleContainer, LayoutContainer, ProjectsContainer } from '../../styles/nonprofit/styles';
 import HackathonList from '../../components/HackathonList/HackathonList';
 import PreviousHackathonList from '../../components/HackathonList/PreviousHackathonList';
@@ -10,6 +11,12 @@ import { EventAvailable, Code, Group, EmojiEvents, Gavel, CameraAlt, Business, P
 
 const HackathonIndex = () => {
   const style = { fontSize: '15px' };
+
+  useEffect(() => { initFacebookPixel(); }, []);
+
+  const track = (action, label) => {
+    trackEvent({ action: `hack_${action}`, params: { event_label: label, page: 'hack' } });
+  };
 
   return (
     <LayoutContainer key="hackathons" container>
@@ -90,6 +97,7 @@ const HackathonIndex = () => {
               startIcon={<EventAvailable />}
               onClick={(e) => {
                 e.preventDefault();
+                track('cta_click', 'view_upcoming_events');
                 document.getElementById('upcoming-events')?.scrollIntoView({ behavior: 'smooth' });
               }}
             >
@@ -104,6 +112,7 @@ const HackathonIndex = () => {
               fullWidth
               href="/signup"
               startIcon={<Group />}
+              onClick={() => track('cta_click', 'join_community')}
             >
               Join Our Community
             </Button>
@@ -240,6 +249,7 @@ const HackathonIndex = () => {
                   href="/hack/code-of-conduct"
                   fullWidth
                   size="small"
+                  onClick={() => track('cta_click', 'code_of_conduct')}
                 >
                   Read Guidelines
                 </Button>
@@ -263,6 +273,7 @@ const HackathonIndex = () => {
                   href="/hack/liability-waiver"
                   fullWidth
                   size="small"
+                  onClick={() => track('cta_click', 'liability_waiver')}
                 >
                   View Waiver
                 </Button>
@@ -286,6 +297,7 @@ const HackathonIndex = () => {
                   href="/hack/photo-release"
                   fullWidth
                   size="small"
+                  onClick={() => track('cta_click', 'photo_release')}
                 >
                   Photo Policy
                 </Button>
@@ -307,9 +319,10 @@ const HackathonIndex = () => {
         <Button 
           variant="contained" 
           size="medium"
-          component={Link} 
+          component={Link}
           href="/sponsor"
           sx={{ textTransform: 'none' }}
+          onClick={() => track('cta_click', 'become_sponsor')}
         >
           Become a Sponsor
         </Button>

--- a/src/pages/judge/index.js
+++ b/src/pages/judge/index.js
@@ -29,6 +29,7 @@ import {
 import { useAuthInfo, withRequiredAuthInfo } from '@propelauth/react';
 import { useSnackbar } from 'notistack';
 import judgeApi from '../../lib/judgeApi';
+import { initFacebookPixel, trackEvent } from '../../lib/ga';
 
 const JudgeDashboard = withRequiredAuthInfo(({ userClass }) => {
   const { accessToken, user } = useAuthInfo();
@@ -37,6 +38,8 @@ const JudgeDashboard = withRequiredAuthInfo(({ userClass }) => {
   
   const [loading, setLoading] = useState(true);
   const [assignments, setAssignments] = useState([]);
+
+  useEffect(() => { initFacebookPixel(); }, []);
 
   useEffect(() => {
     const fetchAssignments = async () => {
@@ -226,7 +229,10 @@ const JudgeDashboard = withRequiredAuthInfo(({ userClass }) => {
                           </Box>
                           <Button
                             variant="contained"
-                            onClick={() => router.push(`/judge/${hackathon.event_id}`)}
+                            onClick={() => {
+                              trackEvent({ action: 'judge_dash_start', params: { event_label: hackathon.event_id, page: 'judge_dashboard' } });
+                              router.push(`/judge/${hackathon.event_id}`);
+                            }}
                             startIcon={<JudgeIcon />}
                           >
                             Start Judging

--- a/src/pages/onboarding/index.js
+++ b/src/pages/onboarding/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import { initFacebookPixel, trackEvent } from '../../lib/ga';
 import Head from 'next/head';
 import { useCookies, CookiesProvider } from 'react-cookie';
 import {
@@ -92,6 +93,8 @@ function OnboardingComponent() {
   const [openCongratulatoryDialog, setOpenCongratulatoryDialog] = useState(false);
   const [cookies, setCookie] = useCookies(['onboarding_visited']);
   
+  useEffect(() => { initFacebookPixel(); }, []);
+
   useEffect(() => {
     const ONBOARDING_VISITED_COOKIE = "onboarding_visited";
 
@@ -183,6 +186,7 @@ function OnboardingComponent() {
       
       // Move to next step
       setActiveStep((prevActiveStep) => prevActiveStep + 1);
+      trackEvent({ action: 'onboarding_step', params: { event_label: steps[activeStep + 1]?.label, step: activeStep + 2, page: 'onboarding' } });
       // Scroll to top of the page when navigating to next step
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
@@ -210,6 +214,7 @@ function OnboardingComponent() {
       // Mark onboarding as completed to prevent dialog from showing again
       localStorage.setItem('ohack_onboarding_completed', 'true');
       
+      trackEvent({ action: 'onboarding_complete', params: { event_label: 'all_steps', page: 'onboarding' } });
       setOpenCongratulatoryDialog(true); // Open the dialog
     } catch (err) {
       console.error('Error completing onboarding:', err);

--- a/src/pages/volunteer/index.js
+++ b/src/pages/volunteer/index.js
@@ -1,24 +1,24 @@
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import Moment from "moment";
+import { initFacebookPixel, trackEvent } from '../../lib/ga';
 import {
   Typography,
   Button,
   Grid,
   Card,
   CardContent,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
   Box,
   Alert,
   Chip,
-  Divider,
   Paper,
-  Tab,
-  Tabs,
+  Container,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
   CircularProgress,
+  useTheme,
+  useMediaQuery,
 } from "@mui/material";
 import {
   CodeRounded,
@@ -30,27 +30,35 @@ import {
   EngineeringRounded,
   SchoolRounded,
   EmojiEventsRounded,
-  WorkRounded,  
+  WorkRounded,
   VolunteerActivismRounded,
   LabelImportantRounded,
-  EventRounded,
   PersonRounded,
-  BuildRounded,
   CalendarTodayRounded,
   LocationOnRounded,
+  ExpandMoreRounded,
 } from "@mui/icons-material";
 import useHackathonEvents from '../../hooks/use-hackathon-events';
 
 const VolunteerPage = () => {
-  const [activeTab, setActiveTab] = useState(0);
-  
-  // Use the same hook as sponsor page for consistency
+  const [expandedRole, setExpandedRole] = useState(null);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
   const { hackathons: upcomingEvents, loading: loadingEvents } = useHackathonEvents("current");
 
-  // Define the four main role categories
+  useEffect(() => {
+    initFacebookPixel();
+  }, []);
+
+  const track = (action, label) => {
+    trackEvent({ action: `volunteer_${action}`, params: { event_label: label, page: 'volunteer' } });
+  };
+
   const roleTypes = {
     hacker: {
-      title: "🚀 Hacker",
+      title: "Hacker",
+      emoji: "🚀",
       subtitle: "Build Solutions",
       description: "You're a developer, designer, or technical creator who wants to build technology solutions for nonprofits.",
       color: "primary",
@@ -82,7 +90,8 @@ const VolunteerPage = () => {
       ]
     },
     mentor: {
-      title: "🎯 Mentor",
+      title: "Mentor",
+      emoji: "🎯",
       subtitle: "Guide Teams",
       description: "You're an experienced professional who can guide teams, provide technical expertise, and help make strategic decisions.",
       color: "secondary",
@@ -114,7 +123,8 @@ const VolunteerPage = () => {
       ]
     },
     volunteer: {
-      title: "🤝 Volunteer",
+      title: "Volunteer",
+      emoji: "🤝",
       subtitle: "Support Events",
       description: "You want to help make our hackathons and events successful through logistics, coordination, and community building.",
       color: "success",
@@ -146,9 +156,10 @@ const VolunteerPage = () => {
       ]
     },
     judge: {
-      title: "⚖️ Judge",
+      title: "Judge",
+      emoji: "⚖️",
       subtitle: "Evaluate Solutions",
-      description: "You're an experienced professional who can evaluate team solutions, provide constructive feedback, and help select winning projects. Judges can be technical, product-focused, industry experts, or nonprofit sector experts.",
+      description: "You're an experienced professional who can evaluate team solutions, provide constructive feedback, and help select winning projects.",
       color: "warning",
       roles: [
         {
@@ -179,11 +190,11 @@ const VolunteerPage = () => {
     }
   };
 
-  const benefits = [
-    { text: "Learn New Skills", icon: <SchoolRounded /> },
-    { text: "Make a Difference", icon: <EmojiEventsRounded /> },
-    { text: "Expand Your Network", icon: <PeopleRounded /> },
-    { text: "Enhance Your Resume", icon: <WorkRounded /> },
+  const impactStats = [
+    { value: "10+", label: "Years of Impact" },
+    { value: "300+", label: "Nonprofits Helped" },
+    { value: "5,000+", label: "Volunteers" },
+    { value: "4", label: "Ways to Contribute" },
   ];
 
   const linkStyle = {
@@ -192,143 +203,150 @@ const VolunteerPage = () => {
     fontWeight: "bold",
   };
 
-  const handleTabChange = (event, newValue) => {
-    setActiveTab(newValue);
-  };
-
-  const handleLearnMoreClick = (roleIndex) => {
-    setActiveTab(roleIndex);
-    // Scroll to the detailed role information section
-    setTimeout(() => {
-      document.getElementById('detailed-roles')?.scrollIntoView({ 
-        behavior: 'smooth' 
-      });
-    }, 100);
+  const handleExpandRole = (key) => (event, isExpanded) => {
+    setExpandedRole(isExpanded ? key : null);
+    if (isExpanded) {
+      track('role_expand', key);
+    }
   };
 
   const formatEventDate = (startDate, endDate) => {
     const start = Moment(startDate);
     const end = Moment(endDate);
-    
+
     if (start.format('YYYY-MM-DD') === end.format('YYYY-MM-DD')) {
       return start.format('dddd, MMMM Do YYYY');
     }
-    
+
     return `${start.format('MMM D')} - ${end.format('MMM D, YYYY')}`;
+  };
+
+  const roleColorMap = {
+    primary: '#1976d2',
+    secondary: '#9c27b0',
+    success: '#2e7d32',
+    warning: '#ed6c02',
   };
 
   return (
     <>
-      <Box sx={{ padding: "2rem", fontSize: "1em" }}>
-        <Typography
-          variant="h1"
-          sx={{ 
-            fontSize: "2.5em", 
-            mb: 2, 
-            mt: 10 
-          }}
-        >
-          How to Get Involved with Opportunity Hack
-        </Typography>
-        
-        <Typography variant="body1" paragraph sx={{ fontSize: "1.2em", mb: 4 }}>
-          <strong>Opportunity Hack</strong> organizes hackathons where developers, designers, and nonprofits come together 
-          to create technology solutions that make a real difference. Whether you build, guide, or support, 
-          there's a perfect role for you!
-        </Typography>
-
-        {/* Hero Image */}
-        <Box 
-          sx={{ 
-            display: 'flex', 
-            justifyContent: 'center', 
-            mb: 5,
-            mt: 3,
-            textAlign: 'center'
-          }}
-        >
-          <Box sx={{ maxWidth: '600px', width: '100%' }}>
-            <Box
-              component="img"
-              src="https://cdn.ohack.dev/ohack.dev/2024_hackathon_2.webp"
-              alt="Volunteers, mentors, hackers, and judges collaborating at an Opportunity Hack event to build technology solutions for nonprofits"
-              sx={{
-                width: '100%',
-                height: 'auto',
-                borderRadius: 2,
-                boxShadow: 3,
-                mb: 2
-              }}
-            />
-            <Typography
-              variant="caption"
-              sx={{
-                color: "text.secondary",
-                fontStyle: "italic",
-                display: "block",
-              }}
-            >
-              Hackers, mentors, volunteers, and judges working together to create impactful technology solutions for nonprofits
-            </Typography>
-          </Box>
-        </Box>
-
-        {/* Role Overview Cards */}
-        <Typography variant="h2" sx={{ fontSize: "2em", mb: 3, mt: 4 }}>
-          Choose Your Role
-        </Typography>
-        
-        <Grid container spacing={3} sx={{ mb: 5 }}>
-          {Object.entries(roleTypes).map(([key, roleType]) => (
-            <Grid size={{ xs: 12, md: 3 }} key={key}>
-              <Card 
-                sx={{ 
-                  height: '100%', 
-                  cursor: 'pointer',
-                  transition: 'transform 0.2s, box-shadow 0.2s',
-                  '&:hover': {
-                    transform: 'translateY(-4px)',
-                    boxShadow: 6
-                  }
-                }}
-                onClick={() => handleLearnMoreClick(Object.keys(roleTypes).indexOf(key))}
-              >
-                <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-                  <Typography variant="h3" sx={{ fontSize: "1.5em", mb: 1 }}>
-                    {roleType.title}
-                  </Typography>
-                  <Typography variant="h4" sx={{ fontSize: "1.1em", color: 'text.secondary', mb: 2 }}>
-                    {roleType.subtitle}
-                  </Typography>
-                  <Typography variant="body1" sx={{ flexGrow: 1, mb: 2 }}>
-                    {roleType.description}
-                  </Typography>
-                  <Button 
-                    variant="contained" 
-                    color={roleType.color}
-                    size="small"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleLearnMoreClick(Object.keys(roleTypes).indexOf(key));
-                    }}
-                  >
-                    Learn More
-                  </Button>
-                </CardContent>
-              </Card>
-            </Grid>
-          ))}
-        </Grid>
-
-        {/* Upcoming Events Section */}
-        <Paper sx={{ p: 3, mb: 5, bgcolor: 'primary.light', color: 'white' }}>
-          <Typography variant="h2" sx={{ fontSize: "2em", mb: 2 }}>
-            🎯 Find Upcoming Events
+      {/* Gradient Hero */}
+      <Box sx={{
+        background: 'linear-gradient(135deg, #1976d2 0%, #9c27b0 100%)',
+        color: 'white',
+        mt: 8,
+        py: { xs: 6, md: 10 },
+      }}>
+        <Container maxWidth="lg">
+          <Typography
+            variant={isMobile ? "h3" : "h1"}
+            sx={{
+              fontWeight: 800,
+              mb: 2,
+              textShadow: '2px 2px 4px rgba(0,0,0,0.3)',
+              fontSize: { xs: '2.5rem', md: '3.5rem' },
+            }}
+          >
+            Make a Difference with Technology
           </Typography>
-          <Typography variant="body1" sx={{ fontSize: "1.1em", mb: 3 }}>
+          <Typography
+            variant={isMobile ? "h6" : "h5"}
+            sx={{ mb: 4, opacity: 0.9, maxWidth: 700 }}
+          >
+            Join Opportunity Hack as a hacker, mentor, volunteer, or judge —
+            and help build technology solutions for nonprofits.
+          </Typography>
+
+          <Box sx={{ display: 'flex', gap: 2, mb: 6, flexWrap: 'wrap' }}>
+            <Button
+              variant="contained"
+              size="large"
+              sx={{
+                bgcolor: 'white',
+                color: 'primary.main',
+                fontWeight: 700,
+                '&:hover': { bgcolor: 'grey.100' },
+              }}
+              href="#upcoming-events"
+              onClick={() => track('hero_cta', 'find_event')}
+            >
+              Find an Event
+            </Button>
+            <Button
+              variant="outlined"
+              size="large"
+              sx={{
+                borderColor: 'white',
+                color: 'white',
+                fontWeight: 700,
+                '&:hover': { borderColor: 'grey.200', bgcolor: 'rgba(255,255,255,0.1)' },
+              }}
+              href="#roles"
+              onClick={() => track('hero_cta', 'explore_roles')}
+            >
+              Explore Roles
+            </Button>
+          </Box>
+
+          {/* Impact stat cards - glassmorphism */}
+          <Grid container spacing={2}>
+            {impactStats.map((stat) => (
+              <Grid size={{ xs: 6, md: 3 }} key={stat.label}>
+                <Card sx={{
+                  background: 'rgba(255,255,255,0.15)',
+                  backdropFilter: 'blur(10px)',
+                  border: '1px solid rgba(255,255,255,0.25)',
+                  color: 'white',
+                  textAlign: 'center',
+                }}>
+                  <CardContent sx={{ py: 2 }}>
+                    <Typography variant="h3" sx={{ fontWeight: 800, fontSize: { xs: '2rem', md: '2.5rem' } }}>
+                      {stat.value}
+                    </Typography>
+                    <Typography variant="body2" sx={{ opacity: 0.9 }}>
+                      {stat.label}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Container>
+      </Box>
+
+      {/* Hero image - below gradient */}
+      <Container maxWidth="lg">
+        <Box sx={{ mt: -4, mb: 5, textAlign: 'center' }}>
+          <Box
+            component="img"
+            src="https://cdn.ohack.dev/ohack.dev/2024_hackathon_2.webp"
+            alt="Volunteers, mentors, hackers, and judges collaborating at an Opportunity Hack event to build technology solutions for nonprofits"
+            sx={{
+              maxWidth: '800px',
+              width: '100%',
+              borderRadius: 3,
+              boxShadow: 6,
+            }}
+          />
+          <Typography
+            variant="caption"
+            sx={{ color: 'text.secondary', fontStyle: 'italic', display: 'block', mt: 1 }}
+          >
+            Hackers, mentors, volunteers, and judges working together to create impactful technology solutions for nonprofits
+          </Typography>
+        </Box>
+      </Container>
+
+      {/* Upcoming Events */}
+      <Container maxWidth="lg" id="upcoming-events">
+        <Paper sx={{ p: 3, mb: 5, bgcolor: 'primary.light', color: 'white' }}>
+          <Typography variant="h2" sx={{ fontSize: { xs: '1.8rem', md: '2rem' }, mb: 2 }}>
+            Find Upcoming Events
+          </Typography>
+          <Typography variant="body1" sx={{ fontSize: '1.1em', mb: 3 }}>
             Ready to jump in? Here are our upcoming hackathons where you can hack, mentor, volunteer, or judge!
           </Typography>
-          
+
           {loadingEvents ? (
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
               <CircularProgress color="inherit" />
@@ -351,32 +369,36 @@ const VolunteerPage = () => {
                         {formatEventDate(event.start_date, event.end_date)}
                       </Typography>
                       <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                        <Button 
-                          size="small" 
-                          variant="contained" 
+                        <Button
+                          size="small"
+                          variant="contained"
                           color="primary"
                           href={`/hack/${event.event_id}/hacker-application`}
+                          onClick={() => track('event_apply', `hacker_${event.event_id}`)}
                         >
                           Apply as Hacker
                         </Button>
-                        <Button 
-                          size="small" 
+                        <Button
+                          size="small"
                           variant="outlined"
                           href={`/hack/${event.event_id}/mentor-application`}
+                          onClick={() => track('event_apply', `mentor_${event.event_id}`)}
                         >
                           Mentor
                         </Button>
-                        <Button 
-                          size="small" 
+                        <Button
+                          size="small"
                           variant="outlined"
                           href={`/hack/${event.event_id}/volunteer-application`}
+                          onClick={() => track('event_apply', `volunteer_${event.event_id}`)}
                         >
                           Volunteer
                         </Button>
-                        <Button 
-                          size="small" 
+                        <Button
+                          size="small"
                           variant="outlined"
                           href={`/hack/${event.event_id}/judge-application`}
+                          onClick={() => track('event_apply', `judge_${event.event_id}`)}
                         >
                           Judge
                         </Button>
@@ -395,338 +417,262 @@ const VolunteerPage = () => {
               .
             </Alert>
           )}
-          
+
           <Box sx={{ mt: 3, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-            <Button 
-              variant="contained" 
-              sx={{ bgcolor: 'white', color: 'primary.main' }}
+            <Button
+              variant="contained"
+              sx={{ bgcolor: 'white', color: 'primary.main', '&:hover': { bgcolor: 'grey.100' } }}
               href="/hack"
+              onClick={() => track('events_cta', 'view_all_hackathons')}
             >
               View All Hackathons
             </Button>
-            <Button 
-              variant="outlined" 
-              sx={{ borderColor: 'white', color: 'white' }}
+            <Button
+              variant="outlined"
+              sx={{ borderColor: 'white', color: 'white', '&:hover': { borderColor: 'grey.200', bgcolor: 'rgba(255,255,255,0.1)' } }}
               href="/signup"
+              onClick={() => track('events_cta', 'join_slack')}
             >
               Join Our Slack Community
             </Button>
           </Box>
         </Paper>
+      </Container>
 
-        {/* Detailed Role Tabs */}
-        <Typography variant="h2" sx={{ fontSize: "2em", mb: 3 }} id="detailed-roles">
-          Detailed Role Information
+      {/* Choose Your Role */}
+      <Container maxWidth="lg" sx={{ mb: 5 }}>
+        <Typography
+          variant="h2"
+          id="roles"
+          sx={{ fontSize: { xs: '1.8rem', md: '2.5rem' }, fontWeight: 700, mb: 1 }}
+        >
+          Choose Your Role
         </Typography>
-        
-        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
-          <Tabs value={activeTab} onChange={handleTabChange}>
-            {Object.entries(roleTypes).map(([key, roleType]) => (
-              <Tab 
-                key={key}
-                label={roleType.title} 
-                icon={key === 'hacker' ? <BuildRounded /> : key === 'mentor' ? <SchoolRounded /> : key === 'volunteer' ? <VolunteerActivismRounded /> : <EmojiEventsRounded />}
-                iconPosition="start"
-              />
-            ))}
-          </Tabs>
-        </Box>
-
-        {Object.entries(roleTypes).map(([key, roleType], index) => (
-          <Box key={key} hidden={activeTab !== index}>
-            <Alert severity="info" sx={{ mb: 3 }}>
-              <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
-                {roleType.description}
-              </Typography>
-            </Alert>
-            
-            {/* Special callout for Judge role */}
-            {key === 'judge' && (
-              <Paper 
-                elevation={3} 
-                sx={{ 
-                  p: 3, 
-                  mb: 3, 
-                  bgcolor: 'warning.light', 
-                  color: 'white',
-                  textAlign: 'center'
-                }}
-              >
-                <EmojiEventsRounded sx={{ fontSize: 48, mb: 2 }} />
-                <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold' }}>
-                  Want to Learn More About Judging?
-                </Typography>
-                <Typography variant="body1" sx={{ mb: 3, maxWidth: '600px', mx: 'auto' }}>
-                  Get the complete guide to judging at Opportunity Hack! Learn about evaluation criteria, 
-                  judging responsibilities, time commitments, and how to provide constructive feedback that helps teams grow.
-                </Typography>
-                <Button 
-                  variant="contained" 
-                  size="large"
-                  href="/about/judges"
-                  sx={{ 
-                    bgcolor: 'white', 
-                    color: 'warning.main',
-                    fontWeight: 'bold',
-                    '&:hover': { 
-                      bgcolor: 'grey.100',
-                      transform: 'translateY(-2px)'
-                    }
-                  }}
-                  startIcon={<EmojiEventsRounded />}
-                >
-                  Read the Complete Judge Guide
-                </Button>
-              </Paper>
-            )}
-            
-            {/* Special callout for Mentor role */}
-            {key === 'mentor' && (
-              <Paper 
-                elevation={3} 
-                sx={{ 
-                  p: 3, 
-                  mb: 3, 
-                  bgcolor: 'secondary.light', 
-                  color: 'white',
-                  textAlign: 'center'
-                }}
-              >
-                <SchoolRounded sx={{ fontSize: 48, mb: 2 }} />
-                <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold' }}>
-                  Want to Learn More About Mentoring?
-                </Typography>
-                <Typography variant="body1" sx={{ mb: 3, maxWidth: '600px', mx: 'auto' }}>
-                  Get the complete guide to mentoring at Opportunity Hack! Learn about mentor responsibilities, 
-                  time commitments, success stories, and detailed tips for making the biggest impact.
-                </Typography>
-                <Button 
-                  variant="contained" 
-                  size="large"
-                  href="/about/mentors"
-                  sx={{ 
-                    bgcolor: 'white', 
-                    color: 'secondary.main',
-                    fontWeight: 'bold',
-                    '&:hover': { 
-                      bgcolor: 'grey.100',
-                      transform: 'translateY(-2px)'
-                    }
-                  }}
-                  startIcon={<SchoolRounded />}
-                >
-                  Read the Complete Mentor Guide
-                </Button>
-              </Paper>
-            )}
-            
-            <Grid container spacing={3}>
-              {roleType.roles.map((role, roleIndex) => (
-                <Grid size={{ xs: 12, sm: 6, md: 6 }} key={roleIndex}>
-                  <Card sx={{ height: '100%' }}>
-                    <CardContent>
-                      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                        {role.icon}
-                        <Typography variant="h6" sx={{ ml: 1 }}>
-                          {role.title}
-                        </Typography>
-                      </Box>
-                      <Typography variant="body1" sx={{ mb: 2 }}>
-                        {role.description}
-                      </Typography>
-                      <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                        Key Skills:
-                      </Typography>
-                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                        {role.skills.map((skill) => (
-                          <Chip 
-                            key={skill} 
-                            label={skill} 
-                            size="small" 
-                            color={roleType.color}
-                            variant="outlined"
-                          />
-                        ))}
-                      </Box>
-                    </CardContent>
-                  </Card>
-                </Grid>
-              ))}
-            </Grid>
-          </Box>
-        ))}
-
-        {/* Benefits Section */}
-        <Typography variant="h2" sx={{ fontSize: "2em", mb: 3, mt: 5 }}>
-          Why Join Opportunity Hack?
+        <Typography variant="body1" sx={{ mb: 4, color: 'text.secondary' }}>
+          Click any role to explore specializations and find your fit.
         </Typography>
-        <Grid container spacing={3} sx={{ mb: 5 }}>
-          {benefits.map((benefit, index) => (
-            <Grid size={{ xs: 12, sm: 6, md: 3 }} key={index}>
-              <Card sx={{ textAlign: 'center', height: '100%' }}>
+
+        <Grid container spacing={3}>
+          {Object.entries(roleTypes).map(([key, roleType]) => (
+            <Grid size={{ xs: 12, md: 6 }} key={key}>
+              <Card sx={{
+                height: '100%',
+                borderLeft: `5px solid ${roleColorMap[roleType.color]}`,
+                transition: 'all 0.3s ease',
+                '&:hover': { transform: 'translateY(-4px)', boxShadow: 6 },
+              }}>
                 <CardContent>
-                  <Box sx={{ mb: 2, color: 'primary.main' }}>
-                    {benefit.icon}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1 }}>
+                    <Typography variant="h4" sx={{ fontSize: '2rem', lineHeight: 1 }}>
+                      {roleType.emoji}
+                    </Typography>
+                    <Box>
+                      <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                        {roleType.title}
+                      </Typography>
+                      <Chip
+                        label={roleType.subtitle}
+                        color={roleType.color}
+                        size="small"
+                        sx={{ mt: 0.5 }}
+                      />
+                    </Box>
                   </Box>
-                  <Typography variant="h6" sx={{ fontSize: "1.1em" }}>
-                    {benefit.text}
+
+                  <Typography variant="body1" sx={{ mb: 2, color: 'text.secondary' }}>
+                    {roleType.description}
                   </Typography>
+
+                  {key === 'judge' && (
+                    <Typography variant="body2" sx={{ mb: 1 }}>
+                      <Link href="/about/judges" style={linkStyle} onClick={() => track('guide_link', 'judge_guide')}>
+                        Read the complete Judge Guide
+                      </Link>
+                    </Typography>
+                  )}
+                  {key === 'mentor' && (
+                    <Typography variant="body2" sx={{ mb: 1 }}>
+                      <Link href="/about/mentors" style={linkStyle} onClick={() => track('guide_link', 'mentor_guide')}>
+                        Read the complete Mentor Guide
+                      </Link>
+                    </Typography>
+                  )}
+
+                  <Accordion
+                    expanded={expandedRole === key}
+                    onChange={handleExpandRole(key)}
+                    elevation={0}
+                    sx={{
+                      '&:before': { display: 'none' },
+                      bgcolor: 'transparent',
+                    }}
+                  >
+                    <AccordionSummary
+                      expandIcon={<ExpandMoreRounded />}
+                      sx={{ px: 0, minHeight: 'auto', '& .MuiAccordionSummary-content': { my: 1 } }}
+                    >
+                      <Typography variant="subtitle2" color={`${roleType.color}.main`}>
+                        View Specializations ({roleType.roles.length})
+                      </Typography>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ px: 0 }}>
+                      <Grid container spacing={2}>
+                        {roleType.roles.map((role) => (
+                          <Grid size={{ xs: 12 }} key={role.title}>
+                            <Box sx={{
+                              p: 2,
+                              borderRadius: 1,
+                              bgcolor: 'grey.50',
+                              border: '1px solid',
+                              borderColor: 'grey.200',
+                            }}>
+                              <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                                <Box sx={{ color: `${roleType.color}.main`, mr: 1, display: 'flex' }}>
+                                  {role.icon}
+                                </Box>
+                                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                                  {role.title}
+                                </Typography>
+                              </Box>
+                              <Typography variant="body2" sx={{ mb: 1.5, color: 'text.secondary' }}>
+                                {role.description}
+                              </Typography>
+                              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                                {role.skills.map((skill) => (
+                                  <Chip
+                                    key={skill}
+                                    label={skill}
+                                    size="small"
+                                    color={roleType.color}
+                                    variant="outlined"
+                                  />
+                                ))}
+                              </Box>
+                            </Box>
+                          </Grid>
+                        ))}
+                      </Grid>
+                    </AccordionDetails>
+                  </Accordion>
                 </CardContent>
               </Card>
             </Grid>
           ))}
         </Grid>
+      </Container>
 
-        {/* How to Get Started */}
-        <Typography variant="h2" sx={{ fontSize: "2em", mb: 3 }}>
-          How to Get Started
-        </Typography>
-        <Grid container spacing={3} sx={{ mb: 5 }}>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ textAlign: 'center', height: '100%' }}>
-              <CardContent>
-                <Typography variant="h3" sx={{ fontSize: "3em", mb: 2, color: 'primary.main' }}>
-                  1
-                </Typography>
-                <Typography variant="h6" sx={{ mb: 2 }}>
-                  Choose Your Role
-                </Typography>
-                <Typography variant="body1">
-                  Decide if you want to be a Hacker (build), Mentor (guide), Volunteer (support), or Judge (evaluate)
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ textAlign: 'center', height: '100%' }}>
-              <CardContent>
-                <Typography variant="h3" sx={{ fontSize: "3em", mb: 2, color: 'secondary.main' }}>
-                  2
-                </Typography>
-                <Typography variant="h6" sx={{ mb: 2 }}>
-                  Find an Event
-                </Typography>
-                <Typography variant="body1">
-                  Browse upcoming hackathons and apply for the role that fits your skills
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ textAlign: 'center', height: '100%' }}>
-              <CardContent>
-                <Typography variant="h3" sx={{ fontSize: "3em", mb: 2, color: 'success.main' }}>
-                  3
-                </Typography>
-                <Typography variant="h6" sx={{ mb: 2 }}>
-                  Make Impact
-                </Typography>
-                <Typography variant="body1">
-                  Join the event and help create technology solutions that make a real difference
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size="auto">
-            <Button
-              variant="contained"
-              color="primary"
-              href="/onboarding"
-              style={{ fontSize: "1.1em" }}
-            >
-              Start Onboarding
-            </Button>
-          </Grid>
-        </Grid>
-
-        {/* Additional Resources */}
-        <Paper sx={{ p: 3, mb: 4, bgcolor: 'grey.50' }}>
-          <Typography variant="h2" sx={{ fontSize: "1.8em", mb: 2 }}>
+      {/* Additional Resources */}
+      <Container maxWidth="lg">
+        <Paper sx={{ p: 3, mb: 5, bgcolor: 'grey.50' }}>
+          <Typography variant="h2" sx={{ fontSize: '1.8em', mb: 2 }}>
             Additional Ways to Support Opportunity Hack
           </Typography>
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-              <Button 
-                variant="outlined" 
+              <Button
+                variant="outlined"
                 fullWidth
                 href="/about/judges"
                 startIcon={<EmojiEventsRounded />}
+                onClick={() => track('resource_link', 'become_judge')}
               >
                 Become a Judge
               </Button>
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-              <Button 
-                variant="outlined" 
+              <Button
+                variant="outlined"
                 fullWidth
                 href="/sponsor"
                 startIcon={<WorkRounded />}
+                onClick={() => track('resource_link', 'sponsor')}
               >
                 Sponsor Us
               </Button>
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-              <Button 
-                variant="outlined" 
+              <Button
+                variant="outlined"
                 fullWidth
                 href="/about/success-stories"
                 startIcon={<SchoolRounded />}
+                onClick={() => track('resource_link', 'success_stories')}
               >
                 Success Stories
               </Button>
             </Grid>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-              <Button 
-                variant="outlined" 
+              <Button
+                variant="outlined"
                 fullWidth
                 href="/nonprofits"
                 startIcon={<PeopleRounded />}
+                onClick={() => track('resource_link', 'view_projects')}
               >
                 View Projects
               </Button>
             </Grid>
           </Grid>
         </Paper>
+      </Container>
 
-        {/* Call to Action */}
-        <Box sx={{ textAlign: 'center', mb: 4 }}>
-          <Typography variant="h2" sx={{ fontSize: "2em", mb: 2 }}>
+      {/* Final CTA */}
+      <Box sx={{
+        background: 'linear-gradient(135deg, #1976d2 0%, #42a5f5 100%)',
+        color: 'white',
+        py: 8,
+        textAlign: 'center',
+      }}>
+        <Container maxWidth="md">
+          <Typography variant="h3" sx={{ fontWeight: 700, mb: 2, fontSize: { xs: '1.8rem', md: '2.5rem' } }}>
             Ready to Make a Difference?
           </Typography>
-          <Typography variant="body1" sx={{ fontSize: "1.2em", mb: 3, maxWidth: '600px', mx: 'auto' }}>
-            Join thousands of developers, designers, mentors, judges, and volunteers who are using their skills 
-            to create positive change in the world through technology.
+          <Typography variant="h6" sx={{ mb: 4, opacity: 0.9 }}>
+            Join thousands of volunteers using their skills for social good.
           </Typography>
-          
           <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
             <Button
               variant="contained"
               size="large"
-              color="primary"
+              sx={{
+                bgcolor: 'white',
+                color: 'primary.main',
+                fontWeight: 700,
+                '&:hover': { bgcolor: 'grey.100' },
+              }}
               href="/hack"
-              sx={{ fontSize: "1.1em" }}
+              onClick={() => track('final_cta', 'find_event')}
             >
               Find an Event
             </Button>
             <Button
-              variant="contained"
+              variant="outlined"
               size="large"
-              color="secondary"
+              sx={{
+                borderColor: 'white',
+                color: 'white',
+                '&:hover': { borderColor: 'grey.200', bgcolor: 'rgba(255,255,255,0.1)' },
+              }}
               href="/signup"
-              sx={{ fontSize: "1.1em" }}
+              onClick={() => track('final_cta', 'join_slack')}
             >
               Join Slack Community
             </Button>
             <Button
               variant="outlined"
               size="large"
-              href="/profile"
-              sx={{ fontSize: "1.1em" }}
+              sx={{
+                borderColor: 'white',
+                color: 'white',
+                '&:hover': { borderColor: 'grey.200', bgcolor: 'rgba(255,255,255,0.1)' },
+              }}
+              href="/onboarding"
+              onClick={() => track('final_cta', 'start_onboarding')}
             >
-              Update Profile
+              Start Onboarding
             </Button>
           </Box>
-        </Box>
+        </Container>
       </Box>
     </>
   );
@@ -734,7 +680,7 @@ const VolunteerPage = () => {
 
 export default VolunteerPage;
 
-export const getStaticProps = async () => {    
+export const getStaticProps = async () => {
     const title = "How to Get Involved - Hacker, Mentor, or Volunteer | Opportunity Hack";
     const description = "Join Opportunity Hack and make a difference! Whether you're a developer who wants to hack solutions, an experienced professional ready to mentor teams, or someone who loves supporting events, we have the perfect volunteer role for you.";
     return {
@@ -765,7 +711,7 @@ export const getStaticProps = async () => {
                     property: "og:description",
                     content: description,
                     key: "ogdescription"
-                },                                
+                },
                 {
                     name: "image",
                     property: "og:image",
@@ -826,7 +772,7 @@ export const getStaticProps = async () => {
                 },
                 {
                     name: "twitter:image:alt",
-                    property: "twitter:image:alt",                    
+                    property: "twitter:image:alt",
                     content: "Volunteers, mentors, and hackers collaborating at an Opportunity Hack event to build technology solutions for nonprofits",
                     key: "twitterimagealt"
                 },
@@ -835,7 +781,7 @@ export const getStaticProps = async () => {
                     property: "twitter:creator",
                     content: "@opportunityhack",
                     key: "twittercreator"
-                }               
+                }
             ],
             structuredData: {
                 "@context": "https://schema.org",
@@ -899,14 +845,14 @@ export const getStaticProps = async () => {
                                 "description": "Developers and designers who build technology solutions for nonprofits"
                             },
                             {
-                                "@type": "ListItem", 
+                                "@type": "ListItem",
                                 "position": 2,
                                 "name": "Mentor - Guide Teams",
                                 "description": "Experienced professionals who guide teams and provide technical expertise"
                             },
                             {
                                 "@type": "ListItem",
-                                "position": 3, 
+                                "position": 3,
                                 "name": "Volunteer - Support Events",
                                 "description": "Event coordinators and support staff who help make hackathons successful"
                             },
@@ -921,7 +867,7 @@ export const getStaticProps = async () => {
                                 "position": 5,
                                 "name": "Sponsor - Support Our Mission",
                                 "description": "Organizations and individuals who sponsor Opportunity Hack events and initiatives"
-                            }                                                
+                            }
                         ]
                     }
                 ]


### PR DESCRIPTION
## Summary
- **Visual redesign of `/volunteer` page**: gradient hero with glassmorphism impact stats, 2x2 role cards with colored borders and expandable specializations, gradient CTA — reduced from 9 sections to 5
- **Event tracking instrumented across 10 high-traffic pages** that previously had zero GA/Facebook Pixel tracking, covering ~600+ weekly organic search views

## Pages Instrumented

| Page | Weekly Views | Events Added |
|------|-------------|--------------|
| `/hack` | 147 | 6 CTA clicks |
| `/hack/[event_id]/judge-application` | 132 | Step progression + submit |
| `/volunteer` (redesigned) | 11 | Hero CTAs, role expansion, guide links, final CTAs |
| Homepage LeadForm | 243 | Newsletter signup funnel |
| `/onboarding` | 18 | Step navigation + completion |
| `/hack/[event_id]/mentor-application` | 14 | Step progression + submit |
| `/profile` | 15 | Tab changes |
| `/hack/[event_id]/volunteer-application` | 5 | Step progression + submit |
| `/hack/[event_id]/hacker-application` | — | Step progression + submit |
| `/contact` | 4 | Form submit success/error |
| `/judge` | 2 | Start judging click |

## Event Naming Convention
All events use `{page_prefix}_{interaction}` pattern with `event_label` and `page` params for easy GA filtering.

## Test plan
- [ ] Visit `/volunteer` — confirm gradient hero, impact stats, 2x2 role cards, expandable specializations, gradient CTA
- [ ] Visit `/hack` — click CTAs, confirm events fire in browser Network tab (filter `collect`)
- [ ] Visit any application form — navigate steps, confirm `_step` events fire
- [ ] Submit LeadForm on homepage — confirm `lead_form_submit` event fires
- [ ] Visit `/onboarding` — navigate steps, confirm tracking
- [ ] `npm run build` passes (network errors from backend are expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)