### PR TITLE
Fix premature Hackathon Ended badge due to UTC date parsing

### DIFF
--- a/src/components/Hackathon/TeamList.js
+++ b/src/components/Hackathon/TeamList.js
@@ -182,18 +182,25 @@ const LoadingIndicator = ({ message }) => (
 );
 
 // Utility function to check if hackathon has ended
-const isHackathonExpired = (endDate) => {  
+// Compares "now" to end-of-day in the hackathon's own timezone so viewers in
+// other timezones don't see a premature "Hackathon Ended" badge.
+const isHackathonExpired = (endDate, eventTimezone) => {
   if (!endDate) return false;
-  const now = new Date();
-  const hackathonEnd = new Date(endDate);
-  
-  // Set the end time to 11:59:59 PM of the end date to allow participation until the last minute
-  hackathonEnd.setHours(23, 59, 59, 999);
 
-  console.log("Hackathon Current time:", now);
-  console.log("Hackathon end time:", hackathonEnd);
-  
-  return now > hackathonEnd;
+  const tz = eventTimezone || 'America/Phoenix';
+
+  // Get the current date/time as it appears in the event timezone
+  const nowInTz = new Date(new Date().toLocaleString('en-US', { timeZone: tz }));
+
+  // Build end-of-day for the end date in the event timezone
+  // endDate is "YYYY-MM-DD"; parse parts to avoid UTC-midnight pitfall
+  const [year, month, day] = endDate.split('-').map(Number);
+  const endInTz = new Date(year, month - 1, day, 23, 59, 59, 999);
+
+  console.log("Hackathon current time in", tz, ":", nowInTz);
+  console.log("Hackathon end time in", tz, ":", endInTz);
+
+  return nowInTz > endInTz;
 };
 
 // Utility function to render team status chip
@@ -1194,7 +1201,7 @@ const TeamCard = ({ team, userProfile, isLoggedIn, onJoin, onLeave, loadingTeamI
   );
 };
 
-const TeamList = ({ teams, event_id, id, endDate, constraints = {} }) => {
+const TeamList = ({ teams, event_id, id, endDate, eventTimezone, constraints = {} }) => {
   const [teamData, setTeamData] = useState(teams);
   const [loading, setLoading] = useState(false);
   const [profilesLoading, setProfilesLoading] = useState(false);
@@ -1529,7 +1536,7 @@ const TeamList = ({ teams, event_id, id, endDate, constraints = {} }) => {
               onJoin={handleJoinTeam}
               onLeave={handleUnjoinTeam}
               loadingTeamId={loadingTeamId}
-              isHackathonExpired={isHackathonExpired(endDate)}
+              isHackathonExpired={isHackathonExpired(endDate, eventTimezone)}
               teamJoinEnabled={teamJoinEnabled}
               nonprofitMap={nonprofitMap}
               accessToken={accessToken}

--- a/src/pages/hack/[event_id].js
+++ b/src/pages/hack/[event_id].js
@@ -752,6 +752,7 @@ export default function HackathonEvent({ eventData }) {
                   event_id={event_id}
                   id={event.id}
                   endDate={event.end_date}
+                  eventTimezone={event.timezone}
                   constraints={event.constraints}
                 />
               </Box>


### PR DESCRIPTION
## Summary
- `new Date("YYYY-MM-DD")` parses date-only strings as UTC midnight, which shifts the effective end date back a day for timezones west of UTC (e.g., MST)
- The "Hackathon Ended" badge was showing ~7 hours early for the ASU WiCS hackathon (`America/Phoenix`)
- `isHackathonExpired` now uses the event's `timezone` field from the API to correctly determine end-of-day in the hackathon's local timezone

## Test plan
- [ ] Verify the hackathon page at `/hack/2026_spring_wics_asu#teams` no longer shows "Hackathon Ended" prematurely on March 29
- [ ] Verify it correctly shows "Hackathon Ended" after 11:59 PM MST on March 29
- [ ] Verify team join/leave buttons remain enabled during the hackathon

🤖 Generated with [Claude Code](https://claude.com/claude-code)