### PR TITLE
Perf: tier-1 bundle + third-party-script wins

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,23 @@ module.exports = {
     removeConsole: process.env.NODE_ENV === "production",
   },
 
+  // Modular imports / tree-shaking for heavy dependencies. Many MUI components
+  // and icons get pulled in via named imports; without this, the full package
+  // ships in the initial bundle. Also covers lodash (use lodash-es per import
+  // path too) and date-fns.
+  experimental: {
+    optimizePackageImports: [
+      "@mui/material",
+      "@mui/icons-material",
+      "@mui/lab",
+      "@mui/x-data-grid",
+      "@mui/x-date-pickers",
+      "date-fns",
+      "lodash",
+      "react-icons",
+    ],
+  },
+
   // Rewrites configuration
   async rewrites() {
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "notistack": "^3.0.2",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
-        "react-beautiful-dnd": "^13.1.1",
         "react-circular-progressbar": "^2.1.0",
         "react-confetti": "^6.1.0",
         "react-cookie": "^8.0.1",
@@ -3193,6 +3192,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3206,27 +3206,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/react-redux": {
-      "version": "7.1.34",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
-      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
-      }
-    },
-    "node_modules/@types/react-redux/node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -8477,12 +8456,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "license": "MIT"
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -10531,66 +10504,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-beautiful-dnd": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
-      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
-      "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-beautiful-dnd/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT"
-    },
-    "node_modules/react-beautiful-dnd/node_modules/react-redux": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
-      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
-        "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-beautiful-dnd/node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
-    },
     "node_modules/react-circular-progressbar": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.2.0.tgz",
@@ -12462,15 +12375,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-memo-one": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
-      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "notistack": "^3.0.2",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
-    "react-beautiful-dnd": "^13.1.1",
     "react-circular-progressbar": "^2.1.0",
     "react-confetti": "^6.1.0",
     "react-cookie": "^8.0.1",

--- a/src/components/LeadForm/LeadForm.js
+++ b/src/components/LeadForm/LeadForm.js
@@ -13,6 +13,7 @@ import MailOutlineIcon from "@mui/icons-material/MailOutline";
 import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
 import CircularProgress from "@mui/material/CircularProgress";
 import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
+import ReCaptchaProvider from "../ReCaptchaProvider";
 import { initFacebookPixel, trackEvent, trackForm } from '../../lib/ga';
 
 // Utility functions for bot detection
@@ -387,4 +388,13 @@ const LeadForm = () => {
   );
 };
 
-export default LeadForm;
+// Wrap the default export so consumers (homepage, etc.) get the reCAPTCHA
+// context without having to mount the provider sitewide. This keeps the
+// reCAPTCHA v3 script off of pages that don't render LeadForm.
+export default function LeadFormWithRecaptcha() {
+  return (
+    <ReCaptchaProvider>
+      <LeadForm />
+    </ReCaptchaProvider>
+  );
+}

--- a/src/components/ReCaptchaProvider.js
+++ b/src/components/ReCaptchaProvider.js
@@ -1,0 +1,18 @@
+import { GoogleReCaptchaProvider } from "react-google-recaptcha-v3";
+
+// Wraps GoogleReCaptchaProvider so pages/components that need reCAPTCHA opt in.
+// Previously this lived in _app.js and loaded the reCAPTCHA v3 script on every
+// page (homepage, event pages, nonprofit pages, profile, etc.). That's a ~200KB
+// download + main-thread cost on pages that don't have any form.
+//
+// Mount this only around the subtree that contains a form using `useRecaptcha`.
+export default function ReCaptchaProvider({ children }) {
+  return (
+    <GoogleReCaptchaProvider
+      reCaptchaKey={process.env.NEXT_PUBLIC_GOOGLE_CAPTCHA_SITE_KEY}
+      scriptProps={{ async: true, defer: true, appendTo: "body" }}
+    >
+      {children}
+    </GoogleReCaptchaProvider>
+  );
+}

--- a/src/components/TeamCreation/NonprofitRanker.js
+++ b/src/components/TeamCreation/NonprofitRanker.js
@@ -7,7 +7,7 @@ import {
   Chip,
   Alert
 } from '@mui/material';
