### PR TITLE
Add store order management and Stripe webhook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10252,6 +10252,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/Hackathon/FloatingNavigation.js
+++ b/src/components/Hackathon/FloatingNavigation.js
@@ -1,14 +1,16 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
-  Fab,
   SpeedDial,
   SpeedDialAction,
   SpeedDialIcon,
-  Tooltip,
   Box,
   useTheme,
   useMediaQuery,
-  Typography
+  Typography,
+  Paper,
+  Fade,
+  IconButton,
+  Backdrop,
 } from "@mui/material";
 import {
   Assignment as AssignmentIcon,
@@ -22,31 +24,49 @@ import {
   Gavel as JudgeIcon,
   Help as HelpIcon,
   KeyboardArrowUp as TopIcon,
-  Menu as MenuIcon
+  Menu as MenuIcon,
+  Close as CloseIcon,
+  Keyboard as KeyboardIcon,
 } from "@mui/icons-material";
 import { trackEvent } from "../../lib/ga";
 
 const sectionConfig = [
-  { id: "applications", name: "Apply Now", icon: <AssignmentIcon />, priority: 1, shortcut: "A" },
-  { id: "nonprofit", name: "Projects", icon: <BusinessIcon />, priority: 2, shortcut: "P" },
-  { id: "teams", name: "Teams", icon: <GroupIcon />, priority: 3, shortcut: "T" },
-  { id: "stats", name: "Stats", icon: <BarChartIcon />, priority: 4, shortcut: "S" },
-  { id: "countdown", name: "Countdown", icon: <TimerIcon />, priority: 5, shortcut: "C" },
-  { id: "hacker", name: "Hackers", icon: <CodeIcon />, priority: 6, shortcut: "H" },
-  { id: "volunteer", name: "Volunteers", icon: <VolunteerIcon />, priority: 7, shortcut: "V" },
-  { id: "mentor", name: "Mentors", icon: <MentorIcon />, priority: 8, shortcut: "M" },
-  { id: "judge", name: "Judges", icon: <JudgeIcon />, priority: 9, shortcut: "J" },
-  { id: "faq", name: "FAQ", icon: <HelpIcon />, priority: 10, shortcut: "F" },
+  { id: "applications", name: "Apply Now", icon: <AssignmentIcon />, shortcut: "A" },
+  { id: "nonprofit", name: "Projects", icon: <BusinessIcon />, shortcut: "P" },
+  { id: "teams", name: "Teams", icon: <GroupIcon />, shortcut: "T" },
+  { id: "stats", name: "Stats", icon: <BarChartIcon />, shortcut: "S" },
+  { id: "countdown", name: "Countdown", icon: <TimerIcon />, shortcut: "C" },
+  { id: "hacker", name: "Hackers", icon: <CodeIcon />, shortcut: "H" },
+  { id: "volunteer", name: "Volunteers", icon: <VolunteerIcon />, shortcut: "V" },
+  { id: "mentor", name: "Mentors", icon: <MentorIcon />, shortcut: "M" },
+  { id: "judge", name: "Judges", icon: <JudgeIcon />, shortcut: "J" },
+  { id: "faq", name: "FAQ", icon: <HelpIcon />, shortcut: "F" },
 ];
+
+// Check if the user is typing in an input, textarea, or contentEditable
+function isTyping() {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    el.isContentEditable
+  );
+}
 
 const FloatingNavigation = () => {
   const [open, setOpen] = useState(false);
   const [activeSection, setActiveSection] = useState("");
   const [isVisible, setIsVisible] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+  const [flashSection, setFlashSection] = useState("");
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const flashTimer = useRef(null);
 
-  // Show/hide based on scroll position
+  // Show/hide FAB based on scroll position
   useEffect(() => {
     const toggleVisibility = () => {
       setIsVisible(window.pageYOffset > 300);
@@ -56,282 +76,404 @@ const FloatingNavigation = () => {
     return () => window.removeEventListener("scroll", toggleVisibility);
   }, []);
 
-  // Track active section based on scroll position
+  // Track active section via IntersectionObserver
   useEffect(() => {
-    const observerOptions = {
-      root: null,
-      rootMargin: "-20% 0px -70% 0px",
-      threshold: 0.1
-    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        });
+      },
+      { root: null, rootMargin: "-20% 0px -70% 0px", threshold: 0.1 }
+    );
 
-    const observerCallback = (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setActiveSection(entry.target.id);
-        }
-      });
-    };
-
-    const observer = new IntersectionObserver(observerCallback, observerOptions);
-    
     sectionConfig.forEach((section) => {
       const element = document.getElementById(section.id);
-      if (element) {
-        observer.observe(element);
-      }
+      if (element) observer.observe(element);
     });
 
     return () => observer.disconnect();
   }, []);
 
