### PR TITLE
Persist template placeholder values across sessions

### DIFF
--- a/src/components/admin/BatchEmailDialog.js
+++ b/src/components/admin/BatchEmailDialog.js
@@ -47,6 +47,7 @@ import {
   detectPlaceholders,
   PLACEHOLDER_LABELS
 } from '../../lib/messageTemplates';
+import useSavedPlaceholders from '../../hooks/use-saved-placeholders';
 
 const StyledDialog = styled(Dialog)(({ theme}) => ({
   '& .MuiDialog-paper': {
@@ -93,6 +94,9 @@ const BatchEmailDialog = ({
   const [testLoading, setTestLoading] = useState(false);
   const [placeholderValues, setPlaceholderValues] = useState({});
   const [detectedPlaceholders, setDetectedPlaceholders] = useState([]);
+  const [restoredFromSaved, setRestoredFromSaved] = useState(false);
+
+  const { savedValues, saveValues, clearValues, hasSavedValues } = useSavedPlaceholders(eventId, selectedTemplate?.id);
 
   // Filter eligible users when volunteers change based on context
   const eligibleUsers = isSelectedUsers
@@ -119,6 +123,7 @@ const BatchEmailDialog = ({
       setShowDetails(false);
       setPlaceholderValues({});
       setDetectedPlaceholders([]);
+      setRestoredFromSaved(false);
     } else if (!isSelectedUsers) {
       // Auto-suggest the appropriate denial template for not-selected users
       const templateId = volunteerType === 'judge' || volunteerType === 'judges'
@@ -129,14 +134,37 @@ const BatchEmailDialog = ({
         setSelectedTemplate(denialTemplate);
         // Use shared utility to prepare template message with placeholder replacements
         // Note: [VOLUNTEER_ID] and [VOLUNTEER_TYPE] will be replaced per-user when emails are sent
-        const message = prepareTemplateMessage(denialTemplate, {
+        let message = prepareTemplateMessage(denialTemplate, {
           eventId: eventId,
           volunteerType: recipientType
         });
-        setMessageText(message);
         setSubject(denialTemplate.title);
         setDetectedPlaceholders(detectPlaceholders(message));
-        setPlaceholderValues({});
+
+        // Check for saved placeholder values
+        const key = eventId && denialTemplate.id ? `ohack_placeholders_${eventId}_${denialTemplate.id}` : null;
+        let restored = null;
+        if (key) {
+          try {
+            const raw = localStorage.getItem(key);
+            if (raw) restored = JSON.parse(raw);
+          } catch { /* ignore */ }
+        }
+
+        if (restored && typeof restored === 'object' && Object.keys(restored).length > 0) {
+          setPlaceholderValues(restored);
+          setRestoredFromSaved(true);
+          for (const [name, val] of Object.entries(restored)) {
+            if (val) {
+              message = message.replaceAll(`[${name}]`, val);
+            }
+          }
+        } else {
+          setPlaceholderValues({});
+          setRestoredFromSaved(false);
+        }
+
+        setMessageText(message);
         setCurrentStep(1); // Skip template selection and go to review step
       }
     }
@@ -147,16 +175,40 @@ const BatchEmailDialog = ({
 
     // Use shared utility to prepare template message with placeholder replacements
     // Note: [VOLUNTEER_ID] and [VOLUNTEER_TYPE] will be replaced per-user when emails are sent
-    const message = prepareTemplateMessage(template, {
+    let message = prepareTemplateMessage(template, {
       eventId: eventId,
       volunteerType: recipientType
     });
 
-    setMessageText(message);
     setSubject(template.title);
     setCustomMessage(false);
-    setDetectedPlaceholders(detectPlaceholders(message));
-    setPlaceholderValues({});
+    const remaining = detectPlaceholders(message);
+    setDetectedPlaceholders(remaining);
+
+    // Check for saved placeholder values
+    const key = eventId && template?.id ? `ohack_placeholders_${eventId}_${template.id}` : null;
+    let restored = null;
+    if (key) {
+      try {
+        const raw = localStorage.getItem(key);
+        if (raw) restored = JSON.parse(raw);
+      } catch { /* ignore */ }
+    }
+
+    if (restored && typeof restored === 'object' && Object.keys(restored).length > 0) {
+      setPlaceholderValues(restored);
+      setRestoredFromSaved(true);
+      for (const [name, val] of Object.entries(restored)) {
+        if (val) {
+          message = message.replaceAll(`[${name}]`, val);
+        }
+      }
+    } else {
+      setPlaceholderValues({});
+      setRestoredFromSaved(false);
+    }
+
+    setMessageText(message);
     setCurrentStep(1);
   };
 
@@ -178,11 +230,14 @@ const BatchEmailDialog = ({
     setSubject('');
     setDetectedPlaceholders([]);
     setPlaceholderValues({});
+    setRestoredFromSaved(false);
   };
 
   const handlePlaceholderChange = (placeholderName, value) => {
     const newValues = { ...placeholderValues, [placeholderName]: value };
     setPlaceholderValues(newValues);
+    saveValues(newValues);
+    setRestoredFromSaved(false);
 
     // Rebuild message from template with all current placeholder values
     let message = prepareTemplateMessage(selectedTemplate, {
@@ -462,9 +517,35 @@ const BatchEmailDialog = ({
 
                 {selectedTemplate && detectedPlaceholders.length > 0 && (
                   <Box sx={{ mb: 2, p: 2, bgcolor: 'action.hover', borderRadius: 1 }}>
-                    <Typography variant="subtitle2" gutterBottom>
-                      This template requires event-specific details:
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="subtitle2">
+                          This template requires event-specific details:
+                        </Typography>
+                        {restoredFromSaved && (
+                          <Chip label="Restored from previous session" size="small" color="info" variant="outlined" />
+                        )}
+                      </Box>
+                      {hasSavedValues && (
+                        <Button
+                          size="small"
+                          variant="text"
+                          color="secondary"
+                          onClick={() => {
+                            clearValues();
+                            setPlaceholderValues({});
+                            setRestoredFromSaved(false);
+                            const message = prepareTemplateMessage(selectedTemplate, {
+                              eventId: eventId,
+                              volunteerType: recipientType
+                            });
+                            setMessageText(message);
+                          }}
+                        >
+                          Clear saved values
+                        </Button>
+                      )}
+                    </Box>
                     <Grid container spacing={2}>
                       {detectedPlaceholders.map((name) => {
                         const info = PLACEHOLDER_LABELS[name] || { label: name.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), example: '' };

--- a/src/components/admin/VolunteerCommunication.js
+++ b/src/components/admin/VolunteerCommunication.js
@@ -5,6 +5,7 @@ import {
   Card,
   CardContent,
   CardHeader,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -31,6 +32,7 @@ import {
   detectPlaceholders,
   PLACEHOLDER_LABELS
 } from '../../lib/messageTemplates';
+import useSavedPlaceholders from '../../hooks/use-saved-placeholders';
 
 
 const VolunteerCommunication = ({ 
@@ -52,6 +54,9 @@ const VolunteerCommunication = ({
   const [testLoading, setTestLoading] = useState(false);
   const [placeholderValues, setPlaceholderValues] = useState({});
   const [detectedPlaceholders, setDetectedPlaceholders] = useState([]);
+  const [restoredFromSaved, setRestoredFromSaved] = useState(false);
+
+  const { savedValues, saveValues, clearValues, hasSavedValues } = useSavedPlaceholders(eventId, selectedTemplate?.id);
 
   const handleSendMessage = async () => {
     if (!messageText.trim() || !volunteer) return;
@@ -166,19 +171,44 @@ const VolunteerCommunication = ({
     setSelectedTemplate(template);
 
     // Use shared utility to prepare template message with placeholder replacements
-    const message = prepareTemplateMessage(template, {
+    let message = prepareTemplateMessage(template, {
       eventId: eventId,
       volunteerId: volunteer?.id,
       volunteerType: volunteerType || volunteer?.type
     });
 
-    setMessageText(message);
     setCustomMessage(false);
 
     // Detect remaining placeholders that need manual input
     const remaining = detectPlaceholders(message);
     setDetectedPlaceholders(remaining);
-    setPlaceholderValues({});
+
+    // Check for saved placeholder values (hook will re-derive on next render,
+    // but we need the current template's saved values now)
+    const key = eventId && template?.id ? `ohack_placeholders_${eventId}_${template.id}` : null;
+    let restored = null;
+    if (key) {
+      try {
+        const raw = localStorage.getItem(key);
+        if (raw) restored = JSON.parse(raw);
+      } catch { /* ignore */ }
+    }
+
+    if (restored && typeof restored === 'object' && Object.keys(restored).length > 0) {
+      setPlaceholderValues(restored);
+      setRestoredFromSaved(true);
+      // Apply saved values to message
+      for (const [name, val] of Object.entries(restored)) {
+        if (val) {
+          message = message.replaceAll(`[${name}]`, val);
+        }
+      }
+    } else {
+      setPlaceholderValues({});
+      setRestoredFromSaved(false);
+    }
+
+    setMessageText(message);
   };
 
   const handleCustomMessageToggle = () => {
@@ -192,6 +222,8 @@ const VolunteerCommunication = ({
   const handlePlaceholderChange = (placeholderName, value) => {
     const newValues = { ...placeholderValues, [placeholderName]: value };
     setPlaceholderValues(newValues);
+    saveValues(newValues);
+    setRestoredFromSaved(false);
 
     // Rebuild message from template with all current placeholder values
     let message = prepareTemplateMessage(selectedTemplate, {
@@ -352,9 +384,37 @@ const VolunteerCommunication = ({
                 
                 {selectedTemplate && detectedPlaceholders.length > 0 && (
                   <Box sx={{ mb: 2, p: 2, bgcolor: 'action.hover', borderRadius: 1 }}>
-                    <Typography variant="subtitle2" gutterBottom>
-                      This template requires event-specific details:
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="subtitle2">
+                          This template requires event-specific details:
+                        </Typography>
+                        {restoredFromSaved && (
+                          <Chip label="Restored from previous session" size="small" color="info" variant="outlined" />
+                        )}
+                      </Box>
+                      {hasSavedValues && (
+                        <Button
+                          size="small"
+                          variant="text"
+                          color="secondary"
+                          onClick={() => {
+                            clearValues();
+                            setPlaceholderValues({});
+                            setRestoredFromSaved(false);
+                            // Rebuild message without placeholder values
+                            const message = prepareTemplateMessage(selectedTemplate, {
+                              eventId: eventId,
+                              volunteerId: volunteer?.id,
+                              volunteerType: volunteerType || volunteer?.type
+                            });
+                            setMessageText(message);
+                          }}
+                        >
+                          Clear saved values
+                        </Button>
+                      )}
+                    </Box>
                     <Grid container spacing={2}>
                       {detectedPlaceholders.map((name) => {
                         const info = PLACEHOLDER_LABELS[name] || { label: name.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), example: '' };
@@ -585,9 +645,37 @@ const VolunteerCommunication = ({
                 
                 {selectedTemplate && detectedPlaceholders.length > 0 && (
                   <Box sx={{ mb: 2, p: 2, bgcolor: 'action.hover', borderRadius: 1 }}>
-                    <Typography variant="subtitle2" gutterBottom>
-                      This template requires event-specific details:
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="subtitle2">
+                          This template requires event-specific details:
+                        </Typography>
+                        {restoredFromSaved && (
+                          <Chip label="Restored from previous session" size="small" color="info" variant="outlined" />
+                        )}
+                      </Box>
+                      {hasSavedValues && (
+                        <Button
+                          size="small"
+                          variant="text"
+                          color="secondary"
+                          onClick={() => {
+                            clearValues();
+                            setPlaceholderValues({});
+                            setRestoredFromSaved(false);
+                            // Rebuild message without placeholder values
+                            const message = prepareTemplateMessage(selectedTemplate, {
+                              eventId: eventId,
+                              volunteerId: volunteer?.id,
+                              volunteerType: volunteerType || volunteer?.type
+                            });
+                            setMessageText(message);
+                          }}
+                        >
+                          Clear saved values
+                        </Button>
+                      )}
+                    </Box>
                     <Grid container spacing={2}>
                       {detectedPlaceholders.map((name) => {
                         const info = PLACEHOLDER_LABELS[name] || { label: name.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), example: '' };

--- a/src/hooks/use-saved-placeholders.js
+++ b/src/hooks/use-saved-placeholders.js
@@ -1,0 +1,56 @@
+import { useState, useCallback, useMemo } from 'react';
+
+const STORAGE_PREFIX = 'ohack_placeholders_';
+
+function getStorageKey(eventId, templateId) {
+  if (!eventId || !templateId) return null;
+  return `${STORAGE_PREFIX}${eventId}_${templateId}`;
+}
+
+export default function useSavedPlaceholders(eventId, templateId) {
+  const storageKey = getStorageKey(eventId, templateId);
+
+  const loadValues = useCallback(() => {
+    if (!storageKey) return null;
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, [storageKey]);
+
+  const savedValues = useMemo(() => loadValues(), [loadValues]);
+  const hasSavedValues = savedValues !== null && Object.keys(savedValues).length > 0;
+
+  const saveValues = useCallback((values) => {
+    if (!storageKey) return;
+    try {
+      // Only save if there are non-empty values
+      const nonEmpty = Object.fromEntries(
+        Object.entries(values).filter(([, v]) => v)
+      );
+      if (Object.keys(nonEmpty).length > 0) {
+        localStorage.setItem(storageKey, JSON.stringify(nonEmpty));
+      }
+    } catch {
+      // localStorage full or unavailable — silently ignore
+    }
+  }, [storageKey]);
+
+  const clearValues = useCallback(() => {
+    if (!storageKey) return;
+    try {
+      localStorage.removeItem(storageKey);
+    } catch {
+      // silently ignore
+    }
+  }, [storageKey]);
+
+  return { savedValues, saveValues, clearValues, hasSavedValues };
+}


### PR DESCRIPTION
## Summary
- Adds `useSavedPlaceholders` hook that persists placeholder field values to `localStorage`, scoped by `eventId` and `templateId`
- Both `VolunteerCommunication` and `BatchEmailDialog` auto-populate placeholder fields from saved values when a template is selected
- Shows a "Restored from previous session" chip when values are loaded, and a "Clear saved values" button to reset

## Test plan
- [ ] Select a volunteer, open communication dialog, choose a template with placeholders (e.g., "Judge Application Approved - Please Confirm Travel")
- [ ] Fill in placeholder fields, close dialog, reopen with a different volunteer and same template — fields should auto-populate
- [ ] Click "Clear saved values" — fields should empty and message resets to template defaults
- [ ] Verify same behavior works in batch email dialog
- [ ] Verify different templates maintain separate saved values
- [ ] Verify different events maintain separate saved values

🤖 Generated with [Claude Code](https://claude.com/claude-code)