-import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { MdDragHandle } from 'react-icons/md';
 
 /**

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,7 +3,6 @@ import dynamic from 'next/dynamic'
 import Head from "next/head";
 import CssBaseline from "@mui/material/CssBaseline";
 import { AuthProvider } from "@propelauth/react";
-import { GoogleReCaptchaProvider } from "react-google-recaptcha-v3";
 import { ThemeProvider } from "@mui/material/styles";
 import { Box } from "@mui/material";
 import { useRouter } from "next/router";
@@ -71,23 +70,21 @@ export default function MyApp({ Component, pageProps }) {
         <title>{pageProps.title}</title>
       </Head>
       <AuthProvider authUrl={process.env.NEXT_PUBLIC_REACT_APP_AUTH_URL}>
-        <GoogleReCaptchaProvider reCaptchaKey={process.env.NEXT_PUBLIC_GOOGLE_CAPTCHA_SITE_KEY}>
-          <AxiosWrapper>
-            <ThemeProvider theme={theme}>
-              <ShoppingCartProvider>
-              <CssBaseline>
-                <Box className="page-layout" sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-                  {!isPrintTimelinePage && <NavBar />}
-                  <Component {...pageProps} />
-                  {!isPrintTimelinePage && <Footer />}
-                </Box>
-              </CssBaseline>
-              <OnboardingDialog />
-              <ProfileCompletionPrompt />
-              </ShoppingCartProvider>
-            </ThemeProvider>
-          </AxiosWrapper>
-        </GoogleReCaptchaProvider>
+        <AxiosWrapper>
+          <ThemeProvider theme={theme}>
+            <ShoppingCartProvider>
+            <CssBaseline>
+              <Box className="page-layout" sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+                {!isPrintTimelinePage && <NavBar />}
+                <Component {...pageProps} />
+                {!isPrintTimelinePage && <Footer />}
+              </Box>
+            </CssBaseline>
+            <OnboardingDialog />
+            <ProfileCompletionPrompt />
+            </ShoppingCartProvider>
+          </ThemeProvider>
+        </AxiosWrapper>
       </AuthProvider>
       <GA/>
     </>

--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import ReCaptchaProvider from "../../components/ReCaptchaProvider";
 import { initFacebookPixel, trackEvent } from '../../lib/ga';
 import {
   Container,
@@ -656,4 +657,10 @@ const ContactPage = () => {
   );
 };
 
-export default ContactPage;
+export default function ContactPageWithRecaptcha(props) {
+  return (
+    <ReCaptchaProvider>
+      <ContactPage {...props} />
+    </ReCaptchaProvider>
+  );
+}

--- a/src/pages/hack/[event_id].js
+++ b/src/pages/hack/[event_id].js
@@ -517,17 +517,6 @@ export default function HackathonEvent({ eventData }) {
           href="https://cdn.ohack.dev"
           crossOrigin="anonymous"
         />
-        <link
-          rel="preconnect"
-          href="https://fonts.googleapis.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-
         {/* DNS Prefetch */}
         <link rel="dns-prefetch" href="https://cdn.ohack.dev" />
 

--- a/src/pages/hack/[event_id]/hacker-application.js
+++ b/src/pages/hack/[event_id]/hacker-application.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
+import ReCaptchaProvider from "../../../components/ReCaptchaProvider";
 import { initFacebookPixel, trackEvent } from '../../../lib/ga';
 import {
   useAuthInfo,
@@ -3454,4 +3455,10 @@ export async function getServerSideProps(context) {
   };
 }
 
-export default HackerApplicationPage;
+export default function HackerApplicationPageWithRecaptcha(props) {
+  return (
+    <ReCaptchaProvider>
+      <HackerApplicationPage {...props} />
+    </ReCaptchaProvider>
+  );
+}

--- a/src/pages/hack/[event_id]/judge-application.js
+++ b/src/pages/hack/[event_id]/judge-application.js
@@ -6,6 +6,7 @@ import React, {
   useMemo,
 } from "react";
 import { useRouter } from "next/router";
+import ReCaptchaProvider from "../../../components/ReCaptchaProvider";
 import { initFacebookPixel, trackEvent } from '../../../lib/ga';
 import {
   useAuthInfo,
@@ -2615,4 +2616,10 @@ export async function getServerSideProps(context) {
   };
 }
 
-export default JudgeApplicationPage;
+export default function JudgeApplicationPageWithRecaptcha(props) {
+  return (
+    <ReCaptchaProvider>
+      <JudgeApplicationPage {...props} />
+    </ReCaptchaProvider>
+  );
+}

--- a/src/pages/hack/[event_id]/mentor-application.js
+++ b/src/pages/hack/[event_id]/mentor-application.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
+import ReCaptchaProvider from "../../../components/ReCaptchaProvider";
 import { initFacebookPixel, trackEvent } from '../../../lib/ga';
 import {
   useAuthInfo,
@@ -2403,4 +2404,10 @@ export async function getServerSideProps(context) {
   };
 }
 
-export default MentorApplicationPage;
+export default function MentorApplicationPageWithRecaptcha(props) {
+  return (
+    <ReCaptchaProvider>
+      <MentorApplicationPage {...props} />
+    </ReCaptchaProvider>
+  );
+}

--- a/src/pages/hack/[event_id]/sponsor-application.js
+++ b/src/pages/hack/[event_id]/sponsor-application.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/router";
+import ReCaptchaProvider from "../../../components/ReCaptchaProvider";
 import {
   useAuthInfo,
   RequiredAuthProvider,
@@ -2335,4 +2336,10 @@ export async function getServerSideProps(context) {
   };
 }
 
-export default SponsorApplicationPage;
+export default function SponsorApplicationPageWithRecaptcha(props) {
+  return (
+    <ReCaptchaProvider>
+      <SponsorApplicationPage {...props} />
+    </ReCaptchaProvider>
+  );
+}