-  // Keyboard shortcuts when menu is open
-  useEffect(() => {
-    const handleKeyPress = (event) => {
-      if (!open) return;
+  const navigateToSection = useCallback((sectionId, sectionName) => {
+    const element = document.getElementById(sectionId);
+    if (!element) return;
 
-      // Prevent default behavior for our shortcuts
-      const key = event.key.toUpperCase();
-      
-      // Handle Escape key to close menu
-      if (key === 'ESCAPE') {
-        setOpen(false);
+    setOpen(false);
+    setShowHelp(false);
+
+    element.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+      inline: "nearest",
+    });
+
+    // Brief flash highlight on the target section
+    setFlashSection(sectionId);
+    clearTimeout(flashTimer.current);
+    flashTimer.current = setTimeout(() => setFlashSection(""), 1500);
+
+    if (window.history?.pushState) {
+      window.history.pushState(null, "", `#${sectionId}`);
+    }
+
+    trackEvent?.({
+      action: "floating_nav_click",
+      params: { section_name: sectionName },
+    });
+  }, []);
+
+  const handleBackToTop = useCallback(() => {
+    setOpen(false);
+    setShowHelp(false);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+
+    if (window.history?.pushState) {
+      window.history.pushState(null, "", window.location.pathname);
+    }
+
+    trackEvent?.({
+      action: "back_to_top",
+      params: { source: "floating_nav" },
+    });
+  }, []);
+
+  // Flash highlight effect — inject a brief outline on the target section element
+  useEffect(() => {
+    if (!flashSection) return;
+    const el = document.getElementById(flashSection);
+    if (!el) return;
+
+    el.style.transition = "box-shadow 0.3s ease";
+    el.style.boxShadow = `0 0 0 3px ${theme.palette.primary.main}40`;
+    const timer = setTimeout(() => {
+      el.style.boxShadow = "none";
+    }, 1200);
+    return () => {
+      clearTimeout(timer);
+      el.style.boxShadow = "none";
+    };
+  }, [flashSection, theme]);
+
+  // Global keyboard shortcuts — work without opening the menu
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      // Never capture when user is typing in a form field
+      if (isTyping()) return;
+
+      // Don't capture if modifier keys are held (allow browser shortcuts)
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      const key = event.key;
+
+      // ? or / toggles help overlay
+      if (key === "?" || key === "/") {
         event.preventDefault();
+        setShowHelp((prev) => !prev);
         return;
       }
 
-      // Handle number keys for top 10 sections
-      if (key >= '1' && key <= '9') {
-        const index = parseInt(key) - 1;
-        if (index < sectionConfig.length) {
-          const section = sectionConfig[index];
-          handleSectionClick(section.id, section.name);
+      // Escape closes help and menu
+      if (key === "Escape") {
+        if (showHelp || open) {
           event.preventDefault();
+          setShowHelp(false);
+          setOpen(false);
         }
         return;
       }
 
-      // Handle '0' for the 10th section (FAQ)
-      if (key === '0' && sectionConfig.length >= 10) {
-        const section = sectionConfig[9]; // FAQ is 10th item (index 9)
-        handleSectionClick(section.id, section.name);
+      // B or Home = back to top
+      if (key.toUpperCase() === "B" || key === "Home") {
         event.preventDefault();
+        handleBackToTop();
         return;
       }
 
-      // Handle letter shortcuts
-      const section = sectionConfig.find(s => s.shortcut === key);
-      if (section) {
-        handleSectionClick(section.id, section.name);
+      // Number keys 1-9 and 0 for sections
+      if (key >= "1" && key <= "9") {
+        const index = parseInt(key) - 1;
+        if (index < sectionConfig.length) {
+          event.preventDefault();
+          const section = sectionConfig[index];
+          navigateToSection(section.id, section.name);
+        }
+        return;
+      }
+      if (key === "0" && sectionConfig.length >= 10) {
         event.preventDefault();
+        const section = sectionConfig[9];
+        navigateToSection(section.id, section.name);
+        return;
       }
 
-      // Handle special shortcuts
-      if (key === 'B' || key === 'HOME') {
-        handleBackToTop();
+      // Letter shortcuts
+      const upper = key.toUpperCase();
+      const section = sectionConfig.find((s) => s.shortcut === upper);
+      if (section) {
         event.preventDefault();
+        navigateToSection(section.id, section.name);
       }
     };
 
-    if (open) {
-      document.addEventListener('keydown', handleKeyPress);
-      return () => document.removeEventListener('keydown', handleKeyPress);
-    }
-  }, [open]);
-
-  const handleSectionClick = (sectionId, sectionName) => {
-    const element = document.getElementById(sectionId);
-    if (element) {
-      // Close the speed dial first
-      setOpen(false);
-      
-      // Small delay to allow speed dial to close, then scroll
-      setTimeout(() => {
-        element.scrollIntoView({ 
-          behavior: "smooth", 
-          block: "start",
-          inline: "nearest"
-        });
-        
-        // Update URL hash
-        if (window.history && window.history.pushState) {
-          window.history.pushState(null, "", `#${sectionId}`);
-        }
-        
-        // Track the event
-        if (typeof trackEvent === 'function') {
-          trackEvent({
-            action: "floating_nav_click",
-            params: { section_name: sectionName },
-          });
-        }
-      }, 100);
-    } else {
-      console.warn(`Section element with id "${sectionId}" not found`);
-      setOpen(false);
-    }
-  };
-
-  const handleBackToTop = () => {
-    setOpen(false);
-    
-    setTimeout(() => {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-      
-      if (window.history && window.history.pushState) {
-        window.history.pushState(null, "", window.location.pathname);
-      }
-      
-      if (typeof trackEvent === 'function') {
-        trackEvent({
-          action: "back_to_top",
-          params: { source: "floating_nav" },
-        });
-      }
-    }, 100);
-  };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, showHelp, navigateToSection, handleBackToTop]);
 
   if (!isVisible) return null;
 
-  // Show only top sections on mobile - create a new array instead of mutating
   const visibleSections = isMobile ? sectionConfig.slice(0, 6) : sectionConfig;
-  
-  // Create reversed array for display order (SpeedDial shows items bottom to top)
   const displaySections = [...visibleSections].reverse();
 
   return (
-    <Box
-      sx={{
-        position: "fixed",
-        bottom: 24,
-        right: 24,
-        zIndex: 1000,
-      }}
-    >
-      <SpeedDial
-        ariaLabel="Section navigation - Press keys when open for shortcuts"
-        sx={{
-          "& .MuiSpeedDial-fab": {
-            bgcolor: "primary.main",
-            "&:hover": {
-              bgcolor: "primary.dark",
-            },
-            width: 56,
-            height: 56,
-          },
-        }}
-        icon={<SpeedDialIcon icon={<MenuIcon />} openIcon={<TopIcon />} />}
-        onClose={() => setOpen(false)}
-        onOpen={() => setOpen(true)}
-        open={open}
-        direction="up"
+    <>
+      {/* Keyboard shortcut help dialog */}
+      <Backdrop
+        open={showHelp}
+        onClick={() => setShowHelp(false)}
+        sx={{ zIndex: 1200, backdropFilter: "blur(2px)" }}
       >
-        {/* Back to Top Action */}
-        <SpeedDialAction
-          key="top"
-          icon={<TopIcon />}
-          tooltipTitle="Back to Top (B)"
-          tooltipPlacement="left"
-          onClick={handleBackToTop}
-          sx={{
-            bgcolor: "secondary.main",
-            "&:hover": {
-              bgcolor: "secondary.dark",
-            },
-            position: 'relative',
-            '&::after': {
-              content: '"B"',
-              position: 'absolute',
-              bottom: -2,
-              right: -2,
-              backgroundColor: 'rgba(0,0,0,0.7)',
-              color: 'white',
-              fontSize: '10px',
-              fontWeight: 'bold',
-              padding: '1px 3px',
-              borderRadius: '2px',
-              lineHeight: 1,
-            }
-          }}
-        />
+        <Fade in={showHelp}>
+          <Paper
+            elevation={8}
+            onClick={(e) => e.stopPropagation()}
+            sx={{
+              p: 3,
+              maxWidth: 420,
+              width: "90%",
+              borderRadius: 3,
+              position: "relative",
+            }}
+          >
+            <IconButton
+              onClick={() => setShowHelp(false)}
+              size="small"
+              sx={{ position: "absolute", top: 8, right: 8 }}
+              aria-label="Close keyboard shortcuts"
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
 
-        {/* Section Actions */}
-        {displaySections.map((section, index) => {
-          const isActive = activeSection === section.id;
-          const reverseIndex = displaySections.length - index;
-          const shortcutKey = section.shortcut || reverseIndex.toString();
-          
-          return (
-            <SpeedDialAction
-              key={section.id}
-              icon={section.icon}
-              tooltipTitle={`${section.name} (${shortcutKey})`}
-              tooltipPlacement="left"
-              onClick={() => handleSectionClick(section.id, section.name)}
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+              <KeyboardIcon color="primary" />
+              <Typography variant="h6" component="h2">
+                Keyboard Shortcuts
+              </Typography>
+            </Box>
+
+            <Box
+              component="table"
               sx={{
-                bgcolor: isActive ? "primary.light" : "background.paper",
-                color: isActive ? "primary.contrastText" : "text.primary",
-                "&:hover": {
-                  bgcolor: isActive ? "primary.main" : "action.hover",
-                },
-                ...(isActive && {
-                  boxShadow: theme.shadows[8],
-                  transform: "scale(1.1)",
-                }),
-                position: 'relative',
-                '&::after': {
-                  content: `"${shortcutKey}"`,
-                  position: 'absolute',
-                  bottom: -2,
-                  right: -2,
-                  backgroundColor: 'rgba(0,0,0,0.7)',
-                  color: 'white',
-                  fontSize: '10px',
-                  fontWeight: 'bold',
-                  padding: '1px 3px',
-                  borderRadius: '2px',
-                  lineHeight: 1,
-                }
+                width: "100%",
+                borderCollapse: "collapse",
+                "& td": { py: 0.5, px: 1, verticalAlign: "middle" },
+                "& td:first-of-type": { whiteSpace: "nowrap", width: 60 },
               }}
-            />
-          );
-        })}
-      </SpeedDial>
+            >
+              <tbody>
+                <tr>
+                  <td colSpan={2}>
+                    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 700 }}>
+                      Sections
+                    </Typography>
+                  </td>
+                </tr>
+                {sectionConfig.map((section, i) => (
+                  <tr key={section.id}>
+                    <td>
+                      <Box sx={{ display: "flex", gap: 0.5 }}>
+                        <Kbd>{section.shortcut}</Kbd>
+                        <Typography variant="caption" color="text.secondary">
+                          or
+                        </Typography>
+                        <Kbd>{i < 9 ? i + 1 : 0}</Kbd>
+                      </Box>
+                    </td>
+                    <td>
+                      <Typography variant="body2">{section.name}</Typography>
+                    </td>
+                  </tr>
+                ))}
+                <tr>
+                  <td colSpan={2}>
+                    <Box sx={{ my: 1, borderTop: "1px solid", borderColor: "divider" }} />
+                    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 700 }}>
+                      Navigation
+                    </Typography>
+                  </td>
+                </tr>
+                <tr>
+                  <td><Kbd>B</Kbd></td>
+                  <td><Typography variant="body2">Back to top</Typography></td>
+                </tr>
+                <tr>
+                  <td><Kbd>?</Kbd></td>
+                  <td><Typography variant="body2">Toggle this help</Typography></td>
+                </tr>
+                <tr>
+                  <td><Kbd>Esc</Kbd></td>
+                  <td><Typography variant="body2">Close menu / help</Typography></td>
+                </tr>
+              </tbody>
+            </Box>
+          </Paper>
+        </Fade>
+      </Backdrop>
 
