### PR TITLE
Add community champions page with tier system and revamp hearts page

### DIFF
--- a/src/components/About/Hearts/Hearts.js
+++ b/src/components/About/Hearts/Hearts.js
@@ -1,416 +1,706 @@
-import React from 'react';
-import { useEffect } from 'react';
-import { 
-  Typography, 
-  Grid, 
-  Card, 
-  CardContent, 
+import React, { useEffect } from "react";
+import {
+  Typography,
+  Grid,
   Button,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Paper,
-  useTheme,
-  useMediaQuery,
   Box,
+  Chip,
   Accordion,
   AccordionSummary,
-  AccordionDetails
-} from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { styled } from '@mui/system';
-import Head from 'next/head';
-import Image from 'next/image';
-import { InstagramEmbed } from 'react-social-media-embed';
-import LoginOrRegister from '../../LoginOrRegister/LoginOrRegister';
-import { LayoutContainer, TitleContainer, ProjectsContainer } from '../../../styles/nonprofit/styles';
-import RewardStructure from './RewardStructure';
-import Link from 'next/link';
-import { FaGavel, FaChalkboardTeacher, FaHeart } from 'react-icons/fa';
-import { initFacebookPixel, trackEvent } from '../../../lib/ga';
+  AccordionDetails,
+  Container,
+  Divider,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Head from "next/head";
+import Image from "next/image";
+import { InstagramEmbed } from "react-social-media-embed";
+import LoginOrRegister from "../../LoginOrRegister/LoginOrRegister";
+import RewardStructure from "./RewardStructure";
+import Link from "next/link";
+import {
+  FaGavel,
+  FaChalkboardTeacher,
+  FaHeart,
+  FaTrophy,
+  FaCode,
+  FaClipboardList,
+  FaFileAlt,
+  FaDraftingCompass,
+  FaCheckCircle,
+  FaEye,
+  FaUsers,
+  FaBolt,
+  FaRocket,
+  FaStar,
+  FaArrowRight,
+} from "react-icons/fa";
+import { initFacebookPixel, trackEvent } from "../../../lib/ga";
+import { TIERS } from "../../../lib/heartTiers";
 
+const track = (label) => trackEvent("click_hearts", label);
 
- const trackOnClickButtonClickWithGoogleAndFacebook = (buttonName) => {
-    trackEvent("click_hearts", buttonName);
-  }
-
-const StyledTypography = styled(Typography)(({ theme }) => ({
-  fontSize: '15px',
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '13px',
+// ─── How-it-works steps ───────────────────────────────────────────────
+const steps = [
+  {
+    icon: <FaClipboardList />,
+    title: "Choose a project",
+    text: "Browse open-source projects for nonprofits and pick one that matches your skills.",
   },
-}));
+  {
+    icon: <FaCode />,
+    title: "Contribute",
+    text: "Write code, design interfaces, gather requirements, or manage tasks — every role counts.",
+  },
+  {
+    icon: <FaHeart />,
+    title: "Earn hearts",
+    text: "The more impactful your contribution, the more hearts you earn per category.",
+  },
+  {
+    icon: <FaTrophy />,
+    title: "Level up",
+    text: "Advance from Bronze to Diamond, unlocking rewards and recognition along the way.",
+  },
+];
 
-const JudgeMentorHeartsCTA = () => {
-  return (
-    <Box sx={{ mb:4, mt: 4, p: 3, bgcolor: 'background.paper', borderRadius: 2, boxShadow: 1 }}>
-      <Typography variant="h5" gutterBottom>
-        Earn Hearts as a Judge or Mentor!
-      </Typography>
-      <Typography variant="body1" paragraph>
-        Did you know you can earn hearts by contributing as a judge or mentor? It's a great way to give back and boost your profile!
-      </Typography>
-      <Grid container spacing={2}>
-        <Grid size={{ xs: 12, sm: 6 }}>
-          <Box display="flex" alignItems="center" mb={2}>
-            <FaGavel size={24} style={{ marginRight: '8px' }} />
-            <Typography variant="body1">
-              Judges earn 1 heart per 3-hour block
-            </Typography>
-          </Box>
-          <Link href="/about/judges" passHref>
-            <Button
-              component="a"
-              variant="contained"
-              color="primary"
-              startIcon={<FaHeart />}
-              onClick={
-                () => trackOnClickButtonClickWithGoogleAndFacebook("judges")
-              }
-            >
-              Learn About Judging
-            </Button>
-          </Link>
-        </Grid>
-        <Grid size={{ xs: 12, sm: 6 }}>
-          <Box display="flex" alignItems="center" mb={2}>
-            <FaChalkboardTeacher size={24} style={{ marginRight: '8px' }} />
-            <Typography variant="body1">
-              Mentors earn 1 heart per 3-hour block
-            </Typography>
-          </Box>
-          <Link href="/about/mentors" passHref>
-            <Button
-              onClick={ 
-                () => trackOnClickButtonClickWithGoogleAndFacebook("mentors")
-              }
-              component="a"
-              variant="contained"
-              color="secondary"
-              startIcon={<FaHeart />}
-            >
-              Learn About Mentoring
-            </Button>
-          </Link>
-        </Grid>
-      </Grid>
-    </Box>
-  );
+// ─── Contribution categories ──────────────────────────────────────────
+const contributions = {
+  what: [
+    { icon: <FaRocket size={18} />, label: "Productionalized projects" },
+    { icon: <FaUsers size={18} />, label: "Requirements gathering" },
+    { icon: <FaFileAlt size={18} />, label: "Documentation" },
+    { icon: <FaDraftingCompass size={18} />, label: "Design architecture" },
+    { icon: <FaCheckCircle size={18} />, label: "Code quality" },
+    { icon: <FaCode size={18} />, label: "Unit tests" },
+    { icon: <FaEye size={18} />, label: "Observability" },
+  ],
+  how: [
+    { icon: <FaClipboardList size={18} />, label: "Standups completed" },
+    { icon: <FaBolt size={18} />, label: "Code reliability" },
+    { icon: <FaUsers size={18} />, label: "Customer-driven innovation & design thinking" },
+    { icon: <FaRocket size={18} />, label: "Iterations pushed to production" },
+  ],
 };
 
-const StyledProjectsContainer = styled(ProjectsContainer)(({ theme }) => ({
-  width: '100%',
-  maxWidth: 'none',
-  padding: theme.spacing(2),
-  [theme.breakpoints.up('md')]: {
-    padding: theme.spacing(3),
+// ─── Scoring guide (accordions) ───────────────────────────────────────
+const scoringLevels = [
+  {
+    hearts: "0.5",
+    title: "Partially met goal",
+    what: "Partial completion of tasks — code complete but not in production, partial docs, <50% architecture coverage, lint warnings or outstanding PRs, some unit tests, <50% observability.",
+    how: "At least 1 standup, code has errors or is slow, spoke to customer once, pushed code once.",
   },
-}));
-
-const StyledTableContainer = styled(TableContainer)(({ theme }) => ({
-  width: '100%',
-  overflowX: 'auto',
-  marginBottom: theme.spacing(3),
-  '& .MuiTable-root': {
-    minWidth: '100%',
+  {
+    hearts: "1",
+    title: "Met goal",
+    what: "More than 90% completion across all categories.",
+    how: "3+ standups, reliable error-free code, 3+ customer interactions with documentation, 3+ production pushes.",
   },
-}));
-
-const StyledTableCell = styled(TableCell)(({ theme }) => ({
-  fontSize: '15px',
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '13px',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    borderBottom: 'none',
-    padding: '8px 16px',
-    '&:before': {
-      content: 'attr(data-label)',
-      fontWeight: 'bold',
-      marginBottom: '4px',
-    },
+  {
+    hearts: "1.5",
+    title: "Exceeded goal",
+    what: "100%+ completion, delivered 25% faster than expected.",
+    how: "8 standups, fault-tolerant reliable code over 1 week, 8 customer interactions, 8 production pushes.",
   },
-}));
-
-const StyledTableRow = styled(TableRow)(({ theme }) => ({
-  [theme.breakpoints.down('sm')]: {
-    display: 'flex',
-    flexDirection: 'column',
-    borderBottom: `1px solid ${theme.palette.divider}`,
+  {
+    hearts: "2",
+    title: "Greatly exceeded goal",
+    what: "100%+ completion, delivered 50% faster than expected.",
+    how: "15+ standups, outstanding reliability over 2 weeks, 15+ customer interactions, 15+ production pushes.",
   },
-}));
-
-const rewardStructure = [
-  { hearts: 2, reward: "Certificate" },
-  { hearts: 4, reward: "IG/FB Shoutout" },
-  { hearts: 5, reward: "LinkedIn Recommendation" },
-  { hearts: 6, reward: "Interview prep & resume review" },
-  { hearts: 10, reward: "Reference for job application" },
-  { hearts: 24, reward: "Opportunity Hack swag" },
-  { hearts: 48, reward: "Sponsor-provided tech award" },
 ];
 
-const heartCategories = [
-  { category: "What", items: [
-    "Productionalized projects", "Requirements Gathering", "Documentation",
-    "Design architecture", "Code quality", "Unit tests", "Observability"
-  ]},
-  { category: "How", items: [
-    "Standups completed", "Code reliability", 
-    "Customer Driven Innovation (CDI) and Design Thinking",
-    "Iterations of code pushed to production"
-  ]}
-];
+// ─── Section wrapper ──────────────────────────────────────────────────
+const Section = ({ children, sx, ...props }) => (
+  <Box sx={{ mb: { xs: 5, md: 7 }, ...sx }} {...props}>
+    {children}
+  </Box>
+);
 
+const SectionTitle = ({ children, subtitle }) => (
+  <Box sx={{ mb: 3 }}>
+    <Typography
+      variant="h4"
+      component="h2"
+      sx={{ fontWeight: 700, fontSize: { xs: "1.6rem", md: "2.15rem" }, mb: subtitle ? 1.5 : 0 }}
+    >
+      {children}
+    </Typography>
+    {subtitle && (
+      <Typography variant="body1" sx={{ color: "text.secondary", maxWidth: 720, fontSize: { xs: "1rem", md: "1.1rem" }, lineHeight: 1.7 }}>
+        {subtitle}
+      </Typography>
+    )}
+  </Box>
+);
+
+// ═════════════════════════════════════════════════════════════════════════
 const Hearts = () => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
     initFacebookPixel();
   }, []);
 
-
- 
-
   return (
-    <LayoutContainer>
+    <Box sx={{ pt: { xs: 10, md: 12 }, pb: 8, backgroundColor: "#fff" }}>
       <Head>
         <title>Earn Hearts, Make Impact: The Opportunity Hack Rewards System</title>
-        <meta name="description" content="Join Opportunity Hack and earn hearts by contributing to open source projects for nonprofits around the world." />
-        <meta property="og:title" content="Earn Hearts, Make Impact: The Opportunity Hack Rewards System" />
-        <meta property="og:description" content="Join Opportunity Hack and earn hearts by contributing to open source projects for nonprofits around the world. The Hearts System recognizes and rewards your contributions, allowing you to make a positive impact on the lives of others." />
-        <meta property="og:image" content="https://i.imgur.com/pzcF1aj.jpg" />
-        <meta property="og:url" content="https://hearts.ohack.dev" />
+        <meta
+          name="description"
+          content="Join Opportunity Hack and earn hearts by contributing to open source projects for nonprofits around the world."
+        />
       </Head>
-      
-      <TitleContainer>  
-        <Typography variant="h3" component="h1" gutterBottom>
-          Opportunity Hack Hearts System
-        </Typography>
-        
-        <Grid container spacing={3}>            
-          <Grid size={{ xs: 12, sm: 6, md: 8 }}>
-            <StyledTypography paragraph>
-              Welcome to the Opportunity Hack Hearts System! By contributing to open source projects for nonprofits, you can earn hearts and make a positive impact on the world. Whether you are a Software Engineer, Product Manager, UX Designer, or Project Manager, your skills are valuable in creating solutions that help nonprofits achieve their goals.
-            </StyledTypography>
-            <Grid container spacing={2}>
-              <Grid size="auto">
-                <Button onClick={
-                  () => trackOnClickButtonClickWithGoogleAndFacebook("original_rfc")
-                } variant="contained" color="primary" href="https://docs.google.com/document/d/1J-1o5YOpdt4slyd_PxitNN0gZe7UcI1GjyTbhTem2qU/edit?usp=sharing" target="_blank">
-                  See the Original RFC
-                </Button>
+
+      {/* ── Hero ─────────────────────────────────────────────────── */}
+      <Box
+        sx={{
+          background: "linear-gradient(135deg, #fce4ec 0%, #fff3e0 50%, #e8f5e9 100%)",
+          py: { xs: 5, md: 8 },
+          px: 2,
+          textAlign: "center",
+          mb: { xs: 4, md: 6 },
+        }}
+      >
+        <Container maxWidth="md">
+          <FaHeart size={40} color="#e53935" />
+          <Typography
+            variant="h2"
+            component="h1"
+            sx={{
+              fontWeight: 800,
+              fontSize: { xs: "2rem", md: "3rem" },
+              mt: 2,
+              mb: 2,
+            }}
+          >
+            The Hearts System
+          </Typography>
+          <Typography
+            variant="h6"
+            component="p"
+            sx={{
+              color: "text.secondary",
+              fontWeight: 400,
+              maxWidth: 640,
+              mx: "auto",
+              lineHeight: 1.7,
+              mb: 3,
+            }}
+          >
+            Contribute your skills to open-source projects for nonprofits, earn
+            hearts, and advance through five tiers of recognition — from Bronze to
+            Diamond.
+          </Typography>
+          <Box sx={{ display: "flex", gap: 1.5, justifyContent: "center", flexWrap: "wrap" }}>
+            <Link href="/community-champions" passHref>
+              <Button
+                variant="contained"
+                size="large"
+                startIcon={<FaTrophy />}
+                onClick={() => track("community_champions")}
+                sx={{ textTransform: "none", fontWeight: 600, borderRadius: 2 }}
+              >
+                See Community Champions
+              </Button>
+            </Link>
+            <Link href="/about/completion" passHref>
+              <Button
+                variant="outlined"
+                size="large"
+                onClick={() => track("project_completion")}
+                sx={{ textTransform: "none", fontWeight: 600, borderRadius: 2 }}
+              >
+                Project Completion Guide
+              </Button>
+            </Link>
+          </Box>
+        </Container>
+      </Box>
+
+      <Container maxWidth="lg">
+        {/* ── How it works ──────────────────────────────────────── */}
+        <Section>
+          <SectionTitle subtitle="Four steps from newcomer to community champion.">
+            How the Hearts System Works
+          </SectionTitle>
+
+          <Grid container spacing={2.5}>
+            {steps.map((step, i) => (
+              <Grid size={{ xs: 6, md: 3 }} key={i}>
+                <Paper
+                  elevation={0}
+                  sx={{
+                    p: { xs: 2, md: 3 },
+                    height: "100%",
+                    borderRadius: 3,
+                    border: "1px solid",
+                    borderColor: "grey.200",
+                    textAlign: "center",
+                    transition: "box-shadow 0.2s",
+                    "&:hover": { boxShadow: "0 4px 20px rgba(0,0,0,0.06)" },
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 48,
+                      height: 48,
+                      borderRadius: "50%",
+                      background: `linear-gradient(135deg, ${theme.palette.primary.light}30, ${theme.palette.secondary.light}30)`,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      mx: "auto",
+                      mb: 1.5,
+                      fontSize: 20,
+                      color: theme.palette.primary.main,
+                    }}
+                  >
+                    {step.icon}
+                  </Box>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 0.5, fontSize: { xs: "0.95rem", md: "1.05rem" } }}>
+                    {i + 1}. {step.title}
+                  </Typography>
+                  <Typography variant="body1" sx={{ color: "text.secondary", fontSize: { xs: "0.9rem", md: "0.95rem" } }}>
+                    {step.text}
+                  </Typography>
+                </Paper>
               </Grid>
-              <Grid size="auto">
-                <Button
-                  onClick={
-                    () => trackOnClickButtonClickWithGoogleAndFacebook("project_completion")
-                  }
-                variant="outlined" color="primary" href="/about/completion">
-                  Project Completion
-                </Button>
+            ))}
+          </Grid>
+        </Section>
+
+        {/* ── Earn hearts as Judge / Mentor ──────────────────────── */}
+        <Section>
+          <Paper
+            elevation={0}
+            sx={{
+              p: { xs: 3, md: 4 },
+              borderRadius: 3,
+              background: "linear-gradient(135deg, #e3f2fd 0%, #f3e5f5 100%)",
+              border: "1px solid #e1bee7",
+            }}
+          >
+            <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, fontSize: { xs: "1.3rem", md: "1.5rem" } }}>
+              Earn Hearts as a Judge or Mentor
+            </Typography>
+            <Typography variant="body1" sx={{ color: "text.secondary", mb: 3, fontSize: { xs: "1rem", md: "1.1rem" } }}>
+              Beyond hacking, you can earn 1 heart per 3-hour block by judging
+              or mentoring at an event.
+            </Typography>
+            <Grid container spacing={3}>
+              <Grid size={{ xs: 12, sm: 6 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1.5,
+                    mb: 2,
+                    p: 2,
+                    borderRadius: 2,
+                    backgroundColor: "rgba(255,255,255,0.7)",
+                  }}
+                >
+                  <FaGavel size={22} color={theme.palette.primary.main} />
+                  <Box>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                      Judging
+                    </Typography>
+                    <Typography variant="body1" sx={{ color: "text.secondary" }}>
+                      1 heart per 3-hour block
+                    </Typography>
+                  </Box>
+                </Box>
+                <Link href="/about/judges" passHref>
+                  <Button
+                    variant="contained"
+                    startIcon={<FaArrowRight />}
+                    onClick={() => track("judges")}
+                    sx={{ textTransform: "none", fontWeight: 600, borderRadius: 2 }}
+                  >
+                    Learn About Judging
+                  </Button>
+                </Link>
               </Grid>
-              <Grid size="auto">
-                <Button onClick={
-                  () => trackOnClickButtonClickWithGoogleAndFacebook("github_issue_8")
-                }
-                variant="outlined" color="primary" href="https://github.com/opportunity-hack/frontend-ohack.dev/issues/8" target="_blank">
-                  GitHub Issue #8
-                </Button>
-              </Grid>
-              <Grid size="auto">
-                <Button onClick={
-                  () => trackOnClickButtonClickWithGoogleAndFacebook("github_issue_7")
-                } variant="outlined" color="primary" href="https://github.com/opportunity-hack/frontend-ohack.dev/issues/7" target="_blank">
-                  GitHub Issue #7
-                </Button>
+              <Grid size={{ xs: 12, sm: 6 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1.5,
+                    mb: 2,
+                    p: 2,
+                    borderRadius: 2,
+                    backgroundColor: "rgba(255,255,255,0.7)",
+                  }}
+                >
+                  <FaChalkboardTeacher size={22} color={theme.palette.secondary.main} />
+                  <Box>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                      Mentoring
+                    </Typography>
+                    <Typography variant="body1" sx={{ color: "text.secondary" }}>
+                      1 heart per 3-hour block
+                    </Typography>
+                  </Box>
+                </Box>
+                <Link href="/about/mentors" passHref>
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    startIcon={<FaArrowRight />}
+                    onClick={() => track("mentors")}
+                    sx={{ textTransform: "none", fontWeight: 600, borderRadius: 2 }}
+                  >
+                    Learn About Mentoring
+                  </Button>
+                </Link>
               </Grid>
             </Grid>
-            <Box mt={2}>
-              <Image 
-                src="https://cdn.ohack.dev/8d2a68667a6911ee9e03e2f442f28a46.png"
-                width={971/3}
-                height={971/3}
-                alt="Opportunity Hack Hearts Certificate Example"                
-              />
-              <StyledTypography variant="caption" display="block">
-                Example Hearts Certificate
-              </StyledTypography>
-            </Box>
+          </Paper>
+        </Section>
+
+        {/* ── Contribution categories ───────────────────────────── */}
+        <Section>
+          <SectionTitle subtitle="Hearts are awarded across two dimensions — what you build and how you build it.">
+            Types of Contributions
+          </SectionTitle>
+
+          <Grid container spacing={3}>
+            {[
+              { key: "what", label: "What You Build", color: theme.palette.primary.main },
+              { key: "how", label: "How You Build It", color: theme.palette.secondary.main },
+            ].map(({ key, label, color }) => (
+              <Grid size={{ xs: 12, md: 6 }} key={key}>
+                <Paper
+                  elevation={0}
+                  sx={{
+                    p: 3,
+                    borderRadius: 3,
+                    border: "1px solid",
+                    borderColor: "grey.200",
+                    height: "100%",
+                  }}
+                >
+                  <Chip
+                    label={label}
+                    size="small"
+                    sx={{
+                      mb: 2,
+                      fontWeight: 700,
+                      backgroundColor: `${color}15`,
+                      color: color,
+                    }}
+                  />
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                    {contributions[key].map((item) => (
+                      <Box
+                        key={item.label}
+                        sx={{ display: "flex", alignItems: "center", gap: 1.5 }}
+                      >
+                        <Box sx={{ color: color, flexShrink: 0 }}>{item.icon}</Box>
+                        <Typography variant="body1" sx={{ fontSize: { xs: "0.95rem", md: "1rem" } }}>{item.label}</Typography>
+                      </Box>
+                    ))}
+                  </Box>
+                </Paper>
+              </Grid>
+            ))}
           </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 4 }}>                
