### PR TITLE
Fix stale PropelAuth access token causing manual refresh requirement

### DIFF
--- a/src/components/axios-wrapper.js
+++ b/src/components/axios-wrapper.js
@@ -1,34 +1,76 @@
 import axios from "axios";
 import { useAuthInfo } from '@propelauth/react';
+import { useEffect, useRef } from 'react';
 
 
 export default function AxiosWrapper({ children }) {
 
-	const { user, accessToken } = useAuthInfo();
+	const { tokens, isLoggedIn } = useAuthInfo();
 
-	axios.interceptors.request.use(function (config) {
-	    // Add bearer auth
-	    if (user) {
-	    	config.headers = {
-	        ...config.headers,
-	        Authorization: `Bearer ${accessToken}`,
-	      };
-		  
-		  }
-	    return config;
-	  }, function (error) {
-	    let result = undefined;
-	    if (axios.isAxiosError(error) && error.response) {
-        result = error.response;
-      }
+	const tokensRef = useRef(tokens);
+	const isLoggedInRef = useRef(isLoggedIn);
 
-      result = error.message;
-	    return Promise.reject(result);
-	  });
+	useEffect(() => {
+		tokensRef.current = tokens;
+		isLoggedInRef.current = isLoggedIn;
+	}, [tokens, isLoggedIn]);
+
+	useEffect(() => {
+		const requestInterceptor = axios.interceptors.request.use(
+			async function (config) {
+				if (isLoggedInRef.current && tokensRef.current) {
+					try {
+						const accessToken = await tokensRef.current.getAccessToken();
+						config.headers = {
+							...config.headers,
+							Authorization: `Bearer ${accessToken}`,
+						};
+					} catch (error) {
+						console.error("Failed to get access token:", error);
+					}
+				}
+				return config;
+			},
+			function (error) {
+				return Promise.reject(error);
+			}
+		);
+
+		const responseInterceptor = axios.interceptors.response.use(
+			function (response) {
+				return response;
+			},
+			async function (error) {
+				const originalRequest = error.config;
+				if (
+					error.response &&
+					error.response.status === 401 &&
+					!originalRequest._retry &&
+					isLoggedInRef.current &&
+					tokensRef.current
+				) {
+					originalRequest._retry = true;
+					try {
+						const accessToken = await tokensRef.current.getAccessToken();
+						originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+						return axios(originalRequest);
+					} catch (refreshError) {
+						return Promise.reject(refreshError);
+					}
+				}
+				return Promise.reject(error);
+			}
+		);
+
+		return () => {
+			axios.interceptors.request.eject(requestInterceptor);
+			axios.interceptors.response.eject(responseInterceptor);
+		};
+	}, []);
 
 	return (
-    <div className="axios-wrapper">
-      {children}
-    </div>
-  );
+		<div className="axios-wrapper">
+			{children}
+		</div>
+	);
 }

--- a/src/hooks/use-admin-check.js
+++ b/src/hooks/use-admin-check.js
@@ -5,20 +5,12 @@ import { useState, useEffect, useCallback } from "react";
 
 
 export default function useAdmin() {
-  const { user, accessToken } = useAuthInfo();
+  const { user } = useAuthInfo();
     const { apiServerUrl } = useEnv();
     const [isAdmin, setIsAdmin ] = useState(false);
 
     const fetchUser = useCallback(async (options) => {
         try {
-            if (options.authenticated) {                
-
-                options.config.headers = {
-                    ...options.config.headers,
-                    Authorization: `Bearer ${accessToken}`,
-                };
-            }
-
             const response = await axios(options.config);
             const { data } = response;
 
@@ -31,7 +23,7 @@ export default function useAdmin() {
 
             return error.message;
         }
-    }, [accessToken]);
+    }, []);
 
   
 