-      {/* Keyboard shortcut help overlay when menu is open */}
-      {open && (
-        <Box
+      {/* Floating navigation */}
+      <Box
+        sx={{
+          position: "fixed",
+          bottom: 24,
+          right: 24,
+          zIndex: 1000,
+        }}
+      >
+        {/* Help hint — shown briefly or on hover, hidden on mobile */}
+        {!isMobile && !open && (
+          <Fade in>
+            <Typography
+              variant="caption"
+              onClick={() => setShowHelp(true)}
+              sx={{
+                position: "absolute",
+                bottom: 64,
+                right: 4,
+                bgcolor: "rgba(0,0,0,0.7)",
+                color: "white",
+                px: 1,
+                py: 0.25,
+                borderRadius: 1,
+                cursor: "pointer",
+                userSelect: "none",
+                fontSize: "11px",
+                opacity: 0.7,
+                transition: "opacity 0.2s",
+                "&:hover": { opacity: 1 },
+              }}
+            >
+              Press <Kbd small>?</Kbd> for shortcuts
+            </Typography>
+          </Fade>
+        )}
+
+        <SpeedDial
+          ariaLabel="Navigate to page sections"
           sx={{
-            position: 'fixed',
-            bottom: 100,
-            right: 24,
-            backgroundColor: 'rgba(0,0,0,0.8)',
-            color: 'white',
-            padding: 2,
-            borderRadius: 1,
-            fontSize: '12px',
-            maxWidth: 200,
-            zIndex: 999,
+            "& .MuiSpeedDial-fab": {
+              bgcolor: "primary.main",
+              "&:hover": { bgcolor: "primary.dark" },
+              width: 56,
+              height: 56,
+            },
           }}
+          icon={<SpeedDialIcon icon={<MenuIcon />} openIcon={<TopIcon />} />}
+          onClose={() => setOpen(false)}
+          onOpen={() => setOpen(true)}
+          open={open}
+          direction="up"
         >
-          <Typography variant="caption" component="div" sx={{ fontWeight: 'bold', mb: 1 }}>
-            Keyboard Shortcuts:
-          </Typography>
-          <Typography variant="caption" component="div">
-            • Press letter keys (A, P, T, etc.)
-          </Typography>
-          <Typography variant="caption" component="div">
-            • Press numbers 1-9, 0
-          </Typography>
-          <Typography variant="caption" component="div">
-            • Press B for Back to Top
-          </Typography>
-          <Typography variant="caption" component="div">
-            • Press Escape to close
-          </Typography>
-        </Box>
-      )}
-    </Box>
+          {/* Back to Top */}
+          <SpeedDialAction
+            key="top"
+            icon={<TopIcon />}
+            tooltipTitle={isMobile ? "Top" : "Back to Top (B)"}
+            tooltipPlacement="left"
+            tooltipOpen={isMobile}
+            onClick={handleBackToTop}
+            sx={{
+              bgcolor: "secondary.main",
+              color: "secondary.contrastText",
+              "&:hover": { bgcolor: "secondary.dark" },
+            }}
+          />
+
+          {/* Section Actions */}
+          {displaySections.map((section) => {
+            const isActive = activeSection === section.id;
+
+            return (
+              <SpeedDialAction
+                key={section.id}
+                icon={section.icon}
+                tooltipTitle={
+                  isMobile
+                    ? section.name
+                    : `${section.name} (${section.shortcut})`
+                }
+                tooltipPlacement="left"
+                tooltipOpen={isMobile}
+                onClick={() => navigateToSection(section.id, section.name)}
+                sx={{
+                  bgcolor: isActive ? "primary.light" : "background.paper",
+                  color: isActive ? "primary.contrastText" : "text.primary",
+                  "&:hover": {
+                    bgcolor: isActive ? "primary.main" : "action.hover",
+                  },
+                  ...(isActive && {
+                    boxShadow: theme.shadows[8],
+                    transform: "scale(1.1)",
+                  }),
+                  // Show shortcut badge on desktop only
+                  ...(!isMobile && {
+                    position: "relative",
+                    "&::after": {
+                      content: `"${section.shortcut}"`,
+                      position: "absolute",
+                      top: -4,
+                      right: -4,
+                      backgroundColor: isActive
+                        ? theme.palette.primary.dark
+                        : "rgba(0,0,0,0.65)",
+                      color: "white",
+                      fontSize: "10px",
+                      fontWeight: "bold",
+                      width: 16,
+                      height: 16,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      borderRadius: "50%",
+                      lineHeight: 1,
+                    },
+                  }),
+                }}
+              />
+            );
+          })}
+        </SpeedDial>
+      </Box>
+    </>
   );
 };
