### PR TITLE
Add nonprofit-project visibility across project, hackathon, and admin pages

### DIFF
--- a/src/components/Hackathon/NonprofitList.js
+++ b/src/components/Hackathon/NonprofitList.js
@@ -82,6 +82,7 @@ const NonprofitList = ({ nonprofits, teams, eventId, visibleProblemStatements })
   const [projectsLoading, setProjectsLoading] = useState(false);
 
   // Collect all problem statement IDs from nonprofits, with nonprofit context
+  // Map project IDs to their parent nonprofit(s) — a project can belong to multiple nonprofits
   const projectIdMap = useMemo(() => {
     const map = {};
     if (!nonprofits) return map;
@@ -89,7 +90,10 @@ const NonprofitList = ({ nonprofits, teams, eventId, visibleProblemStatements })
       (npo.problem_statements || []).forEach((psId) => {
         // If visibleProblemStatements is set, filter by it
         if (!visibleProblemStatements || visibleProblemStatements.includes(psId)) {
-          map[psId] = { nonprofitId: npo.id, nonprofitName: npo.name };
+          if (!map[psId]) {
+            map[psId] = [];
+          }
+          map[psId].push({ nonprofitId: npo.id, nonprofitName: npo.name });
         }
       });
     });
@@ -245,7 +249,7 @@ const NonprofitList = ({ nonprofits, teams, eventId, visibleProblemStatements })
     return (
       <Grid container spacing={3}>
         {projects.map((project) => {
-          const npoInfo = projectIdMap[project.id];
+          const npoInfoList = projectIdMap[project.id] || [];
           return (
             <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.id}>
               <ProjectCard>
@@ -256,8 +260,9 @@ const NonprofitList = ({ nonprofits, teams, eventId, visibleProblemStatements })
                       size="small"
                       color={STATUS_COLORS[project.status] || "default"}
                     />
-                    {npoInfo?.nonprofitName && (
+                    {npoInfoList.map((npoInfo) => (
                       <Chip
+                        key={npoInfo.nonprofitId}
                         component={Link}
                         href={`/nonprofit/${npoInfo.nonprofitId}`}
                         label={npoInfo.nonprofitName}
@@ -265,7 +270,7 @@ const NonprofitList = ({ nonprofits, teams, eventId, visibleProblemStatements })
                         variant="outlined"
                         clickable
                       />
-                    )}
+                    ))}
                   </Box>
                   <Typography
                     gutterBottom

--- a/src/components/Hackathon/NonprofitList.js
+++ b/src/components/Hackathon/NonprofitList.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import {
   Paper,
   Typography,
@@ -8,12 +8,17 @@ import {
   Button,
   Chip,
   Box,
-  Skeleton,
+  ToggleButtonGroup,
+  ToggleButton,
+  CircularProgress,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import Link from "next/link";
 import Image from "next/image";
 import AddIcon from "@mui/icons-material/Add";
+import BusinessIcon from "@mui/icons-material/Business";
+import AssignmentIcon from "@mui/icons-material/Assignment";
+import axios from "axios";
 import { normalizeImageUrl } from "../../lib/imageUtils";
 
 const ListContainer = styled(Paper)(({ theme }) => ({
@@ -41,8 +46,12 @@ const NonprofitContent = styled(CardContent)({
   flexGrow: 1,
 });
 
-const TeamChip = styled(Chip)(({ theme }) => ({
-  margin: theme.spacing(0.5),
+const ProjectCard = styled(Card)(({ theme }) => ({
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+  transition: "transform 0.15s ease-in-out",
+  "&:hover": { transform: "scale3d(1.02, 1.02, 1)" },
 }));
 
 const EmptyStateContainer = styled(Box)(({ theme }) => ({
@@ -54,7 +63,79 @@ const EmptyStateContainer = styled(Box)(({ theme }) => ({
   textAlign: "center",
 }));
 
-const NonprofitList = ({ nonprofits, teams, eventId }) => {
+const STATUS_COLORS = {
+  production: "success",
+  "post-hackathon": "info",
+  hackathon: "warning",
+  concept: "default",
+  maintenance: "secondary",
+};
+
+const NonprofitList = ({ nonprofits, teams, eventId, visibleProblemStatements }) => {
+  const [viewMode, setViewMode] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("ohack_hackathon_view") || "nonprofits";
+    }
+    return "nonprofits";
+  });
+  const [projects, setProjects] = useState([]);
+  const [projectsLoading, setProjectsLoading] = useState(false);
+
+  // Collect all problem statement IDs from nonprofits, with nonprofit context
+  const projectIdMap = useMemo(() => {
+    const map = {};
+    if (!nonprofits) return map;
+    nonprofits.forEach((npo) => {
+      (npo.problem_statements || []).forEach((psId) => {
+        // If visibleProblemStatements is set, filter by it
+        if (!visibleProblemStatements || visibleProblemStatements.includes(psId)) {
+          map[psId] = { nonprofitId: npo.id, nonprofitName: npo.name };
+        }
+      });
+    });
+    return map;
+  }, [nonprofits, visibleProblemStatements]);
+
+  // Fetch project details when switching to projects view
+  useEffect(() => {
+    const projectIds = Object.keys(projectIdMap);
+    if (viewMode !== "projects" || projectIds.length === 0) return;
+
+    // Don't refetch if we already have data
+    if (projects.length > 0) return;
+
+    let cancelled = false;
+    const fetchProjects = async () => {
+      setProjectsLoading(true);
+      try {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/problem_statements`
+        );
+        if (!cancelled && response.data?.problem_statements) {
+          const relevant = response.data.problem_statements.filter(
+            (ps) => projectIds.includes(ps.id)
+          );
+          setProjects(relevant);
+        }
+      } catch (err) {
+        console.error("Error fetching projects for hackathon view:", err);
+      } finally {
+        if (!cancelled) setProjectsLoading(false);
+      }
+    };
+    fetchProjects();
+    return () => { cancelled = true; };
+  }, [viewMode, projectIdMap, projects.length]);
+
+  const handleViewChange = (_, newView) => {
+    if (newView) {
+      setViewMode(newView);
+      if (typeof window !== "undefined") {
+        localStorage.setItem("ohack_hackathon_view", newView);
+      }
+    }
+  };
+
   if (!nonprofits || nonprofits.length === 0) {
     return (
       <ListContainer elevation={2}>
@@ -80,89 +161,184 @@ const NonprofitList = ({ nonprofits, teams, eventId }) => {
     );
   }
 
-  // TODO: Logic is complex and we're not showing teams right now anyway
-  const getTeamsForNonprofit = (problem_statements) => {
-    return teams?.filter((team) => team.problem_statements.includes(problem_statements)  ) || [];
+  const renderNonprofitsView = () => (
+    <Grid container spacing={3}>
+      {nonprofits.map((nonprofit) => (
+        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={nonprofit.id}>
+          <NonprofitCard>
+            <ImageContainer>
+              {nonprofit.image ? (
+                <Image
+                  src={normalizeImageUrl(nonprofit.image) || "/npo_placeholder.png"}
+                  alt={`${nonprofit.name} logo or image`}
+                  fill
+                  sizes="(max-width: 600px) 100vw, (max-width: 960px) 50vw, 33vw"
+                  style={{ objectFit: "cover" }}
+                  priority={false}
+                  loading="lazy"
+                />
+              ) : (
+                <Image
+                  src="/npo_placeholder.png"
+                  alt="Nonprofit placeholder image"
+                  fill
+                  sizes="(max-width: 600px) 100vw, (max-width: 960px) 50vw, 33vw"
+                  style={{ objectFit: "cover" }}
+                  priority={false}
+                  loading="lazy"
+                />
+              )}
+            </ImageContainer>
+            <NonprofitContent>
+              <Typography
+                gutterBottom
+                variant="h3"
+                component="h3"
+                sx={{
+                  fontSize: { xs: "1.25rem", sm: "1.35rem" },
+                  fontWeight: 600,
+                  lineHeight: 1.3,
+                  marginBottom: 1,
+                }}
+              >
+                {nonprofit.name}
+              </Typography>
+              <Typography variant="body1" color="textSecondary" component="p">
+                {nonprofit.description?.length > 100
+                  ? `${nonprofit.description.substring(0, 100)}...`
+                  : nonprofit.description}
+              </Typography>
+            </NonprofitContent>
+            <Button
+              component={Link}
+              href={`/nonprofit/${nonprofit.id}`}
+              variant="contained"
+              color="primary"
+              fullWidth
+              aria-label={`View ${nonprofit.name} projects and ways to help`}
+            >
+              View Projects & Ways to Help
+            </Button>
+          </NonprofitCard>
+        </Grid>
+      ))}
+    </Grid>
+  );
+
+  const renderProjectsView = () => {
+    if (projectsLoading) {
+      return (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+          <CircularProgress />
+        </Box>
+      );
+    }
+
+    if (projects.length === 0) {
+      return (
+        <Typography variant="body1" color="textSecondary" sx={{ p: 2 }}>
+          No projects found for this hackathon.
+        </Typography>
+      );
+    }
+
+    return (
+      <Grid container spacing={3}>
+        {projects.map((project) => {
+          const npoInfo = projectIdMap[project.id];
+          return (
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} key={project.id}>
+              <ProjectCard>
+                <CardContent sx={{ flexGrow: 1 }}>
+                  <Box sx={{ display: "flex", gap: 1, mb: 1, flexWrap: "wrap" }}>
+                    <Chip
+                      label={project.status || "unknown"}
+                      size="small"
+                      color={STATUS_COLORS[project.status] || "default"}
+                    />
+                    {npoInfo?.nonprofitName && (
+                      <Chip
+                        component={Link}
+                        href={`/nonprofit/${npoInfo.nonprofitId}`}
+                        label={npoInfo.nonprofitName}
+                        size="small"
+                        variant="outlined"
+                        clickable
+                      />
+                    )}
+                  </Box>
+                  <Typography
+                    gutterBottom
+                    variant="h3"
+                    component="h3"
+                    sx={{
+                      fontSize: { xs: "1.25rem", sm: "1.35rem" },
+                      fontWeight: 600,
+                      lineHeight: 1.3,
+                      marginBottom: 1,
+                    }}
+                  >
+                    {project.title}
+                  </Typography>
+                  <Typography variant="body1" color="textSecondary" component="p">
+                    {project.description?.length > 150
+                      ? `${project.description.substring(0, 150)}...`
+                      : project.description}
+                  </Typography>
+                </CardContent>
+                <Button
+                  component={Link}
+                  href={`/project/${project.id}`}
+                  variant="contained"
+                  color="primary"
+                  fullWidth
+                  aria-label={`View project: ${project.title}`}
+                >
+                  View Project Details
+                </Button>
+              </ProjectCard>
+            </Grid>
+          );
+        })}
+      </Grid>
+    );
   };
 
   return (
     <ListContainer elevation={2}>
-      <Typography
-        variant="h5"
-        gutterBottom
-        id="nonprofit-section-heading"
-        fontWeight="bold"
-      >
-        Step 2. Choose your hackathon project
-      </Typography>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 2, mb: 1 }}>
+        <Typography
+          variant="h5"
+          id="nonprofit-section-heading"
+          fontWeight="bold"
+        >
+          Step 2. Choose your hackathon project
+        </Typography>
+        <ToggleButtonGroup
+          value={viewMode}
+          exclusive
+          onChange={handleViewChange}
+          size="small"
+          aria-label="Switch between nonprofits and projects view"
+        >
+          <ToggleButton value="nonprofits" aria-label="View by nonprofit">
+            <BusinessIcon sx={{ mr: 0.5 }} fontSize="small" />
+            Nonprofits
+          </ToggleButton>
+          <ToggleButton value="projects" aria-label="View by project">
+            <AssignmentIcon sx={{ mr: 0.5 }} fontSize="small" />
+            Projects
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
       <Typography variant="body2" color="textSecondary" paragraph>
-        <strong>These are the only projects you can work on during this hackathon.</strong> Select one that matches your team's skills and interests.
+        {viewMode === "nonprofits" ? (
+          <strong>Browse by nonprofit organization. Click one to see their specific projects.</strong>
+        ) : (
+          <strong>Browse all projects directly. Each project shows which nonprofit it belongs to.</strong>
+        )}
       </Typography>
-      <Grid container spacing={3}>
-        {nonprofits.map((nonprofit) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={nonprofit.id}>
-            <NonprofitCard>
-              <ImageContainer>
-                {nonprofit.image ? (
-                  <Image
-                    src={normalizeImageUrl(nonprofit.image) || "/npo_placeholder.png"}
-                    alt={`${nonprofit.name} logo or image`}
-                    fill
-                    sizes="(max-width: 600px) 100vw, (max-width: 960px) 50vw, 33vw"
-                    style={{
-                      objectFit: "cover",
-                    }}
-                    priority={false}
-                    loading="lazy"
-                  />
-                ) : (
-                  <Image
-                    src="/npo_placeholder.png"
-                    alt="Nonprofit placeholder image"
-                    fill
-                    sizes="(max-width: 600px) 100vw, (max-width: 960px) 50vw, 33vw"
-                    style={{
-                      objectFit: "cover",
-                    }}
-                    priority={false}
-                    loading="lazy"
-                  />
-                )}
-              </ImageContainer>
-              <NonprofitContent>
-                <Typography
-                  gutterBottom
-                  variant="h3"
-                  component="h3"
-                  sx={{
-                    fontSize: { xs: "1.25rem", sm: "1.35rem" },
-                    fontWeight: 600,
-                    lineHeight: 1.3,
-                    marginBottom: 1,
-                  }}
-                >
-                  {nonprofit.name}
-                </Typography>
-                <Typography variant="body1" color="textSecondary" component="p">
-                  {nonprofit.description?.length > 100
-                    ? `${nonprofit.description.substring(0, 100)}...`
-                    : nonprofit.description}
-                </Typography>
-              </NonprofitContent>
-              <Button
-                component={Link}
-                href={`/nonprofit/${nonprofit.id}`}
-                variant="contained"
-                color="primary"
-                fullWidth
-                aria-label={`View ${nonprofit.name} projects and ways to help`}
-              >
-                View Projects & Ways to Help
-              </Button>
-            </NonprofitCard>
-          </Grid>
-        ))}
-      </Grid>
+      {viewMode === "nonprofits" ? renderNonprofitsView() : renderProjectsView()}
     </ListContainer>
   );
 };

--- a/src/components/ProblemStatement/ProblemStatement.js
+++ b/src/components/ProblemStatement/ProblemStatement.js
@@ -53,6 +53,7 @@ import SkillSet from "../skill-set";
 import CopyToClipboardButton from "../buttons/CopyToClipboardButton";
 import useProblemstatements from "../../hooks/use-problem-statements";
 import useHackathonEvents from "../../hooks/use-hackathon-events";
+import useProjectNonprofit from "../../hooks/use-project-nonprofit";
 import {useRedirectFunctions} from "@propelauth/react";
 import { trackEvent, initFacebookPixel } from '../../lib/ga';
 import { 
@@ -211,6 +212,11 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
   const { problem_statement } = useProblemstatements(problem_statement_id);
   const { handle_get_hackathon_id } = useHackathonEvents();
   const { handle_join_team, handle_unjoin_a_team } = useTeams();
+
+  // Resolve parent nonprofit when npo_id is not provided (direct project page visit)
+  const { nonprofit: resolvedNonprofit } = useProjectNonprofit(problem_statement_id, npo_id);
+  const effectiveNpoId = npo_id || resolvedNonprofit?.id;
+  const nonprofitName = resolvedNonprofit?.name;
   
   // States
   const [hackathonEvents, setHackathonEvents] = useState([]);  
@@ -424,12 +430,12 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
     const params = {
       action_name: isExpanded ? "open" : "close",
       panel_id: panel,
-      npo_id: npo_id,
+      npo_id: effectiveNpoId,
       problem_statement_id: problem_statement?.id,
       problem_statement_title: problem_statement?.title,
       user_id: user?.userId
     };
-    
+
     trackEvent({
       action: "problem_statement_accordion",
       params: params
@@ -446,7 +452,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
         params: {
           problem_statement_id: problem_statement?.id,
           problem_statement_title: problem_statement?.title,
-          npo_id: npo_id,
+          npo_id: effectiveNpoId,
           user_id: user?.userId
         }
       });
@@ -457,8 +463,8 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
         params: {
           problem_statement_id: problem_statement?.id,
           problem_statement_title: problem_statement?.title,
-          npo_id: npo_id,
-          user_id: user?.userId 
+          npo_id: effectiveNpoId,
+          user_id: user?.userId
         }
       });
     }
@@ -500,7 +506,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
         label: "Helping",
         problem_statement_id: problem_statement?.id,
         problem_statement_title: problem_statement?.title,
-        npo_id: npo_id,
+        npo_id: effectiveNpoId,
         user_id: user?.userId,
         mentor_or_hacker: helperType
       }
@@ -514,7 +520,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
       "helping",
       problem_statement.id,
       helperType,
-      npo_id
+      effectiveNpoId
     );
   };
 
@@ -526,7 +532,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
         label: "Helping",
         problem_statement_id: problem_statement?.id,
         problem_statement_title: problem_statement?.title,
-        npo_id: npo_id,
+        npo_id: effectiveNpoId,
         user_id: user?.userId
       }
     });
@@ -544,7 +550,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
         label: "Helping",
         problem_statement_id: problem_statement?.id,
         problem_statement_title: problem_statement?.title,
-        npo_id: npo_id,
+        npo_id: effectiveNpoId,
         user_id: user?.userId
       }
     });
@@ -553,7 +559,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
     setHelpedChecked("");
     setHelpingType("");
     // FIXED: Use correct parameter order
-    handle_help_toggle("not_helping", problem_statement.id, "", npo_id);
+    handle_help_toggle("not_helping", problem_statement.id, "", effectiveNpoId);
   };
 
   const handleCloseUnhelpCancel = () => {
@@ -726,7 +732,7 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
         <Stack direction={isMobile ? 'column' : 'row'} spacing={2} sx={{ mt: 3 }}>
           <ActionButton
             component={Link}
-            href={`/signup?previousPage=/nonprofit/${npo_id}`}
+            href={`/signup?previousPage=/nonprofit/${effectiveNpoId}`}
             variant="contained"
             size="large"
             fullWidth={isMobile}
@@ -824,7 +830,25 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
               >
                 {problem_statement.title}
               </Typography>
-              
+
+              {/* Nonprofit attribution - only show on direct project page visits */}
+              {!npo_id && resolvedNonprofit && (
+                <Chip
+                  component={Link}
+                  href={`/nonprofit/${resolvedNonprofit.id}`}
+                  label={`Project by ${resolvedNonprofit.name}`}
+                  clickable
+                  size="small"
+                  sx={{
+                    mb: 2,
+                    bgcolor: 'rgba(255,255,255,0.2)',
+                    color: 'white',
+                    '&:hover': { bgcolor: 'rgba(255,255,255,0.35)' },
+                    fontWeight: 600,
+                  }}
+                />
+              )}
+
               <SkillSet Skills={problem_statement.skills} />
               
               <Box sx={{ mt: 3 }}>

--- a/src/components/ProblemStatement/ProblemStatement.js
+++ b/src/components/ProblemStatement/ProblemStatement.js
@@ -213,10 +213,10 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
   const { handle_get_hackathon_id } = useHackathonEvents();
   const { handle_join_team, handle_unjoin_a_team } = useTeams();
 
-  // Resolve parent nonprofit when npo_id is not provided (direct project page visit)
-  const { nonprofit: resolvedNonprofit } = useProjectNonprofit(problem_statement_id, npo_id);
-  const effectiveNpoId = npo_id || resolvedNonprofit?.id;
-  const nonprofitName = resolvedNonprofit?.name;
+  // Resolve parent nonprofit(s) when npo_id is not provided (direct project page visit)
+  // A project can belong to multiple nonprofits
+  const { nonprofits: resolvedNonprofits } = useProjectNonprofit(problem_statement_id, npo_id);
+  const effectiveNpoId = npo_id || resolvedNonprofits[0]?.id;
   
   // States
   const [hackathonEvents, setHackathonEvents] = useState([]);  
@@ -832,21 +832,25 @@ export default function ProblemStatement({ problem_statement_id, user, npo_id })
               </Typography>
 
               {/* Nonprofit attribution - only show on direct project page visits */}
-              {!npo_id && resolvedNonprofit && (
-                <Chip
-                  component={Link}
-                  href={`/nonprofit/${resolvedNonprofit.id}`}
-                  label={`Project by ${resolvedNonprofit.name}`}
-                  clickable
-                  size="small"
-                  sx={{
-                    mb: 2,
-                    bgcolor: 'rgba(255,255,255,0.2)',
-                    color: 'white',
-                    '&:hover': { bgcolor: 'rgba(255,255,255,0.35)' },
-                    fontWeight: 600,
-                  }}
-                />
+              {!npo_id && resolvedNonprofits.length > 0 && (
+                <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap' }}>
+                  {resolvedNonprofits.map((npo) => (
+                    <Chip
+                      key={npo.id}
+                      component={Link}
+                      href={`/nonprofit/${npo.id}`}
+                      label={`Project by ${npo.name}`}
+                      clickable
+                      size="small"
+                      sx={{
+                        bgcolor: 'rgba(255,255,255,0.2)',
+                        color: 'white',
+                        '&:hover': { bgcolor: 'rgba(255,255,255,0.35)' },
+                        fontWeight: 600,
+                      }}
+                    />
+                  ))}
+                </Stack>
               )}
 
               <SkillSet Skills={problem_statement.skills} />

--- a/src/components/admin/NonprofitManagement.js
+++ b/src/components/admin/NonprofitManagement.js
@@ -36,6 +36,8 @@ import {
   Save as SaveIcon,
   Search as SearchIcon,
   Edit as EditIcon,
+  Visibility as VisibilityIcon,
+  VisibilityOff as VisibilityOffIcon,
 } from "@mui/icons-material";
 import axios from "axios";
 import ProblemStatementManagement from "./ProblemStatementManagement";
@@ -56,7 +58,10 @@ const NonprofitManagement = memo(({
   const [selectedNonprofitId, setSelectedNonprofitId] = useState("");
   const [problemStatementDialogOpen, setProblemStatementDialogOpen] = useState(false);
   const [selectedNonprofit, setSelectedNonprofit] = useState(null);
-  
+  const [visiblePsIds, setVisiblePsIds] = useState(hackathon?.visible_problem_statements || null);
+  const [visibilityDirty, setVisibilityDirty] = useState(false);
+  const [savingVisibility, setSavingVisibility] = useState(false);
+
   // Use refs to keep track of loading state and current hackathon ID to prevent race conditions
   const isLoadingRef = useRef(false);
   const hackathonIdRef = useRef(hackathon?.id);
@@ -284,6 +289,69 @@ const NonprofitManagement = memo(({
     }
   };
 
+  // Toggle visibility of a problem statement in the hackathon
+  const togglePsVisibility = (psId) => {
+    setVisiblePsIds((prev) => {
+      // If null (no visibility list yet), build one with all PS IDs minus the toggled one
+      if (prev === null) {
+        const allPsIds = getAllProblemStatementIds();
+        return allPsIds.filter((id) => id !== psId);
+      }
+      if (prev.includes(psId)) {
+        return prev.filter((id) => id !== psId);
+      }
+      return [...prev, psId];
+    });
+    setVisibilityDirty(true);
+  };
+
+  const isPsVisible = (psId) => {
+    // If no visibility list, all are visible
+    if (visiblePsIds === null) return true;
+    return visiblePsIds.includes(psId);
+  };
+
+  const getAllProblemStatementIds = () => {
+    const ids = [];
+    hackathonNonprofits.forEach((npoOrId) => {
+      const npo = getNonprofit(npoOrId);
+      if (npo?.problem_statements) {
+        npo.problem_statements.forEach((psId) => {
+          if (!ids.includes(psId)) ids.push(psId);
+        });
+      }
+    });
+    return ids;
+  };
+
+  const saveVisibility = async () => {
+    if (!hackathon?.id) return;
+    setSavingVisibility(true);
+    try {
+      await axios.patch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/hackathon/problem_statements`,
+        {
+          hackathonId: hackathon.id,
+          problemStatementIds: visiblePsIds || getAllProblemStatementIds(),
+        },
+        {
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            "content-type": "application/json",
+            "X-Org-Id": orgId,
+          },
+        }
+      );
+      setVisibilityDirty(false);
+      onUpdate();
+    } catch (error) {
+      console.error("Error saving visibility:", error);
+      onError("Failed to save project visibility settings");
+    } finally {
+      setSavingVisibility(false);
+    }
+  };
+
   // Filter out nonprofits that are already added to this hackathon
   const availableNonprofits = nonprofits.filter(
     nonprofit => !hackathonNonprofits.some(hn => hn.id === nonprofit.id)
@@ -375,11 +443,41 @@ const NonprofitManagement = memo(({
         </Box>
       </Paper>
 
+      {/* Project visibility save bar */}
+      {visibilityDirty && (
+        <Alert
+          severity="warning"
+          sx={{ mb: 2 }}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              startIcon={savingVisibility ? <CircularProgress size={16} /> : <SaveIcon />}
+              onClick={saveVisibility}
+              disabled={savingVisibility}
+            >
+              Save Visibility
+            </Button>
+          }
+        >
+          You have unsaved project visibility changes.
+        </Alert>
+      )}
+
       {/* Currently assigned nonprofits */}
       <Paper sx={{ p: 2 }}>
-        <Typography variant="subtitle1" gutterBottom>
-          Nonprofits in this Hackathon
-        </Typography>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
+          <Typography variant="subtitle1">
+            Nonprofits in this Hackathon
+          </Typography>
+          {hackathonNonprofits.length > 0 && (
+            <Typography variant="caption" color="text.secondary">
+              {visiblePsIds === null
+                ? `All projects visible`
+                : `${visiblePsIds.length} of ${getAllProblemStatementIds().length} projects visible`}
+            </Typography>
+          )}
+        </Box>
         
         {loading && hackathonNonprofits.length === 0 ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
@@ -444,28 +542,36 @@ const NonprofitManagement = memo(({
                       </Box>
 
                       {nonprofitProblemStatements.length > 0 ? (
-                        <Box
-                          sx={{
-                            display: "flex",
-                            flexWrap: "wrap",
-                            gap: 1,
-                            mb: 2,
-                          }}
-                        >
-                          {nonprofitProblemStatements.map((psId) => {
-                            const ps = problemStatements.find(
-                              (p) => p.id === psId
-                            );
-                            return ps ? (
-                              <Chip
-                                key={ps.id}
-                                label={ps.title}
-                                size="small"
-                                color="primary"
-                                variant="outlined"
-                              />
-                            ) : null;
-                          })}
+                        <Box sx={{ mb: 2 }}>
+                          <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
+                            Toggle visibility to control which projects appear on the hackathon page:
+                          </Typography>
+                          <Box
+                            sx={{
+                              display: "flex",
+                              flexWrap: "wrap",
+                              gap: 1,
+                            }}
+                          >
+                            {nonprofitProblemStatements.map((psId) => {
+                              const ps = problemStatements.find(
+                                (p) => p.id === psId
+                              );
+                              const visible = isPsVisible(psId);
+                              return ps ? (
+                                <Chip
+                                  key={ps.id}
+                                  icon={visible ? <VisibilityIcon fontSize="small" /> : <VisibilityOffIcon fontSize="small" />}
+                                  label={ps.title}
+                                  size="small"
+                                  color={visible ? "primary" : "default"}
+                                  variant={visible ? "filled" : "outlined"}
+                                  onClick={() => togglePsVisibility(ps.id)}
+                                  sx={{ cursor: "pointer" }}
+                                />
+                              ) : null;
+                            })}
+                          </Box>
                         </Box>
                       ) : (
                         <Typography variant="body2" color="text.secondary">

--- a/src/hooks/use-project-nonprofit.js
+++ b/src/hooks/use-project-nonprofit.js
@@ -6,13 +6,15 @@ import { useEnv } from "../context/env.context";
  * Hook to fetch the parent nonprofit(s) for a given problem statement / project.
  * Uses the reverse-lookup endpoint: GET /api/messages/problem_statement/{id}/nonprofit
  *
+ * A project can belong to multiple nonprofits, so this returns an array.
+ *
  * @param {string} problemStatementId - The project/problem statement ID
  * @param {string} [existingNpoId] - If already known (e.g. navigated from nonprofit page), skip the fetch
- * @returns {{ nonprofit: object|null, loading: boolean, error: string|null }}
+ * @returns {{ nonprofits: object[], loading: boolean, error: string|null }}
  */
 export default function useProjectNonprofit(problemStatementId, existingNpoId) {
   const { apiServerUrl } = useEnv();
-  const [nonprofit, setNonprofit] = useState(null);
+  const [nonprofits, setNonprofits] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -23,7 +25,7 @@ export default function useProjectNonprofit(problemStatementId, existingNpoId) {
     }
 
     let cancelled = false;
-    const fetchNonprofit = async () => {
+    const fetchNonprofits = async () => {
       setLoading(true);
       setError(null);
       try {
@@ -31,11 +33,11 @@ export default function useProjectNonprofit(problemStatementId, existingNpoId) {
           `${apiServerUrl}/api/messages/problem_statement/${problemStatementId}/nonprofit`
         );
         if (!cancelled && response.data?.nonprofits?.length > 0) {
-          setNonprofit(response.data.nonprofits[0]);
+          setNonprofits(response.data.nonprofits);
         }
       } catch (err) {
         if (!cancelled) {
-          console.error("Error fetching project nonprofit:", err);
+          console.error("Error fetching project nonprofits:", err);
           setError("Failed to load nonprofit information");
         }
       } finally {
@@ -45,12 +47,12 @@ export default function useProjectNonprofit(problemStatementId, existingNpoId) {
       }
     };
 
-    fetchNonprofit();
+    fetchNonprofits();
 
     return () => {
       cancelled = true;
     };
   }, [problemStatementId, existingNpoId, apiServerUrl]);
 
-  return { nonprofit, loading, error };
+  return { nonprofits, loading, error };
 }

--- a/src/hooks/use-project-nonprofit.js
+++ b/src/hooks/use-project-nonprofit.js
@@ -1,0 +1,56 @@
+import { useState, useEffect } from "react";
+import axios from "axios";
+import { useEnv } from "../context/env.context";
+
+/**
+ * Hook to fetch the parent nonprofit(s) for a given problem statement / project.
+ * Uses the reverse-lookup endpoint: GET /api/messages/problem_statement/{id}/nonprofit
+ *
+ * @param {string} problemStatementId - The project/problem statement ID
+ * @param {string} [existingNpoId] - If already known (e.g. navigated from nonprofit page), skip the fetch
+ * @returns {{ nonprofit: object|null, loading: boolean, error: string|null }}
+ */
+export default function useProjectNonprofit(problemStatementId, existingNpoId) {
+  const { apiServerUrl } = useEnv();
+  const [nonprofit, setNonprofit] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    // If we already have the nonprofit ID from props, don't fetch
+    if (existingNpoId || !problemStatementId || !apiServerUrl) {
+      return;
+    }
+
+    let cancelled = false;
+    const fetchNonprofit = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await axios.get(
+          `${apiServerUrl}/api/messages/problem_statement/${problemStatementId}/nonprofit`
+        );
+        if (!cancelled && response.data?.nonprofits?.length > 0) {
+          setNonprofit(response.data.nonprofits[0]);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Error fetching project nonprofit:", err);
+          setError("Failed to load nonprofit information");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchNonprofit();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [problemStatementId, existingNpoId, apiServerUrl]);
+
+  return { nonprofit, loading, error };
+}

--- a/src/pages/hack/[event_id].js
+++ b/src/pages/hack/[event_id].js
@@ -601,6 +601,7 @@ export default function HackathonEvent({ eventData }) {
               nonprofits={event.nonprofits}
               teams={event.teams}
               eventId={event_id}
+              visibleProblemStatements={event.visible_problem_statements}
             />
           </Grid>
 

--- a/src/pages/project/[project_id].js
+++ b/src/pages/project/[project_id].js
@@ -34,24 +34,24 @@ export async function getStaticProps({ params = {} } = {}) {
   );
   const ps = await res.json();
 
-  // Fetch parent nonprofit for SEO context
-  let nonprofitName = "";
+  // Fetch parent nonprofit(s) for SEO context — a project can belong to multiple nonprofits
+  let nonprofitNames = "";
   try {
     const npoRes = await fetch(
       `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/problem_statement/${params.project_id}/nonprofit`
     );
     const npoData = await npoRes.json();
     if (npoData?.nonprofits?.length > 0) {
-      nonprofitName = npoData.nonprofits[0].name || "";
+      nonprofitNames = npoData.nonprofits.map((n) => n.name).filter(Boolean).join(", ");
     }
   } catch (e) {
-    // Non-critical — continue without nonprofit name
+    // Non-critical — continue without nonprofit names
   }
 
-  var title = nonprofitName
-    ? `Project: ${ps.title} — ${nonprofitName}`
+  var title = nonprofitNames
+    ? `Project: ${ps.title} — ${nonprofitNames}`
     : "Project: " + ps.title;
-  var metaDescription = (nonprofitName ? `For ${nonprofitName}. ` : "") + ps.status + ": " + ps.description + " ";
+  var metaDescription = (nonprofitNames ? `For ${nonprofitNames}. ` : "") + ps.status + ": " + ps.description + " ";
   var countOfhelpingMentors = 0;
   var countOfhelpingHackers = 0;
 

--- a/src/pages/project/[project_id].js
+++ b/src/pages/project/[project_id].js
@@ -34,8 +34,24 @@ export async function getStaticProps({ params = {} } = {}) {
   );
   const ps = await res.json();
 
-  var title = "Project: " + ps.title;
-  var metaDescription = ps.status + ": " + ps.description + " ";
+  // Fetch parent nonprofit for SEO context
+  let nonprofitName = "";
+  try {
+    const npoRes = await fetch(
+      `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/problem_statement/${params.project_id}/nonprofit`
+    );
+    const npoData = await npoRes.json();
+    if (npoData?.nonprofits?.length > 0) {
+      nonprofitName = npoData.nonprofits[0].name || "";
+    }
+  } catch (e) {
+    // Non-critical — continue without nonprofit name
+  }
+
+  var title = nonprofitName
+    ? `Project: ${ps.title} — ${nonprofitName}`
+    : "Project: " + ps.title;
+  var metaDescription = (nonprofitName ? `For ${nonprofitName}. ` : "") + ps.status + ": " + ps.description + " ";
   var countOfhelpingMentors = 0;
   var countOfhelpingHackers = 0;
 


### PR DESCRIPTION
## Summary
- **Project pages** (`/project/[id]`) now show which nonprofit owns the project via a new reverse-lookup backend endpoint and a "Project by [Name]" chip in the hero section
- **Hackathon pages** (`/hack/[event_id]`) now have a Nonprofits/Projects toggle so users can browse by organization or by individual project
- **Admin hackathon management** (`/admin/hackathons`) now supports per-project visibility toggles within each nonprofit, controlling which projects appear on the public hackathon page
- Fixes broken `/nonprofit/undefined` redirect that occurred when visiting project pages directly

## Changes

### Backend (in `backend-ohack.dev` repo — separate commit needed)
- `GET /api/messages/problem_statement/{id}/nonprofit` — reverse lookup endpoint
- `PATCH /api/messages/hackathon/problem_statements` — update visible projects for a hackathon
- `visible_problem_statements` field support in hackathon save/update

### Frontend
- New `use-project-nonprofit.js` hook for resolving parent nonprofit
- `ProblemStatement.js` — nonprofit chip + effectiveNpoId for analytics/API calls
- `NonprofitList.js` — toggle between Nonprofits and Projects views with localStorage persistence
- `NonprofitManagement.js` — visibility toggle chips per project with save functionality
- `[project_id].js` — nonprofit name in SEO meta tags
- `[event_id].js` — passes `visible_problem_statements` to NonprofitList

## Test plan
- [ ] Visit `/project/KNcxMWT2sfZWxGvcyYe3` directly — should show "Project by [Nonprofit]" chip
- [ ] Visit `/nonprofit/D41SIwT6pc48JNy5zUX7` — should NOT show the nonprofit chip on project cards (already on nonprofit page)
- [ ] Visit `/hack/2026_spring_wics_asu` — toggle between Nonprofits and Projects views
- [ ] Refresh hackathon page — toggle preference should persist via localStorage
- [ ] In `/admin/hackathons`, edit a hackathon → Nonprofits tab → expand a nonprofit → toggle project visibility chips
- [ ] Save visibility → verify filtered projects appear/disappear on public hackathon page

🤖 Generated with [Claude Code](https://claude.com/claude-code)