-            <InstagramEmbed url="https://www.instagram.com/p/CoupvGxuiLX/" maxWidth={328} height={500} />
-          </Grid>                                
-        </Grid>
-      </TitleContainer>
-        
-      <StyledProjectsContainer>
-        <Typography variant="h4" gutterBottom>
-          Earn Hearts and Make a Difference
-        </Typography>
-        <StyledTypography paragraph>
-          Are you passionate about making a tangible, meaningful difference in the world through open source projects? The Opportunity Hack Hearts System offers you the chance to earn hearts by contributing to projects for nonprofits. Your skills and expertise can transform ideas into impactful solutions that benefit communities worldwide.
-        </StyledTypography>
-        <StyledTypography paragraph>
-          As a contributor, you play a vital role in the hearts system. Your contributions help nonprofits address real-world challenges and create sustainable solutions. By earning hearts, you not only showcase your skills but also make a lasting impact on the lives of others. Join us and be part of a community that uses technology to drive positive change.
-        </StyledTypography>
+        </Section>
 
-        <JudgeMentorHeartsCTA />
+        {/* ── Tier & reward structure ───────────────────────────── */}
+        <Section>
+          <SectionTitle subtitle="Advance through five tiers as you accumulate hearts — each unlocking new rewards and community recognition.">
+            Tier &amp; Reward Structure
+          </SectionTitle>
 