+
+// Styled keyboard key indicator
+const Kbd = ({ children, small }) => (
+  <Box
+    component="kbd"
+    sx={{
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      minWidth: small ? 16 : 22,
+      height: small ? 16 : 22,
+      px: small ? 0.25 : 0.5,
+      bgcolor: small ? "transparent" : "grey.100",
+      border: small ? "1px solid rgba(255,255,255,0.5)" : "1px solid",
+      borderColor: small ? "rgba(255,255,255,0.5)" : "grey.300",
+      borderRadius: 0.5,
+      fontSize: small ? "9px" : "12px",
+      fontFamily: "monospace",
+      fontWeight: 600,
+      color: small ? "inherit" : "text.primary",
+      lineHeight: 1,
+      boxShadow: small ? "none" : "0 1px 0 1px rgba(0,0,0,0.08)",
+    }}
+  >
+    {children}
+  </Box>
+);
 
 export default FloatingNavigation;

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -31,7 +31,7 @@ const pages = [
   ["Hackathons", "/hack"],
   ["Projects", "/projects"],
   ["Nonprofits", "/nonprofits"],
-  ["Store", "/store"],
+  // ["Store", "/store"],
   ["Sponsors", "/sponsor"],
 ];
 

--- a/src/components/admin/AdminNavigation.js
+++ b/src/components/admin/AdminNavigation.js
@@ -40,6 +40,7 @@ import {
   Gavel as JudgingIcon,
   PostAdd as RequestIcon,
   ContactMail as ContactMailIcon,
+  Storefront as StorefrontIcon,
 } from "@mui/icons-material";
 import HandshakeIcon from '@mui/icons-material/Handshake';
 
@@ -153,6 +154,11 @@ const adminPages = [
     label: "Social Media",
     icon: <ShareIcon style={{ color: "#1DA1F2" }} />
   },
