### PR TITLE
Fix Core Web Vitals CLS regressions flagged by Google Search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,16 @@
 - E2E tests located in `/src/tests/e2e/`
 - Mock implementation examples available in test files
 
+## Core Web Vitals (CLS hygiene)
+Patterns that must stay in place to keep Google Search Console CWV green:
+- `NavBar` and `Footer` are `ssr: true` in `_app.js`; their loading placeholders in `_app.js` match the rendered heights (NavBar 64px, Footer 760px/560px mobile/desktop). Don't flip them back to `ssr: false`.
+- The auth-reactive right side of `Navbar.js` (Log In button ↔ Avatar) must stay inside the fixed-width slot (`minWidth: { xs: 56, md: 140 }`). Adding content there requires keeping both branches the same width.
+- `HeartsLeaderboard` reserves `minHeight: { xs: 128, md: 172 }` in both its loading placeholder on `pages/index.js` and in the component's empty state — don't return `null` from it.
+- Any new above-the-fold async component on the homepage must reserve space via `minHeight` in its loading fallback. `SimplePlaceholder` (opacity:0 with no height) is not enough.
+- Raw `<img>` tags need `width`/`height` attributes. Prefer `next/image` with explicit dimensions.
+- Iframes (YouTube, Instagram, Calendar) must be wrapped in an aspect-ratio container (the existing pattern is `paddingBottom: '56.25%'` with `height: 0` + absolutely-positioned iframe) or given a fixed pixel height.
+- `initFacebookPixel` in `src/lib/ga/index.js` is idempotent via `pixelInitPromise`. Don't add `ReactPixel.init` calls outside of it.
+
 ## Social Media Integration
 
 ### Overview