-        <Typography variant="h4" gutterBottom>
-          How the Hearts System Works
-        </Typography>
-        <StyledTypography paragraph>
-          The hearts system is designed to recognize and reward your contributions. Here's how it works:
-        </StyledTypography>
-        <ol>
-          <li><StyledTypography>Choose a project: Browse through the available open source projects for nonprofits and select one that aligns with your interests and skills.</StyledTypography></li>
-          <li><StyledTypography>Contribute: Dive into the project and start contributing. Whether it's writing code, designing user interfaces, or managing project tasks, your contributions are valuable.</StyledTypography></li>
-          <li><StyledTypography>Earn hearts: As you make contributions, you'll earn hearts. The more impactful your contributions, the more hearts you'll earn.</StyledTypography></li>
-          <li><StyledTypography>Level up: As you accumulate hearts, you'll level up in the hearts system. Higher levels unlock additional benefits and recognition within the Opportunity Hack community.</StyledTypography></li>
-        </ol>
+          {/* Tier journey — visual timeline */}
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: { xs: "column", md: "row" },
+              gap: { xs: 2, md: 0 },
+              mb: 4,
+              position: "relative",
+            }}
+          >
+            {/* Desktop connecting line */}
+            <Box
+              sx={{
+                display: { xs: "none", md: "block" },
+                position: "absolute",
+                top: 32,
+                left: "5%",
+                right: "5%",
+                height: 3,
+                background: `linear-gradient(90deg, ${TIERS[0].color}, ${TIERS[1].color}, ${TIERS[2].color}, ${TIERS[3].color}, ${TIERS[4].color})`,
+                borderRadius: 2,
+                zIndex: 0,
+              }}
+            />
+            {TIERS.map((tier, i) => (
+              <Box
+                key={tier.name}
+                sx={{
+                  flex: 1,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  position: "relative",
+                  zIndex: 1,
+                }}
+              >
+                {/* Tier circle */}
+                <Box
+                  sx={{
+                    width: 64,
+                    height: 64,
+                    borderRadius: "50%",
+                    backgroundColor: tier.color,
+                    border: tier.name === "Diamond" ? "2px solid #90caf9" : "3px solid #fff",
+                    boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    mb: 1.5,
+                  }}
+                >
+                  <FaTrophy
+                    size={24}
+                    color={
+                      tier.name === "Gold" || tier.name === "Platinum" || tier.name === "Diamond"
+                        ? "#333"
+                        : "#fff"
+                    }
+                  />
+                </Box>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 0.25, fontSize: { xs: "1rem", md: "1.1rem" } }}>
+                  {tier.name}
+                </Typography>
+                <Typography variant="body2" sx={{ color: "text.secondary", mb: 1, fontSize: { xs: "0.85rem", md: "0.9rem" } }}>
+                  {tier.minHearts}+ hearts
+                </Typography>
+                {/* Rewards under each tier */}
+                <Box sx={{ textAlign: "center" }}>
+                  {tier.rewards.map((r) => (
+                    <Typography
+                      key={r.hearts}
+                      variant="body2"
+                      sx={{
+                        display: "block",
+                        color: "text.secondary",
+                        lineHeight: 1.6,
+                        fontSize: { xs: "0.85rem", md: "0.9rem" },
+                      }}
+                    >
+                      {r.reward}
+                    </Typography>
+                  ))}
+                </Box>
+              </Box>
+            ))}
+          </Box>
 