+  // {
+  //   path: "/admin/store",
+  //   label: "Store Orders",
+  //   icon: <StorefrontIcon style={{ color: "#4caf50" }} />
+  // },
 ];
 
 const AdminNavigation = () => {

--- a/src/components/admin/StoreOrderDetailDialog.js
+++ b/src/components/admin/StoreOrderDetailDialog.js
@@ -1,0 +1,378 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Grid,
+  Chip,
+  Divider,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Paper,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import AdminEmailCompose from "./AdminEmailCompose";
+
+const statusOptions = [
+  { value: "new", label: "New", color: "warning" },
+  { value: "processing", label: "Processing", color: "info" },
+  { value: "shipped", label: "Shipped", color: "primary" },
+  { value: "delivered", label: "Delivered", color: "success" },
+  { value: "cancelled", label: "Cancelled", color: "error" },
+];
+
+const carrierOptions = ["USPS", "UPS", "FedEx", "Other"];
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return "Not set";
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
+    return d.toLocaleDateString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return dateStr;
+  }
+};
+
+const Section = ({ title, children }) => (
+  <Box sx={{ mb: 3 }}>
+    <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1, color: "primary.main" }}>
+      {title}
+    </Typography>
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      {children}
+    </Paper>
+  </Box>
+);
+
+const Field = ({ label, value }) => (
+  <Box sx={{ mb: 1.5, minWidth: 0 }}>
+    <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+      {label}
+    </Typography>
+    <Typography variant="body1" sx={{ wordBreak: "break-all", overflowWrap: "anywhere" }}>
+      {value || "-"}
+    </Typography>
+  </Box>
+);
+
+const StoreOrderDetailDialog = ({
+  open,
+  onClose,
+  order,
+  onSave,
+  accessToken,
+  orgId,
+  onRefresh,
+}) => {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const [status, setStatus] = useState("");
+  const [trackingNumber, setTrackingNumber] = useState("");
+  const [trackingCarrier, setTrackingCarrier] = useState("");
+  const [adminNotes, setAdminNotes] = useState("");
+
+  useEffect(() => {
+    if (order) {
+      setStatus(order.status || "new");
+      setTrackingNumber(order.trackingNumber || "");
+      setTrackingCarrier(order.trackingCarrier || "");
+      setAdminNotes(order.adminNotes || "");
+    }
+  }, [order]);
+
+  if (!order) return null;
+
+  const handleSave = () => {
+    onSave({
+      id: order.id,
+      status,
+      trackingNumber,
+      trackingCarrier,
+      adminNotes,
+    });
+  };
+
+  const shipping = order.shippingAddress || {};
+  const shippingStr = [
+    shipping.line1,
+    shipping.line2,
+    [shipping.city, shipping.state, shipping.postal_code].filter(Boolean).join(", "),
+    shipping.country,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullScreen={fullScreen}
+      maxWidth="md"
+      fullWidth
+      scroll="paper"
+    >
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Typography variant="h6" component="span">
+            Order #{(order.id || "").substring(0, 8)}
+          </Typography>
+          <Chip
+            label={order.status || "new"}
+            color={statusOptions.find((s) => s.value === (order.status || "new"))?.color || "default"}
+            size="small"
+            sx={{ textTransform: "capitalize" }}
+          />
+        </Box>
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {/* Admin Controls */}
+        <Paper
+          elevation={0}
+          sx={{
+            p: 2,
+            mb: 3,
+            bgcolor: "grey.50",
+            border: "2px solid",
+            borderColor: "primary.light",
+            borderRadius: 2,
+          }}
+        >
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 2, color: "primary.main" }}>
+            Admin Controls
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 3 }}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Status</InputLabel>
+                <Select value={status} onChange={(e) => setStatus(e.target.value)} label="Status">
+                  {statusOptions.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid size={{ xs: 12, sm: 3 }}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Carrier</InputLabel>
+                <Select
+                  value={trackingCarrier}
+                  onChange={(e) => setTrackingCarrier(e.target.value)}
+                  label="Carrier"
+                >
+                  <MenuItem value="">None</MenuItem>
+                  {carrierOptions.map((c) => (
+                    <MenuItem key={c} value={c}>
+                      {c}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Tracking Number"
+                value={trackingNumber}
+                onChange={(e) => setTrackingNumber(e.target.value)}
+              />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Admin Notes"
+                value={adminNotes}
+                onChange={(e) => setAdminNotes(e.target.value)}
+                multiline
+                rows={2}
+              />
+            </Grid>
+          </Grid>
+        </Paper>
+
+        {/* Order Info */}
+        <Section title="Order Information">
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Field label="Order ID" value={order.id} />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Field label="Stripe Session" value={order.stripeSessionId} />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Field label="Payment Intent" value={order.stripePaymentIntentId} />
+            </Grid>
+          </Grid>
+        </Section>
+
+        {/* Customer & Shipping */}
+        <Section title="Customer & Shipping">
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Field label="Name" value={order.customerName} />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Field label="Email" value={order.customerEmail} />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Field
+                label="Shipping Address"
+                value={
+                  shippingStr ? (
+                    <Typography variant="body2" sx={{ whiteSpace: "pre-line" }}>
+                      {shippingStr}
+                    </Typography>
+                  ) : (
+                    "-"
+                  )
+                }
+              />
+            </Grid>
+          </Grid>
+        </Section>
+
+        {/* Items */}
+        <Section title="Items">
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Item</TableCell>
+                  <TableCell>Details</TableCell>
+                  <TableCell align="center">Qty</TableCell>
+                  <TableCell align="right">Unit Price</TableCell>
+                  <TableCell align="right">Total</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {(order.items || []).map((item, i) => (
+                  <TableRow key={i}>
+                    <TableCell>{item.name || "-"}</TableCell>
+                    <TableCell>{item.description || "-"}</TableCell>
+                    <TableCell align="center">{item.quantity || 1}</TableCell>
+                    <TableCell align="right">
+                      ${(item.unitPrice || 0).toFixed(2)}
+                    </TableCell>
+                    <TableCell align="right">
+                      ${(item.totalPrice || 0).toFixed(2)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                <TableRow>
+                  <TableCell colSpan={4} align="right" sx={{ fontWeight: "bold" }}>
+                    Total
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: "bold" }}>
+                    ${(order.total || 0).toFixed(2)} {(order.currency || "usd").toUpperCase()}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Section>
+
+        {/* Status History */}
+        <Section title="Status History">
+          {(order.statusHistory || []).length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No status history available.
+            </Typography>
+          ) : (
+            <Box>
+              {[...(order.statusHistory || [])].reverse().map((entry, i) => (
+                <Box
+                  key={i}
+                  sx={{
+                    display: "flex",
+                    gap: 2,
+                    alignItems: "center",
+                    mb: 1,
+                    pb: 1,
+                    borderBottom: i < (order.statusHistory || []).length - 1 ? "1px solid #eee" : "none",
+                  }}
+                >
+                  <Chip
+                    label={entry.status}
+                    size="small"
+                    sx={{ textTransform: "capitalize", minWidth: 80 }}
+                  />
+                  <Typography variant="body2" color="text.secondary">
+                    {formatDate(entry.timestamp)}
+                  </Typography>
+                  {entry.note && (
+                    <Typography variant="body2">{entry.note}</Typography>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Section>
+
+        {/* Email Correspondence */}
+        <AdminEmailCompose
+          recipientEmail={order.customerEmail}
+          recipientName={order.customerName}
+          collectionName="store_orders"
+          documentId={order.id}
+          sentEmails={order.sent_emails || []}
+          accessToken={accessToken}
+          orgId={orgId}
+          onEmailSent={onRefresh}
+        />
+
+        {/* Metadata */}
+        <Divider sx={{ my: 2 }} />
+        <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
+          <Typography variant="body2" color="text.secondary">
+            Created: {formatDate(order.timestamp)}
+          </Typography>
+          {order.updatedAt && (
+            <Typography variant="body2" color="text.secondary">
+              Last Updated: {formatDate(order.updatedAt)}
+            </Typography>
+          )}
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ p: 2 }}>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave}>
+          Save Changes
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default StoreOrderDetailDialog;

--- a/src/components/admin/StoreOrderTable.js
+++ b/src/components/admin/StoreOrderTable.js
@@ -1,0 +1,188 @@
+import React from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Paper,
+  Button,
+  Chip,
+  Tooltip,
+} from "@mui/material";
+import { styled } from "@mui/system";
+
+const StyledTableContainer = styled(TableContainer)(({ theme }) => ({
+  width: "100%",
+  overflowX: "auto",
+  "& .MuiTable-root": {
+    minWidth: "100%",
+  },
+}));
+
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  padding: theme.spacing(1, 2),
+  [theme.breakpoints.down("md")]: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    borderBottom: "none",
+    padding: theme.spacing(1, 2),
+    "&:before": {
+      content: "attr(data-label)",
+      fontWeight: "bold",
+      marginBottom: theme.spacing(0.5),
+    },
+  },
+}));
+
+const StyledTableRow = styled(TableRow)(({ theme }) => ({
+  [theme.breakpoints.down("md")]: {
+    display: "flex",
+    flexDirection: "column",
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+}));
+
+const statusColorMap = {
+  new: "warning",
+  processing: "info",
+  shipped: "primary",
+  delivered: "success",
+  cancelled: "error",
+};
+
+const columns = [
+  { id: "timestamp", label: "Date", minWidth: 100 },
+  { id: "id", label: "Order ID", minWidth: 100 },
+  { id: "customerName", label: "Customer", minWidth: 120 },
+  { id: "customerEmail", label: "Email", minWidth: 140 },
+  { id: "itemCount", label: "Items", minWidth: 60 },
+  { id: "total", label: "Total", minWidth: 80 },
+  { id: "status", label: "Status", minWidth: 100 },
+  { id: "trackingNumber", label: "Tracking", minWidth: 100 },
+];
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return "-";
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
+    return d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return dateStr;
+  }
+};
+
+const getCellValue = (order, columnId) => {
+  switch (columnId) {
+    case "itemCount":
+      return (order.items || []).length;
+    case "id":
+      return (order.id || "").substring(0, 8);
+    default:
+      return order[columnId];
+  }
+};
+
+const StoreOrderTable = ({
+  orders,
+  orderBy,
+  order,
+  onRequestSort,
+  onViewOrder,
+}) => {
+  return (
+    <StyledTableContainer component={Paper}>
+      <Table stickyHeader>
+        <TableHead>
+          <TableRow>
+            {columns.map((column) => (
+              <StyledTableCell
+                key={column.id}
+                style={{ minWidth: column.minWidth }}
+              >
+                <TableSortLabel
+                  active={orderBy === column.id}
+                  direction={orderBy === column.id ? order : "asc"}
+                  onClick={() => onRequestSort(column.id)}
+                >
+                  {column.label}
+                </TableSortLabel>
+              </StyledTableCell>
+            ))}
+            <StyledTableCell style={{ minWidth: 80 }}>Actions</StyledTableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {orders.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={columns.length + 1} align="center">
+                No orders found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            orders.map((ord) => (
+              <StyledTableRow key={ord.id}>
+                {columns.map((column) => (
+                  <StyledTableCell key={column.id} data-label={column.label}>
+                    {column.id === "status" ? (
+                      <Chip
+                        label={ord.status || "new"}
+                        color={statusColorMap[ord.status] || "warning"}
+                        size="small"
+                        sx={{ textTransform: "capitalize" }}
+                      />
+                    ) : column.id === "timestamp" ? (
+                      formatDate(ord.timestamp)
+                    ) : column.id === "total" ? (
+                      `$${(ord.total || 0).toFixed(2)}`
+                    ) : column.id === "trackingNumber" ? (
+                      ord.trackingNumber ? (
+                        <Tooltip title={`${ord.trackingCarrier || ""} ${ord.trackingNumber}`}>
+                          <Chip
+                            label={ord.trackingCarrier || "Tracked"}
+                            size="small"
+                            variant="outlined"
+                            color="success"
+                          />
+                        </Tooltip>
+                      ) : (
+                        "-"
+                      )
+                    ) : (
+                      <Tooltip title={String(getCellValue(ord, column.id) || "")}>
+                        <span>
+                          {String(getCellValue(ord, column.id) || "-").length > 25
+                            ? String(getCellValue(ord, column.id) || "").substring(0, 25) + "..."
+                            : getCellValue(ord, column.id) || "-"}
+                        </span>
+                      </Tooltip>
+                    )}
+                  </StyledTableCell>
+                ))}
+                <StyledTableCell data-label="Actions">
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => onViewOrder(ord)}
+                  >
+                    View
+                  </Button>
+                </StyledTableCell>
+              </StyledTableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </StyledTableContainer>
+  );
+};
+
+export default StoreOrderTable;

--- a/src/context/ShoppingCartContext.js
+++ b/src/context/ShoppingCartContext.js
@@ -131,7 +131,14 @@ export function ShoppingCartProvider({ children }) {
       type: "UPDATE_QUANTITY",
       payload: { id, selectedVariations, quantity },
     });
-  const clearCart = () => dispatch({ type: "CLEAR_CART" });
+  const clearCart = () => {
+    dispatch({ type: "CLEAR_CART" });
+    try {
+      localStorage.removeItem(CART_STORAGE_KEY);
+    } catch {
+      // Ignore localStorage errors
+    }
+  };
 
   const itemCount = state.items.reduce((sum, item) => sum + item.quantity, 0);
 

--- a/src/pages/admin/store/index.js
+++ b/src/pages/admin/store/index.js
@@ -1,0 +1,252 @@
+import React, { useState, useEffect } from "react";
+import { useAuthInfo, withRequiredAuthInfo } from "@propelauth/react";
+import {
+  Box,
+  Grid,
+  CircularProgress,
+  TextField,
+  Button,
+  Typography,
+  Chip,
+} from "@mui/material";
+import AdminPage from "../../../components/admin/AdminPage";
+import StoreOrderTable from "../../../components/admin/StoreOrderTable";
+import StoreOrderDetailDialog from "../../../components/admin/StoreOrderDetailDialog";
+
+const AdminStorePage = withRequiredAuthInfo(({ userClass }) => {
+  const { accessToken } = useAuthInfo();
+  const [orders, setOrders] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [snackbar, setSnackbar] = useState({
+    open: false,
+    message: "",
+    severity: "success",
+  });
+  const [orderBy, setOrderBy] = useState("timestamp");
+  const [order, setOrder] = useState("desc");
+  const [filter, setFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [detailDialogOpen, setDetailDialogOpen] = useState(false);
+  const [selectedOrder, setSelectedOrder] = useState(null);
+
+  const org = userClass.getOrgByName("Opportunity Hack Org");
+  const isAdmin = org.hasPermission("volunteer.admin");
+  const orgId = org.orgId;
+
+  const fetchOrders = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/store/orders`,
+        {
+          method: "GET",
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            "content-type": "application/json",
+            "X-Org-Id": orgId,
+          },
+        }
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        setOrders(data.orders || []);
+      } else {
+        throw new Error("Failed to fetch orders");
+      }
+    } catch (error) {
+      setSnackbar({
+        open: true,
+        message: "Failed to fetch orders. Please try again.",
+        severity: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isAdmin) {
+      fetchOrders();
+    }
+  }, [isAdmin, accessToken]);
+
+  const handleRequestSort = (property) => {
+    const isAsc = orderBy === property && order === "asc";
+    setOrder(isAsc ? "desc" : "asc");
+    setOrderBy(property);
+  };
+
+  const handleViewOrder = (ord) => {
+    setSelectedOrder(ord);
+    setDetailDialogOpen(true);
+  };
+
+  const handleSaveOrder = async (updatedData) => {
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/store/orders/${updatedData.id}`,
+        {
+          method: "PATCH",
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            "content-type": "application/json",
+            "X-Org-Id": orgId,
+          },
+          body: JSON.stringify({
+            status: updatedData.status,
+            trackingNumber: updatedData.trackingNumber,
+            trackingCarrier: updatedData.trackingCarrier,
+            adminNotes: updatedData.adminNotes,
+          }),
+        }
+      );
+
+      if (response.ok) {
+        setSnackbar({
+          open: true,
+          message: "Order updated successfully",
+          severity: "success",
+        });
+        fetchOrders();
+      } else {
+        throw new Error("Failed to update order");
+      }
+    } catch (error) {
+      setSnackbar({
+        open: true,
+        message: "Failed to update order. Please try again.",
+        severity: "error",
+      });
+    } finally {
+      setLoading(false);
+      setDetailDialogOpen(false);
+    }
+  };
+
+  const handleSnackbarClose = () => {
+    setSnackbar({ ...snackbar, open: false });
+  };
+
+  const getSortValue = (ord, key) => {
+    if (key === "itemCount") return (ord.items || []).length;
+    if (key === "total") return ord.total || 0;
+    return ord[key] || "";
+  };
+
+  const sortedAndFilteredOrders = orders
+    .filter((ord) => {
+      if (statusFilter !== "all" && (ord.status || "new") !== statusFilter) return false;
+      if (!filter) return true;
+      const searchValue = filter.toLowerCase();
+      return (
+        (ord.customerName || "").toLowerCase().includes(searchValue) ||
+        (ord.customerEmail || "").toLowerCase().includes(searchValue) ||
+        (ord.id || "").toLowerCase().includes(searchValue)
+      );
+    })
+    .sort((a, b) => {
+      const valueA = getSortValue(a, orderBy);
+      const valueB = getSortValue(b, orderBy);
+      if (valueA < valueB) return order === "asc" ? -1 : 1;
+      if (valueA > valueB) return order === "asc" ? 1 : -1;
+      return 0;
+    });
+
+  const statusCounts = orders.reduce((acc, ord) => {
+    const s = ord.status || "new";
+    acc[s] = (acc[s] || 0) + 1;
+    return acc;
+  }, {});
+
+  const statusColorMap = {
+    new: "warning",
+    processing: "info",
+    shipped: "primary",
+    delivered: "success",
+    cancelled: "error",
+  };
+
+  if (!isAdmin) {
+    return (
+      <AdminPage title="Store Orders" isAdmin={false}>
+        <Typography>You do not have permission to view this page.</Typography>
+      </AdminPage>
+    );
+  }
+
+  return (
+    <AdminPage
+      title="Store Orders"
+      snackbar={snackbar}
+      onSnackbarClose={handleSnackbarClose}
+      isAdmin={isAdmin}
+    >
+      {/* Summary chips */}
+      <Box sx={{ mb: 2, display: "flex", gap: 1, flexWrap: "wrap" }}>
+        <Chip
+          label={`Total: ${orders.length}`}
+          variant={statusFilter === "all" ? "filled" : "outlined"}
+          onClick={() => setStatusFilter("all")}
+        />
+        {Object.entries(statusCounts).map(([status, count]) => (
+          <Chip
+            key={status}
+            label={`${status}: ${count}`}
+            color={statusColorMap[status] || "default"}
+            variant={statusFilter === status ? "filled" : "outlined"}
+            onClick={() => setStatusFilter(statusFilter === status ? "all" : status)}
+            sx={{ textTransform: "capitalize" }}
+          />
+        ))}
+      </Box>
+
+      <Box sx={{ mb: 3, width: "100%" }}>
+        <Grid container spacing={2} alignItems="center">
+          <Grid>
+            <Button onClick={fetchOrders} variant="outlined">
+              Refresh Data
+            </Button>
+          </Grid>
+          <Grid size={{ xs: true }}>
+            <TextField
+              fullWidth
+              label="Filter by Customer Name, Email, or Order ID"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+          </Grid>
+        </Grid>
+      </Box>
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Box sx={{ mt: 2 }}>
+          <StoreOrderTable
+            orders={sortedAndFilteredOrders}
+            orderBy={orderBy}
+            order={order}
+            onRequestSort={handleRequestSort}
+            onViewOrder={handleViewOrder}
+          />
+        </Box>
+      )}
+
+      <StoreOrderDetailDialog
+        open={detailDialogOpen}
+        onClose={() => setDetailDialogOpen(false)}
+        order={selectedOrder}
+        onSave={handleSaveOrder}
+        accessToken={accessToken}
+        orgId={orgId}
+        onRefresh={fetchOrders}
+      />
+    </AdminPage>
+  );
+});
+
+export default AdminStorePage;