--- a/src/pages/hack/[event_id]/volunteer-application.js
+++ b/src/pages/hack/[event_id]/volunteer-application.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
+import ReCaptchaProvider from "../../../components/ReCaptchaProvider";
 import { initFacebookPixel, trackEvent } from '../../../lib/ga';
 import {
   useAuthInfo,
@@ -2902,4 +2903,10 @@ export async function getServerSideProps(context) {
   };
 }
 
-export default VolunteerApplicationPage;
+export default function VolunteerApplicationPageWithRecaptcha(props) {
+  return (
+    <ReCaptchaProvider>
+      <VolunteerApplicationPage {...props} />
+    </ReCaptchaProvider>
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -128,10 +128,6 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
         
-        {/* Performance optimizations */}        
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        
         {/* Preload critical assets with higher fetchpriority */}
         <link 
           rel="preload" 

--- a/src/pages/nonprofits/apply/index.js
+++ b/src/pages/nonprofits/apply/index.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import Head from 'next/head';
+import ReCaptchaProvider from '../../../components/ReCaptchaProvider';
 import {
   Typography, TextField, Button, FormControlLabel, Checkbox,
   Container, Box, Grid, Paper, List, ListItem, ListItemIcon,
@@ -164,7 +165,7 @@ const CTAButton = styled(Button)(({ theme }) => ({
   transition: 'all 0.3s ease-in-out',
 }));
 
-export default function Apply({ title, description, openGraphData }) {
+function Apply({ title, description, openGraphData }) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const { executeRecaptcha } = useGoogleReCaptcha();
@@ -1087,6 +1088,14 @@ export default function Apply({ title, description, openGraphData }) {
         </Box>
       </Container>
     </>
+  );
+}
+
+export default function ApplyWithRecaptcha(props) {
+  return (
+    <ReCaptchaProvider>
+      <Apply {...props} />
+    </ReCaptchaProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

PageSpeed Insights reported mobile perf score **10** / desktop **41**. CLS is a small fraction of that — the rest is JS payload + render-blocking third-party scripts + tree-shaking misses. This PR takes four low-risk, high-leverage cuts at that payload.

**Stacked on top of #275 (CLS/CWV fixes).** Targeting that branch, not `develop`, so the two land cleanly together.

## What changed

### 1. Scope `GoogleReCaptchaProvider` to form pages only (biggest win)
Previously wrapped the entire app in `_app.js`, which meant every visitor to the homepage, event pages, nonprofit detail pages, profile, etc. was downloading Google's reCAPTCHA v3 bundle (~200KB) and hitting a cross-origin script request — even though those pages have no form.

Now there's a thin `<ReCaptchaProvider>` wrapper in `src/components/ReCaptchaProvider.js` that only mounts around:
- `LeadForm` (homepage newsletter signup)
- `/contact`
- `/nonprofits/apply`
- `/hack/[event_id]/{hacker,mentor,judge,volunteer,sponsor}-application`

Every other page is now reCAPTCHA-free. `scriptProps={{ async: true, defer: true }}` on the provider so even the form pages don't block render.

### 2. `experimental.optimizePackageImports` in `next.config.js`
Added for `@mui/material`, `@mui/icons-material`, `@mui/lab`, `@mui/x-data-grid`, `@mui/x-date-pickers`, `date-fns`, `lodash`, `react-icons`. Next 16 tree-shakes transitive named imports from these when declared — should trim the main chunk meaningfully.

### 3. Remove orphan Google Fonts preconnects
`pages/index.js` and `pages/hack/[event_id].js` both had `<link rel="preconnect" href="https://fonts.googleapis.com">` and `https://fonts.gstatic.com`. The codebase declares `Inter`, `Space Grotesk`, `Fira Code` as CSS variables, but there's no `@font-face` or `@import` anywhere — nothing actually loads from those hosts. The preconnects were wasted DNS+TLS handshakes.

### 4. Drop `react-beautiful-dnd` (tier 2)
Removed the deprecated package. Migrated the only usage (`src/components/TeamCreation/NonprofitRanker.js`) to `@hello-pangea/dnd`, which is already a dep (used in `LinkManagement.js`) and has an identical API. `npm install` removed 8 transitive packages.

## Test plan

- [x] `npm run build` green
- [ ] Preview deployment: run PageSpeed Insights on `/`, `/hack/[event_id]`, `/nonprofit/[nonprofit_id]`, `/about`, `/volunteer` and compare to baseline (mobile 10 / desktop 41).
- [ ] Verify reCAPTCHA still fires on:
  - [ ] Homepage newsletter signup (`LeadForm`)
  - [ ] `/contact` form submit
  - [ ] `/nonprofits/apply` submit
  - [ ] Each of the 5 application pages under `/hack/[event_id]/*-application`
- [ ] Verify `NonprofitRanker` drag-and-drop still works.
- [ ] DevTools Network tab on homepage: confirm no request to `google.com/recaptcha/api.js` and no `fonts.googleapis.com` preconnects.

## Follow-ups (not in this PR)
- Further `moment` / `moment-timezone` removal (21 files still import it) now that `react-moment` is down to 1 usage.
- Lazy-load GiveButter widget chunk on pages that include it.
- Dynamic-import `mermaid`, `html2canvas`, `recharts` where used.
- Audit `AuthProvider` (Propelauth) — it still mounts globally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)