### PR TITLE
Move admin volunteer fetchers off public API

### DIFF
--- a/src/components/admin/JudgingRound1.js
+++ b/src/components/admin/JudgingRound1.js
@@ -219,7 +219,7 @@ const JudgingRound1 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
       setLoadingJudges(true);
       console.log('Fetching judges for hackathon:', selectedHackathon);
       const judgesResponse = await axios.get(
-        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/hackathon/${selectedHackathon}/judge`,
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/admin/hackathon/${selectedHackathon}/judge`,
         {
           headers: {
             Authorization: `Bearer ${accessToken}`,

--- a/src/components/admin/JudgingRound2.js
+++ b/src/components/admin/JudgingRound2.js
@@ -379,7 +379,7 @@ const JudgingRound2 = ({ orgId, hackathons, selectedHackathon, setSelectedHackat
     try {
       const [judgesResponse, teamsResponse] = await Promise.all([
         axios.get(
-          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/hackathon/${selectedHackathon}/judge`,
+          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/admin/hackathon/${selectedHackathon}/judge`,
           {
             headers: {
               Authorization: `Bearer ${accessToken}`,

--- a/src/pages/admin/check-in/index.js
+++ b/src/pages/admin/check-in/index.js
@@ -241,7 +241,7 @@ const AdminCheckInPage = withRequiredAuthInfo(({ userClass }) => {
     setLoading(true);
     try {
       // First, fetch the volunteer data to verify it exists
-      const fetchUrl = `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/hackathon/${eventId}/${volunteerType}`;
+      const fetchUrl = `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/admin/hackathon/${eventId}/${volunteerType}`;
       const response = await fetch(fetchUrl, {
         headers: {
           authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## Summary
- Backend PR https://github.com/opportunity-hack/backend-ohack.dev/pull/208 is locking down the public volunteer endpoint to strip PII and internal metadata.
- Three admin pages were incorrectly calling the public endpoint and will lose fields they depend on once that PR lands. Switch them to the authenticated `/api/messages/admin/hackathon/<event>/<type>` endpoint:
  - \`src/pages/admin/check-in/index.js\` — needs full record for the PATCH round-trip (was otherwise silently dropping \`email\` and audit fields).
  - \`src/components/admin/JudgingRound1.js\` — depends on \`judge.user_id\` for team assignments.
  - \`src/components/admin/JudgingRound2.js\` — same.
- The only legitimate public consumer (\`src/pages/hack/[event_id]/census.js\`) is unchanged — it only reads \`name\`, \`availability\`, \`expertise\`, \`background\`, \`isSelected\`, all of which remain on the public endpoint.

## Test plan
- [ ] \`npm run dev\`; visit \`/admin/check-in\` — scan/lookup still finds volunteers; check-in PATCH succeeds and the Firestore record retains \`email\`/audit fields after the round-trip.
- [ ] Visit a judging admin page (round 1 and round 2) — judges load with \`user_id\` present; team assignment still works.
- [ ] Visit \`/hack/<event>/census\` — mentor/volunteer/judge/hacker grids still render (no regression).
- [ ] Visit \`/admin/volunteer\` — unchanged behavior (already used \`/admin/\` path).

## Coordination
Merge after the backend PR is deployed, or together — both are needed for the fix to be complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)