--- a/src/pages/api/store/create-checkout-session.js
+++ b/src/pages/api/store/create-checkout-session.js
@@ -56,7 +56,7 @@ export default async function handler(req, res) {
       },
     });
 
-    return res.status(200).json({ sessionId: session.id });
+    return res.status(200).json({ sessionId: session.id, url: session.url });
   } catch (error) {
     console.error("Stripe checkout error:", error.message);
     return res.status(500).json({

--- a/src/pages/api/store/webhook.js
+++ b/src/pages/api/store/webhook.js
@@ -1,0 +1,111 @@
+import Stripe from "stripe";
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function getRawBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  const storeWebhookSecret = process.env.STORE_WEBHOOK_SECRET;
+  const apiServerUrl = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+  if (!secretKey || !webhookSecret) {
+    console.error("Missing STRIPE_SECRET_KEY or STRIPE_WEBHOOK_SECRET");
+    return res.status(500).json({ error: "Stripe is not configured" });
+  }
+
+  const stripe = new Stripe(secretKey);
+
+  let event;
+  try {
+    const rawBody = await getRawBody(req);
+    const sig = req.headers["stripe-signature"];
+    event = stripe.webhooks.constructEvent(rawBody, sig, webhookSecret);
+  } catch (err) {
+    console.error("Webhook signature verification failed:", err.message);
+    return res.status(400).json({ error: `Webhook Error: ${err.message}` });
+  }
+
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object;
+
+    try {
+      // Retrieve full session with line items and customer details
+      const fullSession = await stripe.checkout.sessions.retrieve(session.id, {
+        expand: ["line_items", "customer_details"],
+      });
+
+      const lineItems = fullSession.line_items?.data || [];
+      const customerDetails = fullSession.customer_details || {};
+      const shipping = fullSession.shipping_details || {};
+
+      const items = lineItems.map((item) => ({
+        name: item.description || item.price?.product?.name || "",
+        description: item.price?.product?.description || "",
+        quantity: item.quantity || 1,
+        unitPrice: (item.price?.unit_amount || 0) / 100,
+        totalPrice: (item.amount_total || 0) / 100,
+      }));
+
+      const orderData = {
+        stripeSessionId: fullSession.id,
+        stripePaymentIntentId: fullSession.payment_intent || "",
+        customerEmail: customerDetails.email || fullSession.customer_email || "",
+        customerName: customerDetails.name || shipping.name || "",
+        shippingAddress: shipping.address
+          ? {
+              line1: shipping.address.line1 || "",
+              line2: shipping.address.line2 || "",
+              city: shipping.address.city || "",
+              state: shipping.address.state || "",
+              postal_code: shipping.address.postal_code || "",
+              country: shipping.address.country || "",
+            }
+          : {},
+        items,
+        subtotal: (fullSession.amount_subtotal || 0) / 100,
+        total: (fullSession.amount_total || 0) / 100,
+        currency: fullSession.currency || "usd",
+      };
+
+      // POST to backend
+      const response = await fetch(`${apiServerUrl}/api/store/orders`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Webhook-Secret": storeWebhookSecret || "",
+        },
+        body: JSON.stringify(orderData),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error("Backend order creation failed:", errorText);
+      } else {
+        const result = await response.json();
+        console.log("Order created:", result.id);
+      }
+    } catch (err) {
+      console.error("Error processing checkout.session.completed:", err);
+      // Still return 200 to Stripe to prevent retries for processing errors
+    }
+  }
+
+  return res.status(200).json({ received: true });
+}