-        <Typography variant="h4" gutterBottom>
-          Types of Contributions
-        </Typography>
-        <StyledTypography paragraph>
-          The hearts system recognizes various types of contributions. Here are the main categories:
-        </StyledTypography>
-        
-        <StyledTableContainer component={Paper}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <StyledTableCell>Category</StyledTableCell>
-                <StyledTableCell>Contribution Areas</StyledTableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {heartCategories.map((category) => (
-                <StyledTableRow key={category.category}>
-                  <StyledTableCell data-label="Category">{category.category}</StyledTableCell>
-                  <StyledTableCell data-label="Contribution Areas">
-                    <ul>
-                      {category.items.map((item, index) => (
-                        <li key={index}><StyledTypography>{item}</StyledTypography></li>
-                      ))}
-                    </ul>
-                  </StyledTableCell>
-                </StyledTableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </StyledTableContainer>
+          <Box sx={{ textAlign: "center" }}>
+            <Link href="/community-champions" passHref>
+              <Button
+                variant="outlined"
+                startIcon={<FaStar />}
+                onClick={() => track("community_champions_tier")}
+                sx={{ textTransform: "none", fontWeight: 600, borderRadius: 2 }}
+              >
+                See Our Community Champions
+              </Button>
+            </Link>
+          </Box>
+        </Section>
 
-        <Typography variant="h4" gutterBottom>
-          Reward Structure
-        </Typography>
-        <StyledTypography paragraph>
-          As you accumulate hearts, you unlock various rewards. Here's what you can earn:
-        </StyledTypography>
-        
-        <StyledTableContainer component={Paper}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <StyledTableCell>Hearts Required</StyledTableCell>
-                <StyledTableCell>Reward</StyledTableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rewardStructure.map((reward) => (
-                <StyledTableRow key={reward.hearts}>
-                  <StyledTableCell data-label="Hearts Required">{reward.hearts}</StyledTableCell>
-                  <StyledTableCell data-label="Reward">{reward.reward}</StyledTableCell>
-                </StyledTableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </StyledTableContainer>
+        {/* ── Scoring guide ─────────────────────────────────────── */}
+        <Section>
+          <SectionTitle subtitle="Each contribution is scored on a 0.5–2 heart scale per category. Here's what each level looks like.">
+            Scoring Guide
+          </SectionTitle>
 
-        <Typography variant="h4" gutterBottom>
-          Rewards
-        </Typography>
-        <StyledTypography paragraph>
-            The hearts system offers a range of rewards to recognize your contributions. Here are the rewards you can earn:
-        </StyledTypography>
-        
-        
-        <Accordion>
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <StyledTypography>Reward: 0.5 heart</StyledTypography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <StyledTypography variant="h6">Partially met goal</StyledTypography>
-            <StyledTypography paragraph>
-              <strong>What:</strong> Partial completion of tasks such as productionalized projects, requirements gathering, documentation, design architecture, code quality, unit tests, and observability.
-            </StyledTypography>
-            <StyledTypography paragraph>
-              <strong>How:</strong> Partial completion of standups, code reliability, customer-driven innovation, and iterations of code pushed to production.
-            </StyledTypography>
-          </AccordionDetails>
-        </Accordion>
-        
-        <Accordion>
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <StyledTypography>Reward: 1 heart</StyledTypography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <StyledTypography variant="h6">Met goal</StyledTypography>
-            <StyledTypography paragraph>
-              <strong>What:</strong> More than 90% completion of tasks.
-            </StyledTypography>
-            <StyledTypography paragraph>
-              <strong>How:</strong> Completion of at least 3 standups, reliable code, significant customer interaction, and multiple code iterations pushed to production.
-            </StyledTypography>
-          </AccordionDetails>
-        </Accordion>
-        
-        <Accordion>
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <StyledTypography>Reward: 1.5 hearts</StyledTypography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <StyledTypography variant="h6">Exceeded goal</StyledTypography>
-            <StyledTypography paragraph>
-              More than 100% completion and work done 25% faster than expected. This includes 8 standups, high code reliability, extensive customer interaction, and multiple code iterations.
-            </StyledTypography>
-          </AccordionDetails>
-        </Accordion>
-        
-        <Accordion>
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <StyledTypography>Reward: 2 hearts</StyledTypography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <StyledTypography variant="h6">Greatly exceeded goal</StyledTypography>
-            <StyledTypography paragraph>
-              More than 100% completion and work done 50% faster than expected. This includes more than 15 standups, outstanding code reliability, extensive customer interaction, and numerous code iterations.
-            </StyledTypography>
-          </AccordionDetails>
-        </Accordion>
+          <Grid container spacing={2}>
+            {scoringLevels.map((level) => (
+              <Grid size={{ xs: 12, sm: 6 }} key={level.hearts}>
+                <Paper
+                  elevation={0}
+                  sx={{
+                    p: 2.5,
+                    borderRadius: 3,
+                    border: "1px solid",
+                    borderColor: "grey.200",
+                    height: "100%",
+                  }}
+                >
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+                    <Chip
+                      icon={<FaHeart size={12} />}
+                      label={`${level.hearts} heart${level.hearts !== "1" ? "s" : ""}`}
+                      sx={{
+                        fontWeight: 700,
+                        fontSize: "0.85rem",
+                        backgroundColor: "#fce4ec",
+                        color: "#c62828",
+                        "& .MuiChip-icon": { color: "#e53935" },
+                      }}
+                    />
+                    <Typography variant="subtitle1" sx={{ fontWeight: 700, fontSize: { xs: "1rem", md: "1.05rem" } }}>
+                      {level.title}
+                    </Typography>
+                  </Box>
+                  <Typography variant="body1" sx={{ mb: 1, fontSize: { xs: "0.95rem", md: "1rem" }, lineHeight: 1.6 }}>
+                    <strong>What:</strong> {level.what}
+                  </Typography>
+                  <Typography variant="body1" sx={{ color: "text.secondary", fontSize: { xs: "0.95rem", md: "1rem" }, lineHeight: 1.6 }}>
+                    <strong>How:</strong> {level.how}
+                  </Typography>
+                </Paper>
+              </Grid>
+            ))}
+          </Grid>
+        </Section>
 
-        <Box mt={4}>              
-            <RewardStructure />
-        </Box>
+        {/* ── Detailed reward structure ──────────────────────────── */}
+        <Section>
+          <RewardStructure />
+        </Section>
 
-        <Box mt={4}>
-          <Typography variant="h4" gutterBottom>
-            Join Us and Make an Impact
+        <Divider sx={{ mb: 6 }} />
+
+        {/* ── Certificate + Social proof ─────────────────────────── */}
+        <Section>
+          <SectionTitle>Recognition in Action</SectionTitle>
+          <Grid container spacing={4} alignItems="stretch">
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Paper
+                elevation={0}
+                sx={{
+                  p: 3,
+                  borderRadius: 3,
+                  border: "1px solid",
+                  borderColor: "grey.200",
+                  textAlign: "center",
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center",
+                }}
+              >
+                <Image
+                  src="https://cdn.ohack.dev//certificates/certificate_4186886b2aca11a005b826c8e878e904e1e8224857771c21c12e05d83bbbe9e5.png"
+                  width={400}
+                  height={300}
+                  alt="Opportunity Hack Hearts Certificate Example"
+                  style={{ maxWidth: "100%", height: "auto", borderRadius: 8 }}
+                />
+                <Typography variant="body2" sx={{ display: "block", mt: 1.5, color: "text.secondary" }}>
+                  Example Hearts Certificate — earned at the Bronze tier
+                </Typography>
+              </Paper>
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Paper
+                elevation={0}
+                sx={{
+                  borderRadius: 3,
+                  overflow: "hidden",
+                  border: "1px solid",
+                  borderColor: "grey.200",
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <Box sx={{ position: "relative", flex: 1, minHeight: 280 }}>
+                  <Image
+                    src="https://cdn.ohack.dev/ohack.dev/2024_hackathon_2.webp"
+                    fill
+                    alt="Volunteers collaborating at Opportunity Hack 2024 hackathon"
+                    style={{ objectFit: "cover" }}
+                  />
+                </Box>
+                <Typography variant="body2" sx={{ p: 2, color: "text.secondary", textAlign: "center" }}>
+                  Volunteers earning hearts at Opportunity Hack 2024
+                </Typography>
+              </Paper>
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <InstagramEmbed
+                url="https://www.instagram.com/p/CoupvGxuiLX/"
+                maxWidth={400}
+                height={480}
+              />
+            </Grid>
+          </Grid>
+        </Section>
+
+        {/* ── Reference links ───────────────────────────────────── */}
+        <Section>
+          <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap", justifyContent: "center" }}>
+            <Button
+              variant="text"
+              size="small"
+              href="https://docs.google.com/document/d/1J-1o5YOpdt4slyd_PxitNN0gZe7UcI1GjyTbhTem2qU/edit?usp=sharing"
+              target="_blank"
+              onClick={() => track("original_rfc")}
+              sx={{ textTransform: "none" }}
+            >
+              Original RFC
+            </Button>
+            <Button
+              variant="text"
+              size="small"
+              href="https://github.com/opportunity-hack/frontend-ohack.dev/issues/8"
+              target="_blank"
+              onClick={() => track("github_issue_8")}
+              sx={{ textTransform: "none" }}
+            >
+              GitHub Issue #8
+            </Button>
+            <Button
+              variant="text"
+              size="small"
+              href="https://github.com/opportunity-hack/frontend-ohack.dev/issues/7"
+              target="_blank"
+              onClick={() => track("github_issue_7")}
+              sx={{ textTransform: "none" }}
+            >
+              GitHub Issue #7
+            </Button>
+          </Box>
+        </Section>
+
+        {/* ── CTA ───────────────────────────────────────────────── */}
+        <Box
+          sx={{
+            textAlign: "center",
+            p: { xs: 4, md: 6 },
+            borderRadius: 4,
+            background: "linear-gradient(135deg, #e8f5e9 0%, #e3f2fd 100%)",
+          }}
+        >
+          <Typography variant="h4" sx={{ fontWeight: 700, mb: 1.5, fontSize: { xs: "1.6rem", md: "2.15rem" } }}>
+            Ready to Start Earning Hearts?
           </Typography>
-          <StyledTypography paragraph>
-            Ready to start earning hearts and making a difference? Join Opportunity Hack today and contribute your skills to meaningful projects that help nonprofits around the world.
-          </StyledTypography>
-          <LoginOrRegister introText="Ready to join us?" previousPage={"/about/hearts"} />
+          <Typography
+            variant="body1"
+            sx={{ color: "text.secondary", maxWidth: 520, mx: "auto", mb: 3, fontSize: { xs: "1rem", md: "1.1rem" } }}
+          >
+            Join Opportunity Hack and contribute your skills to meaningful
+            projects that help nonprofits around the world.
+          </Typography>
+          <LoginOrRegister introText="Ready to join us?" previousPage="/about/hearts" />
         </Box>
-      </StyledProjectsContainer>
-    </LayoutContainer>
+      </Container>
+    </Box>
   );
 };
 

--- a/src/components/About/Hearts/RewardStructure.js
+++ b/src/components/About/Hearts/RewardStructure.js
@@ -1,162 +1,219 @@
-import React from 'react';
+import React, { useState } from "react";
 import {
   Typography,
   Paper,
   Grid,
   Box,
-} from '@mui/material';
-import { styled } from '@mui/system';
-import NextLink from 'next/link';
-import Link from '@mui/material/Link';
-
-const StyledTypography = styled(Typography)(({ theme }) => ({
-  fontSize: '15px',
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '13px',
-  },
-}));
-
-const StyledPaper = styled(Paper)(({ theme }) => ({
-  padding: theme.spacing(2),
-  height: '100%',
-  display: 'flex',
-  flexDirection: 'column',
-}));
-
-const CategoryTitle = styled(Typography)(({ theme }) => ({
-  fontWeight: 'bold',
-  marginBottom: theme.spacing(1),
-}));
-
-const ItemBox = styled(Box)(({ theme }) => ({
-  marginBottom: theme.spacing(1),
-}));
+  Chip,
+  Tabs,
+  Tab,
+} from "@mui/material";
+import NextLink from "next/link";
+import Link from "@mui/material/Link";
+import { FaHeart, FaArrowRight } from "react-icons/fa";
 
 const rewardStructure = [
   {
     hearts: 0.5,
-    title: 'Partially met goal',
+    title: "Partially met goal",
     what: [
-      { primary: 'Productionalized projects', secondary: 'Code complete, but not pushed to production' },
-      { primary: 'Requirements Gathering', secondary: 'Requirements not fully collected' },
-      { primary: 'Documentation', secondary: 'Documentation not fully completed' },
-      { primary: 'Design architecture', secondary: 'Partial architecture less than 50% of overall system' },
-      { primary: 'Code quality', secondary: 'Code has P0-level lint warnings, errors or security bugs, has outstanding PR comments and outstanding PRs to be merged' },
-      { primary: 'Unit tests written', secondary: 'Some unit tests improved' },
-      { primary: 'Unit test coverage', secondary: 'Unit test coverage less than 50%' },
-      { primary: 'Observability', secondary: 'Less than 50% of the system is instrumented for monitoring with decent logging' },
+      { primary: "Productionalized projects", secondary: "Code complete, but not pushed to production" },
+      { primary: "Requirements gathering", secondary: "Requirements not fully collected" },
+      { primary: "Documentation", secondary: "Documentation not fully completed" },
+      { primary: "Design architecture", secondary: "Partial architecture — less than 50% of overall system" },
+      { primary: "Code quality", secondary: "P0-level lint warnings, errors or security bugs, outstanding PR comments" },
+      { primary: "Unit tests written", secondary: "Some unit tests improved" },
+      { primary: "Unit test coverage", secondary: "Coverage less than 50%" },
+      { primary: "Observability", secondary: "Less than 50% of the system instrumented with decent logging" },
     ],
     how: [
-      { primary: 'Standups completed', secondary: 'For a single project, attended at least 1 standup with the team' },
-      { primary: 'Code reliability', secondary: 'For a single project, developed code that is not consistently reliable - has errors, takes more than 10 seconds to load, has obvious bugs' },
-      { primary: 'Customer Driven Innovation (CDI) and Design Thinking', secondary: 'For a single project, spoke to customer at least one time to gather more information on their problem' },
-      { primary: 'Iterations of code pushed to production', secondary: 'Single project, pushed code to production at least one time' },
+      { primary: "Standups completed", secondary: "Attended at least 1 standup" },
+      { primary: "Code reliability", secondary: "Code not consistently reliable — errors, >10s load times, obvious bugs" },
+      { primary: "Customer-driven innovation", secondary: "Spoke to customer at least once" },
+      { primary: "Production pushes", secondary: "Pushed code to production at least once" },
     ],
   },
   {
     hearts: 1,
-    title: 'Met goal',
+    title: "Met goal",
     what: [
-      { primary: 'All criteria from 0.5 hearts', secondary: 'But more than 90% completion' },
+      { primary: "All 0.5-heart criteria", secondary: "But with more than 90% completion" },
     ],
     how: [
-      { primary: 'Standups completed', secondary: 'For a single project, at least 3 standups' },
-      { primary: 'Code reliability', secondary: 'For a single project, code works without errors, can consistently be pushed to production, nothing takes more than 10 seconds to load, no obvious bugs' },
-      { primary: 'Customer Driven Innovation (CDI) and Design Thinking', secondary: 'For a single project, worked with customer more than 3 times and gathered significant documentation on how to build the solution' },
-      { primary: 'Iterations of code pushed to production', secondary: 'Single project, pushed code to production at least 3 times' },
+      { primary: "Standups completed", secondary: "At least 3 standups" },
+      { primary: "Code reliability", secondary: "Works without errors, loads under 10 seconds, no obvious bugs" },
+      { primary: "Customer-driven innovation", secondary: "3+ customer interactions with documentation" },
+      { primary: "Production pushes", secondary: "Pushed code at least 3 times" },
     ],
   },
   {
     hearts: 1.5,
-    title: 'Exceeded goal',
+    title: "Exceeded goal",
     what: [
-      { primary: 'More than 100% completion', secondary: 'More things completed than expected and work done 25% faster than expected' },
+      { primary: "100%+ completion", secondary: "Delivered 25% faster than expected" },
     ],
     how: [
-      { primary: 'Standups completed', secondary: '8 standups' },
-      { primary: 'Code reliability', secondary: 'No outstanding issues, obvious signs of reliability like fault tolerance, retries, exception handling, caching for performance, etc. over 1 week of usage' },
-      { primary: 'Customer Driven Innovation (CDI) and Design Thinking', secondary: '8 times' },
-      { primary: 'Iterations of code pushed to production', secondary: '8 times' },
+      { primary: "Standups completed", secondary: "8 standups" },
+      { primary: "Code reliability", secondary: "Fault tolerance, retries, caching — reliable over 1 week" },
+      { primary: "Customer-driven innovation", secondary: "8 customer interactions" },
+      { primary: "Production pushes", secondary: "8 pushes" },
     ],
   },
   {
     hearts: 2,
-    title: 'Greatly exceeded goal',
+    title: "Greatly exceeded goal",
     what: [
-      { primary: 'More than 100% completion', secondary: 'More things completed than expected and work done 50% faster than expected' },
+      { primary: "100%+ completion", secondary: "Delivered 50% faster than expected" },
     ],
     how: [
-      { primary: 'Standups completed', secondary: '> 15 standups' },
-      { primary: 'Code reliability', secondary: 'Includes all previous expectations and has outstanding reliability over 2 weeks of usage' },
-      { primary: 'Customer Driven Innovation (CDI) and Design Thinking', secondary: '> 15 times' },
-      { primary: 'Iterations of code pushed to production', secondary: '> 15 times' },
+      { primary: "Standups completed", secondary: "15+ standups" },
+      { primary: "Code reliability", secondary: "Outstanding reliability over 2 weeks" },
+      { primary: "Customer-driven innovation", secondary: "15+ customer interactions" },
+      { primary: "Production pushes", secondary: "15+ pushes" },
     ],
   },
 ];
 
-const RewardStructure = () => {
-  return (
-    <>
-      <Typography variant="h4" gutterBottom>
-        Detailed Reward Structure
-      </Typography>
-      <Box mt={1} mb={4}>
-      
-      <StyledTypography variant="body1" paragraph>
-        The detailed heart reward structure serves as a guideline to recognize and incentivize valuable contributions in the things we build to support the world. It's designed to provide clear objectives and motivate continuous improvement. However, it's important to note that these criteria are not rigid rules, but flexible guidelines.
-        </StyledTypography>
-        <StyledTypography variant="body1" paragraph>
-        Opportunity Hack retains discretion in awarding hearts, considering the unique aspects of each contribution. This approach, inspired by insights from decision-making research, allows for nuanced evaluation that accounts for context, creativity, and unexpected positive outcomes. It helps mitigate biases and 'noise' in decision-making while maintaining a fair and motivating system.
-        </StyledTypography>
-        <StyledTypography variant="body1">
-        Remember, the heart system aims to encourage growth, collaboration, and impactful contributions. Focus on the spirit of these guidelines rather than treating them as a checklist. Your unique efforts and their real-world impact are what truly matter.
-        </StyledTypography>
+const heartColors = ["#ffcdd2", "#ef9a9a", "#ef5350", "#c62828"];
 
-        <NextLink href="/about/completion" passHref>
-      <Link color="primary" underline="hover">
-        <StyledTypography variant="body1" style={{ fontWeight: 'bold', marginTop: '8px' }}>
-          Read More About Project Completion →
-        </StyledTypography>
-      </Link>
-    </NextLink>
-        </Box>
-      <Grid container spacing={3}>
-        {rewardStructure.map((reward, index) => (
-          <Grid size={{ xs: 12, sm: 6, md: 3 }} key={index}>
-            <StyledPaper elevation={3}>
-              <Typography variant="h5" gutterBottom>
-                {reward.hearts} heart{reward.hearts !== 1 ? 's' : ''}
+const RewardStructure = () => {
+  const [activeTab, setActiveTab] = useState(0);
+  const active = rewardStructure[activeTab];
+
+  return (
+    <Box>
+      <Typography
+        variant="h4"
+        component="h2"
+        sx={{ fontWeight: 700, fontSize: { xs: "1.6rem", md: "2.15rem" }, mb: 1.5 }}
+      >
+        Detailed Scoring Criteria
+      </Typography>
+      <Typography
+        variant="body1"
+        sx={{ color: "text.secondary", maxWidth: 720, mb: 1.5, fontSize: { xs: "1rem", md: "1.1rem" }, lineHeight: 1.7 }}
+      >
+        These criteria are flexible guidelines, not rigid rules. Opportunity Hack
+        retains discretion when awarding hearts — context, creativity, and
+        real-world impact matter more than checking boxes.
+      </Typography>
+      <NextLink href="/about/completion" passHref>
+        <Link
+          color="primary"
+          underline="hover"
+          sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, fontWeight: 600, fontSize: "1rem", mb: 3 }}
+        >
+          Read more about project completion <FaArrowRight size={12} />
+        </Link>
+      </NextLink>
+
+      {/* Tab selector */}
+      <Paper
+        elevation={0}
+        sx={{
+          borderRadius: 3,
+          border: "1px solid",
+          borderColor: "grey.200",
+          overflow: "hidden",
+          mt: 2,
+        }}
+      >
+        <Tabs
+          value={activeTab}
+          onChange={(_, v) => setActiveTab(v)}
+          variant="fullWidth"
+          sx={{
+            borderBottom: "1px solid",
+            borderColor: "grey.200",
+            "& .MuiTab-root": {
+              textTransform: "none",
+              fontWeight: 600,
+              fontSize: { xs: "0.85rem", md: "1rem" },
+              py: 2,
+            },
+          }}
+        >
+          {rewardStructure.map((level, i) => (
+            <Tab
+              key={level.hearts}
+              label={
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                  <FaHeart size={12} color={heartColors[i]} />
+                  {level.hearts} {level.hearts === 1 ? "heart" : "hearts"}
+                </Box>
+              }
+            />
+          ))}
+        </Tabs>
+
+        {/* Active tab content */}
+        <Box sx={{ p: { xs: 2.5, md: 4 } }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 3 }}>
+            <Chip
+              icon={<FaHeart size={12} />}
+              label={`${active.hearts} ${active.hearts === 1 ? "heart" : "hearts"} per category`}
+              sx={{
+                fontWeight: 700,
+                fontSize: "0.9rem",
+                height: 32,
+                backgroundColor: heartColors[activeTab] + "30",
+                color: "#b71c1c",
+                "& .MuiChip-icon": { color: heartColors[activeTab] },
+              }}
+            />
+            <Typography variant="h6" sx={{ fontWeight: 700, fontSize: { xs: "1.1rem", md: "1.25rem" } }}>
+              {active.title}
+            </Typography>
+          </Box>
+
+          <Grid container spacing={3}>
+            {/* What column */}
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Typography
+                variant="subtitle1"
+                sx={{ fontWeight: 700, mb: 2, color: "primary.main", fontSize: "1.05rem" }}
+              >
+                What You Build
               </Typography>
-              <Typography variant="h6" gutterBottom>
-                {reward.title}
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                {active.what.map((item, idx) => (
+                  <Box key={idx}>
+                    <Typography variant="body1" sx={{ fontWeight: 600, fontSize: { xs: "0.95rem", md: "1rem" } }}>
+                      {item.primary}
+                    </Typography>
+                    <Typography variant="body1" sx={{ color: "text.secondary", fontSize: { xs: "0.9rem", md: "0.95rem" }, lineHeight: 1.6 }}>
+                      {item.secondary}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            </Grid>
+
+            {/* How column */}
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Typography
+                variant="subtitle1"
+                sx={{ fontWeight: 700, mb: 2, color: "secondary.main", fontSize: "1.05rem" }}
+              >
+                How You Build It
               </Typography>
-              <CategoryTitle variant="subtitle1">What</CategoryTitle>
-              {reward.what.map((item, itemIndex) => (
-                <ItemBox key={itemIndex}>
-                  <StyledTypography variant="body1" color="textSecondary">
-                    {item.primary}
-                  </StyledTypography>
-                  <StyledTypography variant="body1">
-                    {item.secondary}
-                  </StyledTypography>
-                </ItemBox>
-              ))}
-              <CategoryTitle variant="subtitle1">How</CategoryTitle>
-              {reward.how.map((item, itemIndex) => (
-                <ItemBox key={itemIndex}>
-                  <StyledTypography variant="body1" color="textSecondary">
-                    {item.primary}
-                  </StyledTypography>
-                  <StyledTypography variant="body1">
-                    {item.secondary}
-                  </StyledTypography>
-                </ItemBox>
-              ))}
-            </StyledPaper>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                {active.how.map((item, idx) => (
+                  <Box key={idx}>
+                    <Typography variant="body1" sx={{ fontWeight: 600, fontSize: { xs: "0.95rem", md: "1rem" } }}>
+                      {item.primary}
+                    </Typography>
+                    <Typography variant="body1" sx={{ color: "text.secondary", fontSize: { xs: "0.9rem", md: "0.95rem" }, lineHeight: 1.6 }}>
+                      {item.secondary}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            </Grid>
           </Grid>
-        ))}
-      </Grid>
-    </>
+        </Box>
+      </Paper>
+    </Box>
   );
 };
 

--- a/src/components/CommunityChampions/CommunityChampions.js
+++ b/src/components/CommunityChampions/CommunityChampions.js
@@ -1,0 +1,476 @@
+import React, { useEffect, useState, useMemo } from "react";
+import {
+  Box,
+  Typography,
+  Avatar,
+  TextField,
+  InputAdornment,
+  Chip,
+  useMediaQuery,
+  useTheme,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import FavoriteIcon from "@mui/icons-material/Favorite";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import Link from "next/link";
+import Image from "next/image";
+import Head from "next/head";
+import { useEnv } from "../../context/env.context";
+import { TIERS, getTierForHearts } from "../../lib/heartTiers";
+
+export default function CommunityChampions() {
+  const { apiServerUrl } = useEnv();
+  const [leaders, setLeaders] = useState([]);
+  const [search, setSearch] = useState("");
+  const [tierFilter, setTierFilter] = useState("all");
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`${apiServerUrl}/api/hearts/leaderboard?limit=50`, {
+      signal: controller.signal,
+    })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => setLeaders(data.leaderboard || []))
+      .catch(() => {});
+    return () => controller.abort();
+  }, [apiServerUrl]);
+
+  const filtered = useMemo(() => {
+    let result = leaders;
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((entry) =>
+        (entry.name || "").toLowerCase().includes(q)
+      );
+    }
+    if (tierFilter !== "all") {
+      result = result.filter((entry) => {
+        const tier = getTierForHearts(entry.totalHearts);
+        return tier && tier.name === tierFilter;
+      });
+    }
+    return result;
+  }, [leaders, search, tierFilter]);
+
+  // Count champions per tier for the filter chips
+  const tierCounts = useMemo(() => {
+    const counts = {};
+    leaders.forEach((entry) => {
+      const tier = getTierForHearts(entry.totalHearts);
+      const name = tier ? tier.name : "Newcomer";
+      counts[name] = (counts[name] || 0) + 1;
+    });
+    return counts;
+  }, [leaders]);
+
+  const structuredData = useMemo(() => {
+    if (!leaders.length) return null;
+    return {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: "Opportunity Hack Community Champions",
+      description:
+        "Top volunteers, mentors, and hackers who have earned the most hearts through their contributions to Opportunity Hack.",
+      numberOfItems: leaders.length,
+      itemListElement: leaders.map((entry, idx) => ({
+        "@type": "ListItem",
+        position: idx + 1,
+        item: {
+          "@type": "Person",
+          name: entry.name,
+          url: `https://ohack.dev/profile/${entry.userId}`,
+          ...(entry.profileImage && { image: entry.profileImage }),
+        },
+      })),
+    };
+  }, [leaders]);
+
+  return (
+    <>
+      {structuredData && (
+        <Head>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+          />
+        </Head>
+      )}
+
+      <Box sx={{ maxWidth: 960, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+        {/* Hero image + Header */}
+        <Box
+          sx={{
+            position: "relative",
+            borderRadius: 4,
+            overflow: "hidden",
+            mb: { xs: 3, md: 4 },
+          }}
+        >
+          <Box sx={{ position: "relative", height: { xs: 180, sm: 240, md: 300 } }}>
+            <Image
+              src="https://cdn.ohack.dev/ohack.dev/2023_hackathon_4.webp"
+              fill
+              alt="Opportunity Hack volunteers collaborating at a hackathon for nonprofits"
+              style={{ objectFit: "cover" }}
+              priority
+            />
+            <Box
+              sx={{
+                position: "absolute",
+                inset: 0,
+                background: "linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.6) 100%)",
+              }}
+            />
+          </Box>
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              right: 0,
+              p: { xs: 2.5, md: 4 },
+              textAlign: "center",
+            }}
+          >
+            <EmojiEventsIcon sx={{ fontSize: 40, color: "#FFD700", mb: 0.5 }} />
+            <Typography
+              variant="h3"
+              component="h1"
+              sx={{
+                fontWeight: 800,
+                fontSize: { xs: "1.75rem", md: "2.5rem" },
+                color: "#fff",
+                textShadow: "0 2px 8px rgba(0,0,0,0.3)",
+              }}
+            >
+              Community Champions
+            </Typography>
+          </Box>
+        </Box>
+
+        <Box sx={{ textAlign: "center", mb: { xs: 3, md: 4 } }}>
+          <Typography
+            variant="body1"
+            sx={{
+              color: "text.secondary",
+              maxWidth: 680,
+              mx: "auto",
+              lineHeight: 1.7,
+              fontSize: { xs: "0.95rem", md: "1.05rem" },
+            }}
+          >
+            These volunteers power Opportunity Hack's mission to connect
+            technology with nonprofits. Through mentoring, judging, hacking, and
+            contributing code, they earn{" "}
+            <Link href="/about/hearts" passHref legacyBehavior>
+              <Box
+                component="a"
+                sx={{
+                  color: "#e53935",
+                  fontWeight: 600,
+                  textDecoration: "none",
+                  "&:hover": { textDecoration: "underline" },
+                }}
+              >
+                hearts
+              </Box>
+            </Link>{" "}
+            — our way of recognizing the people who make tech-for-good happen.
+          </Typography>
+        </Box>
+
+        {/* Tier Legend */}
+        <Box
+          sx={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: 1.5,
+            mb: 3,
+          }}
+        >
+          {TIERS.map((tier) => (
+            <Box
+              key={tier.name}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  backgroundColor: tier.color,
+                  border: tier.name === "Diamond" ? "1px solid #90caf9" : "none",
+                }}
+              />
+              <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                {tier.name} ({tier.minHearts}+ hearts)
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+
+        {/* Search + Tier Filter */}
+        <Box sx={{ mb: { xs: 3, md: 4 }, maxWidth: 580, mx: "auto" }}>
+          <TextField
+            fullWidth
+            placeholder="Search champions by name..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            size="small"
+            aria-label="Search community champions"
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ color: "text.disabled" }} />
+                </InputAdornment>
+              ),
+              sx: { borderRadius: 3, backgroundColor: "#fafafa" },
+            }}
+          />
+          <Box
+            sx={{
+              mt: 1.5,
+              display: "flex",
+              justifyContent: "center",
+            }}
+          >
+            <ToggleButtonGroup
+              value={tierFilter}
+              exclusive
+              onChange={(_, val) => val && setTierFilter(val)}
+              size="small"
+              aria-label="Filter by tier"
+              sx={{
+                flexWrap: "wrap",
+                justifyContent: "center",
+                "& .MuiToggleButton-root": {
+                  textTransform: "none",
+                  px: { xs: 1, sm: 1.5 },
+                  py: 0.5,
+                  fontSize: { xs: "0.75rem", sm: "0.8rem" },
+                },
+              }}
+            >
+              <ToggleButton value="all">
+                All ({leaders.length})
+              </ToggleButton>
+              {[...TIERS].reverse().map((tier) => (
+                <ToggleButton key={tier.name} value={tier.name}>
+                  <Box
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: "50%",
+                      backgroundColor: tier.color,
+                      mr: 0.5,
+                      border: tier.name === "Diamond" ? "1px solid #90caf9" : "none",
+                    }}
+                  />
+                  {tier.name} ({tierCounts[tier.name] || 0})
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+          </Box>
+          {(search || tierFilter !== "all") && (
+            <Typography
+              variant="caption"
+              sx={{ mt: 0.5, display: "block", textAlign: "center", color: "text.secondary" }}
+            >
+              {filtered.length} champion{filtered.length !== 1 ? "s" : ""} found
+            </Typography>
+          )}
+        </Box>
+
+        {/* Champions Grid */}
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "repeat(2, 1fr)",
+              sm: "repeat(3, 1fr)",
+              md: "repeat(4, 1fr)",
+            },
+            gap: { xs: 1.5, md: 2.5 },
+          }}
+        >
+          {filtered.map((entry) => {
+            const tier = getTierForHearts(entry.totalHearts);
+            const tierColor = tier ? tier.color : "#ccc";
+            const tierName = tier ? tier.name : "Newcomer";
+            const hasTier = !!tier;
+
+            return (
+              <Link
+                key={entry.userId}
+                href={`/profile/${entry.userId}`}
+                passHref
+                legacyBehavior
+              >
+                <Box
+                  component="a"
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    textDecoration: "none",
+                    color: "inherit",
+                    p: { xs: 2, md: 2.5 },
+                    borderRadius: 3,
+                    backgroundColor: hasTier ? `${tierColor}08` : "#fafafa",
+                    border: hasTier
+                      ? `1.5px solid ${tierColor}40`
+                      : "1px solid rgba(0,0,0,0.06)",
+                    transition: "transform 0.15s ease, box-shadow 0.15s ease",
+                    "&:hover": {
+                      transform: "translateY(-3px)",
+                      boxShadow: "0 6px 20px rgba(0,0,0,0.08)",
+                    },
+                  }}
+                >
+                  {/* Tier badge */}
+                  <Chip
+                    label={tierName}
+                    size="small"
+                    sx={{
+                      mb: 1,
+                      fontWeight: 700,
+                      fontSize: "0.7rem",
+                      height: 22,
+                      backgroundColor: hasTier ? tierColor : "#e0e0e0",
+                      color:
+                        tierName === "Gold" || tierName === "Platinum" || tierName === "Diamond"
+                          ? "#333"
+                          : "#fff",
+                      border: tierName === "Diamond" ? "1px solid #90caf9" : "none",
+                    }}
+                  />
+
+                  {/* Avatar */}
+                  <Box sx={{ position: "relative", mb: 1 }}>
+                    <Avatar
+                      src={entry.profileImage}
+                      alt={`${entry.name} - Opportunity Hack ${tierName} community champion`}
+                      sx={{
+                        width: { xs: 64, md: 80 },
+                        height: { xs: 64, md: 80 },
+                        border: `3px solid ${tierColor}`,
+                        fontSize: { xs: 20, md: 26 },
+                      }}
+                    />
+                  </Box>
+
+                  {/* Name */}
+                  <Typography
+                    variant="subtitle2"
+                    component="h2"
+                    sx={{
+                      fontWeight: 700,
+                      textAlign: "center",
+                      lineHeight: 1.2,
+                      mb: 0.5,
+                      fontSize: { xs: "0.85rem", md: "0.95rem" },
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      maxWidth: "100%",
+                    }}
+                  >
+                    {entry.name}
+                  </Typography>
+
+                  {/* Hearts */}
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                    }}
+                  >
+                    <FavoriteIcon sx={{ fontSize: 16, color: "#e53935" }} />
+                    <Typography
+                      variant="body2"
+                      sx={{ fontWeight: 600, color: "#666" }}
+                    >
+                      {entry.totalHearts} heart{entry.totalHearts !== 1 ? "s" : ""}
+                    </Typography>
+                  </Box>
+                </Box>
+              </Link>
+            );
+          })}
+        </Box>
+
+        {filtered.length === 0 && (search || tierFilter !== "all") && (
+          <Typography
+            sx={{ textAlign: "center", color: "text.secondary", mt: 4 }}
+          >
+            No champions found. Try adjusting your search or filter.
+          </Typography>
+        )}
+
+        {/* CTA Section */}
+        <Box
+          sx={{
+            mt: { xs: 5, md: 6 },
+            p: { xs: 3, md: 4 },
+            borderRadius: 3,
+            backgroundColor: "#f5f5f5",
+            textAlign: "center",
+          }}
+        >
+          <Typography
+            variant="h5"
+            component="h2"
+            sx={{ fontWeight: 700, mb: 1.5 }}
+          >
+            Join Our Champions
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ color: "text.secondary", maxWidth: 560, mx: "auto", mb: 2 }}
+          >
+            Earn hearts by volunteering as a mentor, judge, or hacker at
+            Opportunity Hack events. Start at Bronze and work your way up to
+            Diamond — every contribution moves us closer to a world where every
+            nonprofit has the technology it needs.
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2, justifyContent: "center", flexWrap: "wrap" }}>
+            <Link href="/about/hearts" passHref legacyBehavior>
+              <Chip
+                component="a"
+                label="How Hearts Work"
+                clickable
+                sx={{ fontWeight: 600, px: 1 }}
+              />
+            </Link>
+            <Link href="/about/mentors" passHref legacyBehavior>
+              <Chip
+                component="a"
+                label="Become a Mentor"
+                clickable
+                sx={{ fontWeight: 600, px: 1 }}
+              />
+            </Link>
+            <Link href="/about/judges" passHref legacyBehavior>
+              <Chip
+                component="a"
+                label="Become a Judge"
+                clickable
+                sx={{ fontWeight: 600, px: 1 }}
+              />
+            </Link>
+          </Box>
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/src/components/CommunityChampions/CommunityChampions.js
+++ b/src/components/CommunityChampions/CommunityChampions.js
@@ -100,59 +100,58 @@ export default function CommunityChampions() {
         </Head>
       )}
 