--- a/src/components/About/Completion/ProjectCompletion.js
+++ b/src/components/About/Completion/ProjectCompletion.js
@@ -89,11 +89,13 @@ const ProjectCompletion = () => {
             </Box>
           </Grid>
           <Grid size={{ xs: 12, md: 4 }}>
-            <InstagramEmbed
-              url="https://www.instagram.com/p/CoBFS8hvcnB/"
-              maxWidth={328}
-              height={500}
-            />
+            <Box sx={{ minHeight: 500, maxWidth: 328, mx: "auto" }}>
+              <InstagramEmbed
+                url="https://www.instagram.com/p/CoBFS8hvcnB/"
+                maxWidth={328}
+                height={500}
+              />
+            </Box>
           </Grid>
         </Grid>
       </TitleContainer>
@@ -287,7 +289,7 @@ const ProjectCompletion = () => {
           </Grid>
         </Grid>
 
-        <Box sx={{ mt: 4 }}>
+        <Box sx={{ mt: 4, minHeight: 500, maxWidth: 328, mx: "auto" }}>
           <InstagramEmbed
             url="https://www.instagram.com/p/CVicxFMPiqo/"
             maxWidth={328}

--- a/src/components/About/Hearts/Hearts.js
+++ b/src/components/About/Hearts/Hearts.js
@@ -633,11 +633,13 @@ const Hearts = () => {
               </Paper>
             </Grid>
             <Grid size={{ xs: 12, md: 4 }}>
-              <InstagramEmbed
-                url="https://www.instagram.com/p/CoupvGxuiLX/"
-                maxWidth={400}
-                height={480}
-              />
+              <Box sx={{ minHeight: 480, maxWidth: 400, mx: "auto" }}>
+                <InstagramEmbed
+                  url="https://www.instagram.com/p/CoupvGxuiLX/"
+                  maxWidth={400}
+                  height={480}
+                />
+              </Box>
             </Grid>
           </Grid>
         </Section>

--- a/src/components/Hearts/HeartsLeaderboard.js
+++ b/src/components/Hearts/HeartsLeaderboard.js
@@ -29,14 +29,29 @@ const HeartsLeaderboard = () => {
     return () => controller.abort();
   }, [apiServerUrl]);
 
-  if (!leaders.length) return null;
-
   const avatarSize = isMobile ? 36 : 48;
   const badgeSize = isMobile ? 16 : 20;
+
+  // Reserve space matching the rendered leaderboard to prevent CLS.
+  // Heights tuned to match: padding + title + row (avatar + name + hearts) + margin.
+  const reservedMinHeight = { xs: 128, md: 172 };
+
+  if (!leaders.length) {
+    return (
+      <Box
+        aria-hidden="true"
+        sx={{
+          minHeight: reservedMinHeight,
+          mb: { xs: 1.5, md: 2 },
+        }}
+      />
+    );
+  }
 
   return (
     <Box
       sx={{
+        minHeight: reservedMinHeight,
         py: { xs: 1.5, md: 2 },
         px: { xs: 0.5, md: 2 },
         mb: { xs: 1.5, md: 2 },

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -429,71 +429,86 @@ export default function NavBar() {
             </Menu>
           </Box>
 
-          {isLoggedIn && (
-            <Box sx={{ flexGrow: 0 }}>
-              <Tooltip title="Open settings">
-                <IconButton 
-                  onClick={handleOpenUserMenu} 
-                  sx={{ 
-                    p: 0,
-                    minWidth: "48px", 
-                    minHeight: "48px",
-                    margin: "4px" 
+          {/*
+            Fixed-width auth slot keeps the navbar's right edge stable whether we
+            render the Log In button (SSR/logged-out) or the Avatar (post-hydration
+            logged-in). Prevents CLS from the auth state flipping on hydration.
+          */}
+          <Box
+            sx={{
+              flexGrow: 0,
+              flexShrink: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "flex-end",
+              minWidth: { xs: 56, md: 140 },
+              minHeight: "56px",
+            }}
+          >
+            {isLoggedIn ? (
+              <>
+                <Tooltip title="Open settings">
+                  <IconButton
+                    onClick={handleOpenUserMenu}
+                    sx={{
+                      p: 0,
+                      minWidth: "48px",
+                      minHeight: "48px",
+                      margin: "4px",
+                    }}
+                  >
+                    <Avatar alt={user?.firstName} src={user?.pictureUrl} />
+                  </IconButton>
+                </Tooltip>
+                <Menu
+                  sx={{ mt: "45px" }}
+                  id="menu-appbar"
+                  anchorEl={anchorElUser}
+                  anchorOrigin={{
+                    vertical: "top",
+                    horizontal: "right",
                   }}
+                  keepMounted
+                  transformOrigin={{
+                    vertical: "top",
+                    horizontal: "right",
+                  }}
+                  open={Boolean(anchorElUser)}
+                  onClose={handleCloseUserMenu}
                 >
-                  <Avatar alt={user?.firstName} src={user?.pictureUrl} />
-                </IconButton>
-              </Tooltip>
-              <Menu
-                sx={{ mt: "45px" }}
-                id="menu-appbar"
-                anchorEl={anchorElUser}
-                anchorOrigin={{
-                  vertical: "top",
-                  horizontal: "right",
-                }}
-                keepMounted
-                transformOrigin={{
-                  vertical: "top",
-                  horizontal: "right",
-                }}
-                open={Boolean(anchorElUser)}
-                onClose={handleCloseUserMenu}
+                  {auth_settings.map((setting) => (
+                    <Link href={setting[1]} key={setting[0]} passHref>
+                      <MenuItem
+                        onClick={handleCloseUserMenu}
+                        sx={{ py: 1.5, minHeight: "48px" }}
+                      >
+                        <Typography textAlign="center">{setting[0]}</Typography>
+                      </MenuItem>
+                    </Link>
+                  ))}
+                  <MenuItem
+                    onClick={() => logout(true)}
+                    sx={{ py: 1.5, minHeight: "48px" }}
+                  >
+                    <Typography textAlign="center">Log Out</Typography>
+                  </MenuItem>
+                </Menu>
+              </>
+            ) : (
+              <LoginButton
+                variant="contained"
+                disableElevation
+                onClick={() =>
+                  redirectToLoginPage({
+                    postLoginRedirectUrl: window.location.href,
+                  })
+                }
+                className="login-button"
               >
-                {auth_settings.map((setting) => (
-                  <Link href={setting[1]} key={setting[0]} passHref>
-                    <MenuItem 
-                      onClick={handleCloseUserMenu}
-                      sx={{ py: 1.5, minHeight: "48px" }}
-                    >
-                      <Typography textAlign="center">{setting[0]}</Typography>
-                    </MenuItem>
-                  </Link>
-                ))}
-                <MenuItem 
-                  onClick={() => logout(true)}
-                  sx={{ py: 1.5, minHeight: "48px" }}
-                >
-                  <Typography textAlign="center">Log Out</Typography>
-                </MenuItem>
-              </Menu>
-            </Box>
-          )}
-
-          {!isLoggedIn && (
-            <LoginButton
-              variant="contained"
-              disableElevation
-              onClick={() =>
-                redirectToLoginPage({
-                  postLoginRedirectUrl: window.location.href,
-                })
-              }
-              className="login-button"
-            >
-              Log In
-            </LoginButton>
-          )}
+                Log In
+              </LoginButton>
+            )}
+          </Box>
         </Toolbar>
       </Container>
     </AppBar>

--- a/src/components/Profile/PublicBadgeList.js
+++ b/src/components/Profile/PublicBadgeList.js
@@ -36,17 +36,19 @@ export default function PublicBadgeList({ badges }) {
               gap: 1
             }}
           >
-            <img 
-              src={badge.image} 
-              alt={badge.description || "Badge"} 
-              style={{ 
-                width: 60, 
-                height: 60, 
+            <img
+              src={badge.image}
+              alt={badge.description || "Badge"}
+              width={60}
+              height={60}
+              loading="lazy"
+              decoding="async"
+              style={{
                 borderRadius: '50%',
                 objectFit: 'cover',
                 border: '2px solid',
                 borderColor: 'rgba(0,0,0,0.1)'
-              }} 
+              }}
             />
             <Typography variant="caption" sx={{ fontWeight: 500, textAlign: 'center' }}>
               {badge.description}

--- a/src/components/badge-list.js
+++ b/src/components/badge-list.js
@@ -15,7 +15,7 @@ export default function BadgeList({badges}){
         </div>
         {
                 badges.map(badge => {
-                    return <div key={badge.id}><img key={badge.id} alt="Badge" src={badge.image} className="profile__avatar" />{badge.description}</div>;
+                    return <div key={badge.id}><img key={badge.id} alt="Badge" src={badge.image} width={80} height={80} loading="lazy" decoding="async" className="profile__avatar" />{badge.description}</div>;
                 })
         }        
     </div>

--- a/src/components/loader.js
+++ b/src/components/loader.js
@@ -5,7 +5,7 @@ export default function Loader(){
 
   return (
     <div className="loader">
-      <img src={loadingImg} alt="Loading..." />
+      <img src={loadingImg} alt="Loading..." width={80} height={80} />
     </div>
   );
 };

--- a/src/components/ohack-feature.js
+++ b/src/components/ohack-feature.js
@@ -14,6 +14,10 @@ export default function OHackFeature({ title, description, resourceUrl, icon }){
         className="ohack-feature__icon"
         src={icon}
         alt="external link icon"
+        width={36}
+        height={36}
+        loading="lazy"
+        decoding="async"
       />
       {title}
     </h3>

--- a/src/lib/ga/index.js
+++ b/src/lib/ga/index.js
@@ -1,4 +1,9 @@
 let ReactPixel;
+// Guards against the pixel being initialized repeatedly — many components call
+// initFacebookPixel() in useEffect, and _document.js also fires fbq('init').
+// Re-initializing imports react-facebook-pixel on every call and re-runs init,
+// which shows up as wasted INP work.
+let pixelInitPromise = null;
 
 /**
  * Enhanced Google Analytics and Facebook Pixel tracking module
@@ -39,9 +44,12 @@ export const EventAction = {
   DOWNLOAD: 'download'
 };
 
-// Initialize Facebook Pixel
+// Initialize Facebook Pixel (idempotent — subsequent calls reuse the first init).
 export const initFacebookPixel = async () => {
-  if (typeof window !== 'undefined') {
+  if (typeof window === 'undefined') return;
+  if (pixelInitPromise) return pixelInitPromise;
+
+  pixelInitPromise = (async () => {
     try {
       ReactPixel = (await import('react-facebook-pixel')).default;
       const options = {
@@ -52,8 +60,11 @@ export const initFacebookPixel = async () => {
       ReactPixel.init(process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID, advancedMatching, options);
     } catch (error) {
       console.error('Failed to initialize Facebook Pixel:', error);
+      pixelInitPromise = null; // allow retry after failure
     }
-  }
+  })();
+
+  return pixelInitPromise;
 };
 
 /**

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -10,9 +10,12 @@ import { useRouter } from "next/router";
 import theme from "../assets/theme";
 import { ShoppingCartProvider } from "../context/ShoppingCartContext";
 
-// Simple placeholder components to reduce CLS
+// Placeholder heights tuned to match the rendered NavBar/Footer so the shell
+// doesn't shift when these chunks load (major source of site-wide CLS).
 const NavBarPlaceholder = () => <Box sx={{ height: '64px', width: '100%' }} />;
-const FooterPlaceholder = () => <Box sx={{ height: '500px', width: '100%', bgcolor: theme.palette.primary.main }} />;
+const FooterPlaceholder = () => (
+  <Box sx={{ height: { xs: '760px', md: '560px' }, width: '100%', bgcolor: theme.palette.primary.main }} />
+);
 
 // NOTE: Load dynamics below static imports to avoid eslint errors.
 
@@ -21,13 +24,16 @@ const AxiosWrapper = dynamic(() => import('../components/axios-wrapper'), {
   loading: () => null
 })
 
+// SSR the NavBar shell so the layout above the fold is stable before hydration.
+// Auth-dependent avatar/login toggle is now wrapped in a fixed-width slot
+// inside Navbar.js so the flip on hydration doesn't shift layout.
 const NavBar = dynamic(() => import('../components/Navbar/Navbar'), {
-  ssr: false,
+  ssr: true,
   loading: () => <NavBarPlaceholder />
 })
 
 const Footer = dynamic(() => import('../components/Footer/Footer'), {
-  ssr: false,
+  ssr: true,
   loading: () => <FooterPlaceholder />
 });
 

--- a/src/pages/hack/[event_id]/print-timeline.js
+++ b/src/pages/hack/[event_id]/print-timeline.js
@@ -328,9 +328,11 @@ const PrintTimelinePage = () => {
       </div>
 
       <div className="qr-code no-print">
-        <img 
-          src={generateQRCode(eventUrl)} 
+        <img
+          src={generateQRCode(eventUrl)}
           alt={`QR code for ${eventUrl}`}
+          width={120}
+          height={120}
           style={{ maxWidth: '120px', height: 'auto' }}
         />
         <div style={{fontSize: '12px', marginTop: '5px'}}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -51,10 +51,19 @@ const LeadForm = dynamic(() => import("../components/LeadForm/LeadForm"), {
   ssr: true, // Enable SSR to reduce CLS
 });
 
+// Reserve above-the-fold space so the leaderboard popping in doesn't shove
+// HeroBanner/LeadForm/HackathonList down on first paint.
+const HeartsLeaderboardPlaceholder = () => (
+  <Box
+    aria-hidden="true"
+    sx={{ minHeight: { xs: 128, md: 172 }, mb: { xs: 1.5, md: 2 } }}
+  />
+);
+
 const HeartsLeaderboard = dynamic(
   () => import("../components/Hearts/HeartsLeaderboard"),
   {
-    loading: () => null,
+    loading: () => <HeartsLeaderboardPlaceholder />,
     ssr: false, // Not critical for first paint
   }
 );


### PR DESCRIPTION
## Summary

- Google Search Console reports **36 mobile + 16 desktop URLs** with Poor CLS (>0.25) and 25 mobile URLs with Need-improvement INP. Regression started ~2026-03-07 on mobile, aligned with the MUI Grid v7 migration, the Next.js 16 upgrade, and the introduction of `HeartsLeaderboard` above-the-fold on the homepage.
- This PR addresses the structural CLS sources in the global shell (NavBar, Footer, homepage above-the-fold) and in widely-reused components (badge images, Instagram embeds). Opportunistic INP win by making `initFacebookPixel` idempotent.

## What changed

**Homepage above-the-fold (highest impact)**
- `HeartsLeaderboard` now reserves `minHeight: { xs: 128, md: 172 }` both in the loading placeholder on `pages/index.js` and in the component itself (instead of returning `null`). Prevents a ~150px insertion that was shoving `HeroBanner`, `LeadForm`, and `HackathonList` down on first render.

**Sitewide shell**
- `NavBar` flipped to `ssr: true` in `_app.js`. The auth-dependent right side (Log In button ↔ user avatar) is now wrapped in a fixed-width slot (`minWidth: { xs: 56, md: 140 }`) so the swap on auth hydration no longer shifts layout.
- `Footer` flipped to `ssr: true`. Fallback placeholder sized to `{ xs: 760px, md: 560px }` to match the rendered footer on mobile vs desktop.

**Image / media dimensions**
- Added explicit `width`/`height` + `loading="lazy"` + `decoding="async"` to raw `<img>` tags in `PublicBadgeList`, `badge-list`, `ohack-feature`, `loader`, and `print-timeline` (QR code).
- Wrapped `InstagramEmbed` usages in `Hearts.js` and `ProjectCompletion.js` in `minHeight` boxes so async iframe loads don't shift surrounding content.

**INP opportunistic**
- `initFacebookPixel` is now idempotent via a cached init promise. Previously every component calling it in `useEffect` re-imported `react-facebook-pixel` and re-ran `ReactPixel.init`, duplicating work already done by the `_document.js` script.

## Not touched (already fine)

- All YouTube iframes — each is wrapped in a `paddingBottom: 56.25%` aspect-ratio container.
- `next/image` with `layout="fill"` (NonProfit banner, VolunteerAutoScroll, CommunityChampions hero) — all parents have explicit heights or responsive aspect ratios.
- Event page (`/hack/[event_id]`) `LoadingPlaceholder` — already sized.

## Test plan
- [x] `npm run build` green
- [ ] Run Lighthouse mobile on `/`, `/hack/[event_id]`, `/nonprofit/[nonprofit_id]`, `/about`, `/volunteer` in preview deployment — target CLS < 0.1.
- [ ] Chrome DevTools Performance panel with Slow 3G + 4× CPU throttle — no Layout Shift events in first 2.5s on homepage.
- [ ] Toggle logged-out vs logged-in on homepage and confirm no visible header shift on hydration.
- [ ] Verify Facebook Pixel still reports PageView once per navigation (not double-firing).
- [ ] Monitor Search Console CWV report weekly after merge (CrUX sampling lags ~28 days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)