--- a/src/pages/store/cart.js
+++ b/src/pages/store/cart.js
@@ -12,7 +12,6 @@ import {
 import ShoppingCartCheckoutIcon from "@mui/icons-material/ShoppingCartCheckout";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Link from "next/link";
-import { loadStripe } from "@stripe/stripe-js";
 import { useShoppingCart } from "../../context/ShoppingCartContext";
 import { trackEvent, initFacebookPixel } from "../../lib/ga";
 import CartItemList from "../../components/Store/CartItemList";
@@ -115,13 +114,10 @@ export default function CartPage() {
         throw new Error(data.error || "Failed to create checkout session");
       }
 
-      const stripe = await loadStripe(stripePublishableKey);
-      const { error: stripeError } = await stripe.redirectToCheckout({
-        sessionId: data.sessionId,
-      });
-
-      if (stripeError) {
-        throw new Error(stripeError.message);
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        throw new Error("No checkout URL returned from Stripe");
       }
     } catch (err) {
       setError(err.message);

--- a/src/pages/store/success.js
+++ b/src/pages/store/success.js
@@ -1,11 +1,19 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import {
   Container,
   Typography,
   Box,
   Button,
   Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  CircularProgress,
 } from "@mui/material";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import StorefrontIcon from "@mui/icons-material/Storefront";
@@ -15,6 +23,10 @@ import { trackEvent, initFacebookPixel } from "../../lib/ga";
 
 export default function SuccessPage() {
   const { clearCart } = useShoppingCart();
+  const router = useRouter();
+  const { session_id } = router.query;
+  const [order, setOrder] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     initFacebookPixel();
@@ -29,6 +41,46 @@ export default function SuccessPage() {
     // Only run once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (!session_id) return;
+
+    let cancelled = false;
+    let retried = false;
+
+    const fetchOrder = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/store/orders/by-session/${session_id}`
+        );
+        if (res.ok) {
+          const data = await res.json();
+          if (!cancelled) setOrder(data.order);
+        } else if (res.status === 404 && !retried) {
+          // Retry once after 2s for webhook race condition
+          retried = true;
+          await new Promise((r) => setTimeout(r, 2000));
+          const retryRes = await fetch(
+            `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/store/orders/by-session/${session_id}`
+          );
+          if (retryRes.ok) {
+            const data = await retryRes.json();
+            if (!cancelled) setOrder(data.order);
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch order:", err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchOrder();
+    return () => {
+      cancelled = true;
+    };
+  }, [session_id]);
 
   return (
     <>
@@ -61,14 +113,87 @@ export default function SuccessPage() {
           <Typography variant="h4" component="h1" fontWeight="bold" gutterBottom>
             Thank You!
           </Typography>
-          <Typography
-            variant="body1"
-            color="text.secondary"
-            sx={{ mb: 1 }}
-          >
-            Your order has been confirmed. You will receive an email
-            confirmation shortly.
-          </Typography>
+
+          {loading ? (
+            <Box sx={{ my: 3 }}>
+              <CircularProgress size={24} />
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                Loading your order details...
+              </Typography>
+            </Box>
+          ) : order ? (
+            <>
+              <Typography variant="body1" color="text.secondary" sx={{ mb: 1 }}>
+                {order.customerName
+                  ? `Thanks, ${order.customerName}! Your`
+                  : "Your"}{" "}
+                order has been confirmed.
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 2 }}
+              >
+                Order #{order.id?.substring(0, 8)}
+              </Typography>
+
+              <TableContainer sx={{ mb: 2 }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Item</TableCell>
+                      <TableCell align="center">Qty</TableCell>
+                      <TableCell align="right">Price</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {order.items?.map((item, i) => (
+                      <TableRow key={i}>
+                        <TableCell>
+                          {item.name}
+                          {item.description && (
+                            <Typography variant="caption" display="block" color="text.secondary">
+                              {item.description}
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell align="center">{item.quantity}</TableCell>
+                        <TableCell align="right">
+                          ${item.totalPrice?.toFixed(2)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                    <TableRow>
+                      <TableCell colSpan={2} align="right" sx={{ fontWeight: "bold" }}>
+                        Total
+                      </TableCell>
+                      <TableCell align="right" sx={{ fontWeight: "bold" }}>
+                        ${order.total?.toFixed(2)} {order.currency?.toUpperCase()}
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </TableContainer>
+
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 1 }}
+              >
+                A confirmation email has been sent to {order.customerEmail}.
+              </Typography>
+            </>
+          ) : (
+            <Typography
+              variant="body1"
+              color="text.secondary"
+              sx={{ mb: 1 }}
+            >
+              Your order has been confirmed. You will receive an email
+              confirmation shortly.
+            </Typography>
+          )}
+
           <Typography
             variant="body1"
             color="text.secondary"


### PR DESCRIPTION
## Summary
- **Stripe webhook** (`/api/store/webhook`) processes `checkout.session.completed` events, extracts line items/shipping/customer details, and POSTs order data to the backend API
- **Success page** now fetches and displays order details (items table, total, customer info) by Stripe session ID, with a 2s retry for webhook race conditions
- **Admin store page** (`/admin/store`) with sortable/filterable order table, detail dialog for managing status, tracking numbers, carrier, and admin notes (hidden from nav until ready to launch)
- **Fix**: Replace deprecated `stripe.redirectToCheckout` with `session.url` redirect
- **Fix**: Cart not clearing after Stripe checkout due to localStorage race condition in `ShoppingCartContext`
- **Improve**: FloatingNavigation keyboard shortcuts now work globally (no need to open menu first), added `?` key for a discoverable help modal, visual flash feedback on section navigation, mobile-aware shortcut handling

## Backend (separate repo: backend-ohack.dev)
Companion backend changes are needed (not in this PR):
- `api/store/store_service.py` — Firestore CRUD, Resend emails (confirmation + status updates), Slack notifications to #store-orders
- `api/store/store_views.py` — Flask blueprint with webhook-auth and admin-auth endpoints
- Blueprint registered in `api/__init__.py`

## New env vars needed
- `STRIPE_WEBHOOK_SECRET` — Stripe webhook signing secret (frontend only, server-side)
- `STORE_WEBHOOK_SECRET` — shared secret between frontend webhook and backend API (both repos)

## Test plan
- [ ] Run `stripe listen --forward-to localhost:3000/api/store/webhook` and complete a test purchase
- [ ] Verify order appears in Firestore `store_orders` collection
- [ ] Verify confirmation email sent to customer and notification to questions@ohack.org
- [ ] Verify success page shows order details (items, total, customer name)
- [ ] Verify cart clears after successful checkout
- [ ] Navigate to `/admin/store`, verify orders display with correct status chips
- [ ] Test status update flow: change status → verify status email sent to customer
- [ ] Test tracking number + carrier update
- [ ] On `/hack/[event_id]`, press `?` to verify keyboard shortcut help modal
- [ ] Press letter keys (A, P, T, etc.) to verify global section navigation
- [ ] Verify shortcuts don't fire when typing in input fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)