-      <Box sx={{ maxWidth: 960, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
-        {/* Hero image + Header — fixed height, isolated from content reflows */}
+      {/* Hero image — outside content container to avoid scrollbar reflow */}
+      <Box
+        sx={{
+          position: "relative",
+          height: { xs: 180, sm: 240, md: 300 },
+          width: "100%",
+          overflow: "hidden",
+          mb: { xs: 3, md: 4 },
+        }}
+      >
+        <Image
+          src="https://cdn.ohack.dev/ohack.dev/2023_hackathon_4.webp"
+          fill
+          sizes="100vw"
+          alt="Opportunity Hack volunteers collaborating at a hackathon for nonprofits"
+          style={{ objectFit: "cover" }}
+          priority
+        />
         <Box
           sx={{
-            position: "relative",
-            borderRadius: 4,
-            overflow: "hidden",
-            mb: { xs: 3, md: 4 },
-            height: { xs: 180, sm: 240, md: 300 },
-            flexShrink: 0,
+            position: "absolute",
+            inset: 0,
+            background: "linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.6) 100%)",
+          }}
+        />
+        <Box
+          sx={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            p: { xs: 2.5, md: 4 },
+            textAlign: "center",
           }}
         >
-          <Image
-            src="https://cdn.ohack.dev/ohack.dev/2023_hackathon_4.webp"
-            fill
-            sizes="(max-width: 960px) 100vw, 960px"
-            alt="Opportunity Hack volunteers collaborating at a hackathon for nonprofits"
-            style={{ objectFit: "cover" }}
-            priority
-          />
-          <Box
+          <EmojiEventsIcon sx={{ fontSize: 40, color: "#FFD700", mb: 0.5 }} />
+          <Typography
+            variant="h3"
+            component="h1"
             sx={{
-              position: "absolute",
-              inset: 0,
-              background: "linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.6) 100%)",
-            }}
-          />
-          <Box
-            sx={{
-              position: "absolute",
-              bottom: 0,
-              left: 0,
-              right: 0,
-              p: { xs: 2.5, md: 4 },
-              textAlign: "center",
+              fontWeight: 800,
+              fontSize: { xs: "1.75rem", md: "2.5rem" },
+              color: "#fff",
+              textShadow: "0 2px 8px rgba(0,0,0,0.3)",
             }}
           >
-            <EmojiEventsIcon sx={{ fontSize: 40, color: "#FFD700", mb: 0.5 }} />
-            <Typography
-              variant="h3"
-              component="h1"
-              sx={{
-                fontWeight: 800,
-                fontSize: { xs: "1.75rem", md: "2.5rem" },
-                color: "#fff",
-                textShadow: "0 2px 8px rgba(0,0,0,0.3)",
-              }}
-            >
-              Community Champions
-            </Typography>
-          </Box>
+            Community Champions
+          </Typography>
         </Box>
+      </Box>
 
+      <Box sx={{ maxWidth: 960, mx: "auto", px: { xs: 2, md: 3 }, pb: { xs: 3, md: 5 } }}>
         <Box sx={{ textAlign: "center", mb: { xs: 3, md: 4 } }}>
           <Typography
             variant="body1"

--- a/src/components/CommunityChampions/CommunityChampions.js
+++ b/src/components/CommunityChampions/CommunityChampions.js
@@ -101,31 +101,32 @@ export default function CommunityChampions() {
       )}
 
       <Box sx={{ maxWidth: 960, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
-        {/* Hero image + Header */}
+        {/* Hero image + Header — fixed height, isolated from content reflows */}
         <Box
           sx={{
             position: "relative",
             borderRadius: 4,
             overflow: "hidden",
             mb: { xs: 3, md: 4 },
+            height: { xs: 180, sm: 240, md: 300 },
+            flexShrink: 0,
           }}
         >
-          <Box sx={{ position: "relative", height: { xs: 180, sm: 240, md: 300 } }}>
-            <Image
-              src="https://cdn.ohack.dev/ohack.dev/2023_hackathon_4.webp"
-              fill
-              alt="Opportunity Hack volunteers collaborating at a hackathon for nonprofits"
-              style={{ objectFit: "cover" }}
-              priority
-            />
-            <Box
-              sx={{
-                position: "absolute",
-                inset: 0,
-                background: "linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.6) 100%)",
-              }}
-            />
-          </Box>
+          <Image
+            src="https://cdn.ohack.dev/ohack.dev/2023_hackathon_4.webp"
+            fill
+            sizes="(max-width: 960px) 100vw, 960px"
+            alt="Opportunity Hack volunteers collaborating at a hackathon for nonprofits"
+            style={{ objectFit: "cover" }}
+            priority
+          />
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              background: "linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.6) 100%)",
+            }}
+          />
           <Box
             sx={{
               position: "absolute",

--- a/src/components/Hackathon/HackathonLeaderboard.js
+++ b/src/components/Hackathon/HackathonLeaderboard.js
@@ -22,6 +22,7 @@ import WeekendIcon from '@mui/icons-material/Weekend';
 import ExploreIcon from '@mui/icons-material/Explore';
 import StarIcon from '@mui/icons-material/Star';
 import CommitIcon from '@mui/icons-material/CommitRounded';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 
 const LeaderboardContainer = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(3),
@@ -172,7 +173,8 @@ const getIconComponent = (iconName, props = {}) => {
     trophy: <EmojiEventsIcon {...defaultProps} />,
     explore: <ExploreIcon {...defaultProps} />,
     launch: <LaunchIcon {...defaultProps} />,
-    link: <LinkIcon {...defaultProps} />
+    link: <LinkIcon {...defaultProps} />,
+    rocket_launch: <RocketLaunchIcon {...defaultProps} />
   };
 
   if (iconMap[iconName]) {
@@ -218,6 +220,7 @@ const HackathonLeaderboard = ({
   const [generalStats, setGeneralStats] = useState(initialGeneralStats || []);
   const [individualAchievements, setIndividualAchievements] = useState(initialIndividualAchievements || []);
   const [teamAchievements, setTeamAchievements] = useState(initialTeamAchievements || []);
+  const [mentorOpportunities, setMentorOpportunities] = useState([]);
   const [orgName, setOrgName] = useState(githubOrg || '');
   const [hackathonName, setHackathonName] = useState(eventName || '');
   const [loading, setLoading] = useState(!initialGeneralStats);
@@ -262,6 +265,7 @@ const HackathonLeaderboard = ({
       setGeneralStats(data.generalStats || []);
       setIndividualAchievements(data.individualAchievements || []);
       setTeamAchievements(data.teamAchievements || []);
+      setMentorOpportunities(data.mentorOpportunities || []);
       setOrgName(data.githubOrg || '');
       setHackathonName(data.eventName || '');
 
@@ -737,27 +741,37 @@ const HackathonLeaderboard = ({
                     </Box>
                   </FlexContent>
                   
-                  <Box sx={{ 
-                    ml: { xs: 0.5, md: 1 }, 
-                    flexShrink: 0, 
-                    minWidth: { xs: '70px', md: '90px' }, 
+                  <Box sx={{
+                    ml: { xs: 0.5, md: 1 },
+                    flexShrink: 0,
+                    minWidth: { xs: '70px', md: '90px' },
                     textAlign: 'right'
                   }}>
-                    <Typography 
-                      variant="h6" 
-                      fontWeight="bold" 
-                      color="primary" 
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="primary"
                       noWrap
                       sx={{ fontSize: { xs: '1rem', md: '1.15rem' } }}
                     >
                       {achievement.value}
                     </Typography>
+                    {achievement.description && (
+                      <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        noWrap
+                        sx={{ fontSize: '0.65rem', display: 'block' }}
+                      >
+                        {achievement.description}
+                      </Typography>
+                    )}
                   </Box>
                 </AchievementCard>
               </Grid>
             );
           })}
-          
+
           {(!individualAchievements || individualAchievements.length === 0) && (
             <Grid size={12}>
               <Box p={3} textAlign="center" bgcolor="background.paper" borderRadius={1}>
@@ -858,21 +872,31 @@ const HackathonLeaderboard = ({
                     </Box>
                   </FlexContent>
                   
-                  <Box sx={{ 
-                    ml: { xs: 0.5, md: 1 }, 
-                    flexShrink: 0, 
-                    minWidth: { xs: '70px', md: '90px' }, 
-                    textAlign: 'right' 
+                  <Box sx={{
+                    ml: { xs: 0.5, md: 1 },
+                    flexShrink: 0,
+                    minWidth: { xs: '70px', md: '90px' },
+                    textAlign: 'right'
                   }}>
-                    <Typography 
-                      variant="h6" 
-                      fontWeight="bold" 
-                      color="primary" 
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="primary"
                       noWrap
                       sx={{ fontSize: { xs: '1.1rem', md: '1.25rem' } }}
                     >
                       {achievement.value}
                     </Typography>
+                    {achievement.description && (
+                      <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        noWrap
+                        sx={{ fontSize: '0.65rem', display: 'block' }}
+                      >
+                        {achievement.description}
+                      </Typography>
+                    )}
                   </Box>
                 </AchievementCard>
               </Grid>
@@ -887,6 +911,83 @@ const HackathonLeaderboard = ({
           )}
         </Grid>
       </Box>
+      {mentorOpportunities && mentorOpportunities.length > 0 && (
+        <Box sx={{ display: { xs: 'block', sm: 'none', md: 'block' } }}>
+          <SectionHeader variant="h6">
+            <RocketLaunchIcon sx={{ mr: 1, verticalAlign: 'middle', color: 'warning.main' }} />
+            Teams Ready for a Boost
+          </SectionHeader>
+          <Typography variant="body2" color="textSecondary" sx={{ mb: 2 }}>
+            These teams could benefit from some mentor support to help them get rolling!
+          </Typography>
+          <Grid container spacing={2}>
+            {mentorOpportunities.map((opportunity, index) => {
+              const hasTeamPage = opportunity.teamPage;
+
+              return (
+                <Grid size={{ xs: 12, md: 6 }} key={index}>
+                  <AchievementCard
+                    sx={{
+                      flexDirection: 'row',
+                      p: { xs: 1.5, md: 2 },
+                      alignItems: 'center',
+                      borderLeft: '4px solid',
+                      borderLeftColor: 'warning.main',
+                      cursor: hasTeamPage ? 'pointer' : 'default',
+                      '&:hover': {
+                        transform: hasTeamPage ? 'scale(1.02)' : 'none',
+                        boxShadow: hasTeamPage ? 3 : 1,
+                      },
+                    }}
+                    component={hasTeamPage ? Link : Box}
+                    href={hasTeamPage ? getGitHubTeamUrl(opportunity.teamPage) : undefined}
+                    target={hasTeamPage ? "_blank" : undefined}
+                    rel="noopener"
+                    underline="none"
+                  >
+                    <StyledBadge
+                      badgeContent={opportunity.members}
+                      color="primary"
+                      overlap="circular"
+                      sx={{ '& .MuiBadge-badge': { fontSize: '0.7rem', height: '18px', minWidth: '18px' } }}
+                    >
+                      <Avatar
+                        sx={{
+                          width: { xs: 40, md: 48 },
+                          height: { xs: 40, md: 48 },
+                          mr: { xs: 1.5, md: 2 },
+                          bgcolor: 'warning.main',
+                          flexShrink: 0
+                        }}
+                      >
+                        {renderIcon(opportunity.icon || 'rocket_launch', { color: "inherit" })}
+                      </Avatar>
+                    </StyledBadge>
+
+                    <FlexContent flexGrow={1}>
+                      <TruncatedText
+                        variant="subtitle1"
+                        fontWeight="bold"
+                        title={opportunity.team}
+                        sx={{ fontSize: { xs: '0.95rem', md: '1rem' } }}
+                      >
+                        {opportunity.team}
+                      </TruncatedText>
+                      <TruncatedText
+                        variant="body2"
+                        color="textSecondary"
+                        sx={{ fontSize: { xs: '0.8rem', md: '0.875rem' } }}
+                      >
+                        {opportunity.value} • {opportunity.members} members
+                      </TruncatedText>
+                    </FlexContent>
+                  </AchievementCard>
+                </Grid>
+              );
+            })}
+          </Grid>
+        </Box>
+      )}
       <Box textAlign="center" mt={4} pt={1} borderTop={1} borderColor="divider">
         <Button
           variant="outlined"

--- a/src/components/HeartGauge/HeartGauge.js
+++ b/src/components/HeartGauge/HeartGauge.js
@@ -11,19 +11,10 @@ import {
 } from "@mui/material";
 import { FaHeart, FaInfoCircle, FaChartPie, FaListUl } from "react-icons/fa";
 import MilestoneProgress from "./MilestoneProgress";
+import { ALL_REWARDS as rewards } from "../../lib/heartTiers";
 
 const COLORS = ["#0088FE", "#f3f3f3"];
 const MAX_HEARTS = 48;
-
-const rewards = [
-  { hearts: 2, reward: "Certificate" },
-  { hearts: 4, reward: "IG/FB Shoutout" },
-  { hearts: 5, reward: "LinkedIn Recommendation" },
-  { hearts: 6, reward: "Interview prep & resume review" },
-  { hearts: 10, reward: "Reference for job application" },
-  { hearts: 24, reward: "Opportunity Hack swag" },
-  { hearts: 48, reward: "Sponsor-provided tech award" },
-];
 
 const countHearts = (h) => {
   var total = 0;

--- a/src/components/HeartGauge/MilestoneProgress.js
+++ b/src/components/HeartGauge/MilestoneProgress.js
@@ -20,41 +20,7 @@ import {
   FaStar,
   FaGift,
 } from "react-icons/fa";
-
-const rewards = [
-  { hearts: 2, reward: "Certificate", tier: "Bronze", color: "#CD7F32" },
-  { hearts: 4, reward: "IG/FB Shoutout", tier: "Bronze", color: "#CD7F32" },
-  {
-    hearts: 5,
-    reward: "LinkedIn Recommendation",
-    tier: "Silver",
-    color: "#C0C0C0",
-  },
-  {
-    hearts: 6,
-    reward: "Interview prep & resume review",
-    tier: "Silver",
-    color: "#C0C0C0",
-  },
-  {
-    hearts: 10,
-    reward: "Reference for job application",
-    tier: "Gold",
-    color: "#FFD700",
-  },
-  {
-    hearts: 24,
-    reward: "Opportunity Hack swag",
-    tier: "Platinum",
-    color: "#E5E4E2",
-  },
-  {
-    hearts: 48,
-    reward: "Sponsor-provided tech award",
-    tier: "Diamond",
-    color: "#B9F2FF",
-  },
-];
+import { ALL_REWARDS as rewards, TIER_ORDER as tierOrder, TIERS } from "../../lib/heartTiers";
 
 const countHearts = (h) => {
   var total = 0;
@@ -103,7 +69,7 @@ const MilestoneProgress = ({ history }) => {
     return acc;
   }, {});
 
-  const tierOrder = ["Bronze", "Silver", "Gold", "Platinum", "Diamond"];
+  // tierOrder imported from shared heartTiers module
 
   return (
     <Paper

--- a/src/components/Hearts/HeartsLeaderboard.js
+++ b/src/components/Hearts/HeartsLeaderboard.js
@@ -45,18 +45,24 @@ const HeartsLeaderboard = () => {
         border: "1px solid rgba(0,0,0,0.06)",
       }}
     >
-      <Typography
-        variant="subtitle2"
-        sx={{
-          textAlign: "center",
-          fontWeight: 700,
-          mb: { xs: 1, md: 1.5 },
-          color: "#333",
-          fontSize: { xs: "0.85rem", md: "1rem" },
-        }}
-      >
-        Community Champions
-      </Typography>
+      <Link href="/community-champions" passHref legacyBehavior>
+        <Typography
+          component="a"
+          variant="subtitle2"
+          sx={{
+            textAlign: "center",
+            fontWeight: 700,
+            mb: { xs: 1, md: 1.5 },
+            color: "#333",
+            fontSize: { xs: "0.85rem", md: "1rem" },
+            display: "block",
+            textDecoration: "none",
+            "&:hover": { color: "#1976d2", textDecoration: "underline" },
+          }}
+        >
+          Community Champions
+        </Typography>
+      </Link>
 
       <Box
         sx={{

--- a/src/lib/heartTiers.js
+++ b/src/lib/heartTiers.js
@@ -1,0 +1,68 @@
+/**
+ * Heart tier system — single source of truth for the Opportunity Hack
+ * recognition tiers used across the community champions page, profile
+ * Heart Progress, and the /about/hearts rewards page.
+ */
+
+export const TIERS = [
+  {
+    name: "Bronze",
+    color: "#CD7F32",
+    minHearts: 2,
+    rewards: [
+      { hearts: 2, reward: "Certificate" },
+      { hearts: 4, reward: "IG/FB Shoutout" },
+    ],
+  },
+  {
+    name: "Silver",
+    color: "#C0C0C0",
+    minHearts: 5,
+    rewards: [
+      { hearts: 5, reward: "LinkedIn Recommendation" },
+      { hearts: 6, reward: "Interview prep & resume review" },
+    ],
+  },
+  {
+    name: "Gold",
+    color: "#FFD700",
+    minHearts: 10,
+    rewards: [{ hearts: 10, reward: "Reference for job application" }],
+  },
+  {
+    name: "Platinum",
+    color: "#E5E4E2",
+    minHearts: 24,
+    rewards: [{ hearts: 24, reward: "Opportunity Hack swag" }],
+  },
+  {
+    name: "Diamond",
+    color: "#B9F2FF",
+    minHearts: 48,
+    rewards: [{ hearts: 48, reward: "Sponsor-provided tech award" }],
+  },
+];
+
+export const TIER_ORDER = TIERS.map((t) => t.name);
+
+/** Flat list of all rewards with tier metadata attached. */
+export const ALL_REWARDS = TIERS.flatMap((tier) =>
+  tier.rewards.map((r) => ({ ...r, tier: tier.name, color: tier.color }))
+);
+
+/** Return the tier object a person belongs to given their heart count, or null. */
+export function getTierForHearts(hearts) {
+  let matched = null;
+  for (const tier of TIERS) {
+    if (hearts >= tier.minHearts) matched = tier;
+  }
+  return matched;
+}
+
+/** Return the next tier object a person is working toward, or null if at max. */
+export function getNextTier(hearts) {
+  for (const tier of TIERS) {
+    if (hearts < tier.minHearts) return tier;
+  }
+  return null;
+}

--- a/src/pages/community-champions/index.js
+++ b/src/pages/community-champions/index.js
@@ -1,0 +1,188 @@
+import dynamic from "next/dynamic";
+
+const CommunityChampions = dynamic(
+  () => import("../../components/CommunityChampions/CommunityChampions"),
+  { ssr: false }
+);
+
+export default function CommunityChampionsPage() {
+  return <CommunityChampions />;
+}
+
+export const getStaticProps = async () => {
+  const title =
+    "Community Champions - Volunteers Powering Tech for Good | Opportunity Hack";
+  const description =
+    "Meet the Opportunity Hack community champions — volunteers, mentors, judges, and hackers who donate their skills to build technology solutions for nonprofits. See who is leading the charge for social good.";
+
+  return {
+    props: {
+      title,
+      description,
+      openGraphData: [
+        {
+          name: "title",
+          property: "title",
+          content: title,
+          key: "title",
+        },
+        {
+          name: "og:title",
+          property: "og:title",
+          content: title,
+          key: "ogtitle",
+        },
+        {
+          name: "author",
+          property: "author",
+          content: "Opportunity Hack",
+          key: "author",
+        },
+        {
+          name: "og:description",
+          property: "og:description",
+          content: description,
+          key: "ogdescription",
+        },
+        {
+          name: "description",
+          property: "description",
+          content: description,
+          key: "description",
+        },
+        {
+          name: "image",
+          property: "og:image",
+          content: "https://cdn.ohack.dev/ohack.dev/2024_hackathon_4.webp",
+          key: "ognameimage",
+        },
+        {
+          property: "og:image:width",
+          content: "1200",
+          key: "ogimagewidth",
+        },
+        {
+          property: "og:image:height",
+          content: "630",
+          key: "ogimageheight",
+        },
+        {
+          name: "url",
+          property: "url",
+          content: "https://ohack.dev/community-champions",
+          key: "url",
+        },
+        {
+          name: "og:url",
+          property: "og:url",
+          content: "https://ohack.dev/community-champions",
+          key: "ogurl",
+        },
+        {
+          name: "og:type",
+          property: "og:type",
+          content: "website",
+          key: "ogtype",
+        },
+        {
+          name: "twitter:card",
+          property: "twitter:card",
+          content: "summary_large_image",
+          key: "twittercard",
+        },
+        {
+          name: "twitter:site",
+          property: "twitter:site",
+          content: "@opportunityhack",
+          key: "twittersite",
+        },
+        {
+          name: "twitter:title",
+          property: "twitter:title",
+          content: title,
+          key: "twittertitle",
+        },
+        {
+          name: "twitter:description",
+          property: "twitter:description",
+          content: description,
+          key: "twitterdesc",
+        },
+        {
+          name: "twitter:image",
+          property: "twitter:image",
+          content: "https://cdn.ohack.dev/ohack.dev/2024_hackathon_4.webp",
+          key: "twitterimage",
+        },
+        {
+          name: "twitter:image:alt",
+          property: "twitter:image:alt",
+          content:
+            "Opportunity Hack community champions volunteering at a hackathon for nonprofits",
+          key: "twitterimagealt",
+        },
+        {
+          name: "twitter:creator",
+          property: "twitter:creator",
+          content: "@opportunityhack",
+          key: "twittercreator",
+        },
+      ],
+      structuredData: {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Organization",
+            "@id": "https://ohack.dev/#organization",
+            name: "Opportunity Hack",
+            url: "https://ohack.dev",
+            logo: {
+              "@type": "ImageObject",
+              url: "https://cdn.ohack.dev/ohack.dev/2024_hackathon_4.webp",
+            },
+            sameAs: [
+              "https://twitter.com/opportunityhack",
+              "https://github.com/opportunity-hack",
+              "https://www.instagram.com/opportunityhack/",
+              "https://www.linkedin.com/company/opportunity-hack/",
+            ],
+          },
+          {
+            "@type": "WebPage",
+            "@id": "https://ohack.dev/community-champions#webpage",
+            url: "https://ohack.dev/community-champions",
+            name: title,
+            description: description,
+            isPartOf: {
+              "@type": "WebSite",
+              "@id": "https://ohack.dev/#website",
+            },
+            about: {
+              "@type": "Organization",
+              name: "Opportunity Hack Community Champions",
+              description:
+                "Volunteers, mentors, judges, and hackers who lead Opportunity Hack's mission to connect technology professionals with nonprofits in need.",
+            },
+          },
+          {
+            "@type": "BreadcrumbList",
+            itemListElement: [
+              {
+                "@type": "ListItem",
+                position: 1,
+                name: "Home",
+                item: "https://ohack.dev",
+              },
+              {
+                "@type": "ListItem",
+                position: 2,
+                name: "Community Champions",
+                item: "https://ohack.dev/community-champions",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- **New `/community-champions` page** with full SEO (OG tags, JSON-LD structured data, breadcrumbs), hero image, search by name, tier-based filtering, and responsive card grid
- **Tier-based recognition system** (Bronze/Silver/Gold/Platinum/Diamond) replaces rank-based 1st/2nd/3rd badges — designed to encourage engagement at every level rather than only rewarding the top few
- **Shared `heartTiers.js` module** as single source of truth for tier definitions, consumed by community champions, HeartGauge, MilestoneProgress, and hearts about page
- **Full `/about/hearts` redesign**: modern card-based layout, visual tier timeline with gradient connector, larger readable fonts, tabbed Detailed Scoring Criteria (replaces cramped 4-card grid)
- **Homepage link**: "Community Champions" title on the landing page now links to the new page
- **Fixed broken certificate image** (old URL was 404) and added hackathon photos for social proof

## Test plan
- [x] Visit `/community-champions` — verify hero image loads, champions render with tier badges, search and tier filter work
- [x] Visit `/about/hearts` — verify all sections render, tier timeline displays, tabbed reward structure works, certificate image loads, hackathon photo loads
- [x] Visit homepage — verify "Community Champions" title links to `/community-champions`
- [x] Check `/profile/[userid]` — verify Heart Progress still renders correctly with shared tier module
- [x] Test on mobile viewport — verify responsive layouts for both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)