--- a/src/hooks/use-hackathon-events.js
+++ b/src/hooks/use-hackathon-events.js
@@ -5,21 +5,13 @@ import { useAuthInfo } from '@propelauth/react';
 
 export default function useHackathonEvents( currentOnly ){
 
-    const { isLoggedIn, user, accessToken } = useAuthInfo();
+    const { user } = useAuthInfo();
     const { apiServerUrl } = useEnv();
     const [hackathons, setHackathons] = useState([]);
 
 
     const makeRequest = useCallback(async (options) => {
         try {
-            if (options.authenticated) {                
-
-                options.config.headers = {
-                    ...options.config.headers,
-                    Authorization: `Bearer ${accessToken}`,
-                };
-            }
-
             const response = await axios(options.config);
             const { data } = response;
 
@@ -32,7 +24,7 @@ export default function useHackathonEvents( currentOnly ){
 
             return error.message;
         }
-    }, [accessToken]);
+    }, []);
 
 
     const handle_get_hackathon = async (event_id, onComplete) => {        

--- a/src/hooks/use-nonprofit.js
+++ b/src/hooks/use-nonprofit.js
@@ -5,8 +5,8 @@ import { useState, useEffect, useCallback } from "react";
 
 
 export default function useNonprofit( nonprofit_id ){
-    
-    const { isLoggedIn, user, accessToken } = useAuthInfo();
+
+    const { user } = useAuthInfo();
     const { apiServerUrl, apiNodeJsServerUrl } = useEnv();
     const [nonprofitApplications, setNonprofitApplications] = useState([]); // This is for /nonprofits/apply/list
 
@@ -20,14 +20,6 @@ export default function useNonprofit( nonprofit_id ){
 
     const makeRequest = useCallback(async (options) => {
         try {
-            if (options.authenticated) {                
-
-                options.config.headers = {
-                    ...options.config.headers,
-                    Authorization: `Bearer ${accessToken}`,
-                };
-            }
-
             const response = await axios(options.config);
             const { data } = response;
 
@@ -36,10 +28,10 @@ export default function useNonprofit( nonprofit_id ){
             console.error(error);
             return { error: error.message,
                     status: error.response?.status,
-                    statusText: error.response?.statusText                
-             };            
+                    statusText: error.response?.statusText
+             };
         }
-    }, [accessToken]);
+    }, []);
 
 
     const handle_npo_form_submission = async (formData, onComplete) => {     
@@ -128,9 +120,6 @@ export default function useNonprofit( nonprofit_id ){
 
         // Publically available, so authenticated: false here
         const data = await makeRequest({ config, authenticated: false });
-        console.log("User: ", user);
-        console.log("isLoggedin: ", isLoggedIn);
-        
         // If no data, set to empty array
         if( !data )
         {
@@ -188,8 +177,6 @@ export default function useNonprofit( nonprofit_id ){
             headers: {
                 "Content-Type": "application/json",
                 "Accept": "application/json",
-                "Bearer": accessToken
-
             },
             data: {
                 id: id,               

--- a/src/hooks/use-problem-statements.js
+++ b/src/hooks/use-problem-statements.js
@@ -17,19 +17,11 @@ export default function useProblemstatements(problem_statement_id){
     const { apiServerUrl } = useEnv();
     const [problem_statements, setProblemStatements] = useState([]);
     const [problem_statement, setProblemStatement] = useState(default_problem_statement);
-    const { user, accessToken } = useAuthInfo();
+    const { user } = useAuthInfo();
 
 
     const fetchProblemStatements = useCallback(async (options) => {
         try {
-            if (options.authenticated) {                
-
-                options.config.headers = {
-                    ...options.config.headers,
-                    Authorization: `Bearer ${accessToken}`,
-                };
-            }
-
             const response = await axios(options.config);
             const { data } = response;
 
@@ -40,7 +32,7 @@ export default function useProblemstatements(problem_statement_id){
             }
             return error.message;
         }
-    }, [accessToken]);
+    }, []);
 
 
 

--- a/src/hooks/use-teams.js
+++ b/src/hooks/use-teams.js
@@ -6,22 +6,14 @@ import { useAuthInfo } from '@propelauth/react';
 
 export default function useTeams(){
 
-    const { isLoggedIn, user, accessToken } = useAuthInfo();
+    const { user } = useAuthInfo();
 
     const { apiServerUrl } = useEnv();
     const [teams, setTeams] = useState([]);
-    
+
 
     const makeRequest = useCallback(async (options) => {
         try {
-            if (options.authenticated) {
-                
-                options.config.headers = {
-                    ...options.config.headers,
-                    Authorization: `Bearer ${accessToken}`,
-                };
-            }
-
             const response = await axios(options.config);
             const { data } = response;
 
@@ -34,7 +26,7 @@ export default function useTeams(){
 
             return error.message;
         }
-    }, [accessToken]);
+    }, []);
 
     // Get a single team
     const handle_get_team = async (team_id, onComplete) => {


### PR DESCRIPTION
## Summary
- **Rewrote `AxiosWrapper`** to fetch fresh tokens at request time via `tokens.getAccessToken()` instead of capturing a static `accessToken` string that goes stale in closures
- **Fixed interceptor stacking bug** — interceptors are now registered once in a `useEffect` with proper cleanup (eject on unmount)
- **Added 401 retry logic** — response interceptor automatically retries once with a fresh token on 401 responses
- **Removed redundant auth header injection** from 5 hooks (`use-teams`, `use-admin-check`, `use-hackathon-events`, `use-nonprofit`, `use-problem-statements`) since the interceptor handles it globally
- **Fixed incorrect `"Bearer"` header key** in `use-nonprofit.js` (was `"Bearer": accessToken` instead of `Authorization: Bearer ...`)

## Problem
Users had to manually refresh the browser when their auth session got stale because:
1. `useAuthInfo()` returns `accessToken` as a static string — it goes stale in closures (axios interceptors, `useCallback` deps) and never updates until a re-render
2. The `AxiosWrapper` re-registered interceptors on every render without cleanup, stacking duplicate interceptors

## Test plan
- [ ] Log in and verify API calls include fresh `Authorization` headers in Network tab
- [ ] Verify no duplicate interceptors (only one `Authorization` header per request)
- [ ] Let session sit idle, then perform an action — should work without manual refresh
- [ ] Verify unauthenticated endpoints (public pages) still work without auth headers
- [ ] `npm run build` passes with no errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)