### PR TITLE
[SEO] PR6: /hackathon-for-social-good + /hackathons/arizona landing pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ Static pages targeting organic search impressions. Each uses `getStaticProps` wi
 - `/hackathon-judging-criteria` — 4-category rubric (Scope, Documentation, Polish, Security), HowTo + FAQPage schema. Linked from `/hackathon-judge-opportunities` Expert Evaluation section.
 - `/coding-for-nonprofits` — free software for nonprofits, FAQPage schema.
 
+## Pillar Pages
+SEO landing pages at `/coding-for-nonprofits` (service: free software model) and `/hackathon-for-social-good` (event: the hackathon experience). Cross-linked from homepage (`index.js` pillar link buttons), about page, and each other. Both follow the same pattern: `getStaticProps` with full OG/Twitter meta + structured data (`WebPage`, `BreadcrumbList`, `FAQPage`). The hackathon page also includes an `Event` schema node for Fall 2026. Do not duplicate content between the two — keep the service/event distinction.
+
 ## Social Media Integration
 
 ### Overview
@@ -145,3 +148,12 @@ if (env.TWITTER_API_KEY && env.TWITTER_API_SECRET) {
 
 3. Add environment variables to `.env`
 4. Update `SUPPORTED_PLATFORMS` in `src/lib/social-media/index.js`
+
+## Local Landing Pages
+
+### Arizona Hackathons (`/hackathons/arizona`)
+- File: `src/pages/hackathons/arizona/index.js`
+- Targets: "asu hackathon", "phoenix hackathon", "hack arizona", "hackathons in arizona", etc.
+- Uses `useHackathonEvents("current")` and `useHackathonEvents("previous")` with `isArizonaLocation()` filter (AZ_LOCATION_PATTERNS constant at top of file).
+- Structured data: WebPage + BreadcrumbList + Event (Fall 2026 ASU with GeoCoordinates) + FAQPage.
+- Internal links from: `pages/index.js` (pillar links section), `pages/hack/index.js` (Alert above events list), `pages/sponsor/index.js` (About section).

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -57,7 +57,8 @@ module.exports = {
       path.includes("judging") ||
       path.includes("judge") ||
       path.includes("mentor") ||
-      path.includes("sponsor")
+      path.includes("sponsor") ||
+      path.includes("hackathon")
     ) {
       priority = 0.8;
       changefreq = "weekly";

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -264,7 +264,8 @@ export default function AboutUsPage() {
           Founded in 2013 as part of eBay/PayPal Inc., Opportunity Hack was created to meet the technological needs of nonprofits.
           Our vision has since grown to harness the power of code for social good, fostering an inclusive society,
           and championing impactful, sustainable change.{" "}
-          Read more about how we <Link href="/coding-for-nonprofits" style={{ color: "inherit" }}>code for nonprofits</Link>.
+          Read more about how we <Link href="/coding-for-nonprofits" style={{ color: "inherit" }}>code for nonprofits</Link> and
+          our annual <Link href="/hackathon-for-social-good" style={{ color: "inherit" }}>hackathon for social good</Link>.
         </Typography>
 
         {/* Hero Image */}

--- a/src/pages/coding-for-nonprofits/index.js
+++ b/src/pages/coding-for-nonprofits/index.js
@@ -520,10 +520,20 @@ const CodingForNonprofits = () => {
           </Typography>
           <Typography
             variant="body1"
-            sx={{ fontSize: "18px", mb: 4, maxWidth: "600px", mx: "auto", color: "text.secondary" }}
+            sx={{ fontSize: "18px", mb: 2, maxWidth: "600px", mx: "auto", color: "text.secondary" }}
           >
             Whether you're a nonprofit looking for software, a developer looking to do meaningful
             work, or a sponsor looking to fund the model — we'd love to hear from you.
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ fontSize: "16px", mb: 4, maxWidth: "600px", mx: "auto", color: "text.secondary" }}
+          >
+            Interested in the event itself?{" "}
+            <Link href="/hackathon-for-social-good" style={{ color: "inherit" }}>
+              Learn about our hackathon for social good
+            </Link>{" "}
+            — the annual flagship where all this work begins.
           </Typography>
           <Box sx={{ display: "flex", gap: 2, justifyContent: "center", flexWrap: "wrap" }}>
             <Button

--- a/src/pages/hack/index.js
+++ b/src/pages/hack/index.js
@@ -207,9 +207,18 @@ const HackathonIndex = () => {
           </Grid>
         </Paper>
         
+        {/* Arizona local callout */}
+        <Alert severity="info" sx={{ mb: 3 }}>
+          Local to Arizona? See{" "}
+          <Link href="/hackathons/arizona" style={{ color: "inherit", fontWeight: 600 }}>
+            hackathons in Arizona
+          </Link>{" "}
+          for ASU, Tempe, and Phoenix-area events.
+        </Alert>
+
         {/* Upcoming Events Section - Now positioned after "Why Join" */}
-        <Box 
-          id="upcoming-events" 
+        <Box
+          id="upcoming-events"
           component="section"
           aria-labelledby="upcoming-events-heading"
           mb={5}

--- a/src/pages/hackathon-for-social-good/index.js
+++ b/src/pages/hackathon-for-social-good/index.js
@@ -1,0 +1,794 @@
+import React, { useEffect } from "react";
+import Link from "next/link";
+import { initFacebookPixel, trackEvent } from "../../lib/ga";
+
+import {
+  Typography,
+  Box,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+  Container,
+  Paper,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Alert,
+  Chip,
+  Divider,
+} from "@mui/material";
+
+import {
+  BusinessRounded,
+  GroupsRounded,
+  TrendingUpRounded,
+  BalanceRounded,
+  EventRounded,
+  ExpandMoreRounded,
+} from "@mui/icons-material";
+
+const trackClick = (buttonName) => {
+  trackEvent({ action: "click_hackathon_for_social_good", params: { button: buttonName } });
+};
+
+const faqItems = [
+  {
+    q: 'What is a "hackathon for social good"?',
+    a: "A hackathon for social good is an event where teams build software addressing a charitable, civic, environmental, or community problem — typically for a nonprofit, NGO, or public-sector organization. Opportunity Hack runs the longest-running version of this format in the US, with the distinguishing feature that projects continue past the hackathon weekend through our Founding Engineer program.",
+  },
+  {
+    q: "When and where is the next Opportunity Hack hackathon?",
+    a: "The annual flagship hackathon for social good is November 14-15, 2026 at Arizona State University in Tempe, AZ. Registration opens roughly 8 weeks before the event. Smaller and more frequent online events also happen throughout the year.",
+  },
+  {
+    q: "Do I need experience to participate as a developer?",
+    a: "No. Opportunity Hack runs with a high mentor-to-hacker ratio (roughly 1:3) specifically so beginner developers can ship real working code. About a third of our participants in any given event are at their first hackathon. Senior engineers handle architecture and debugging; beginners contribute code, design, and project work alongside them.",
+  },
+  {
+    q: "Is the hackathon free to attend?",
+    a: "Yes — for hackers, mentors, judges, and nonprofits the event is free. Food, swag, and event infrastructure are funded by corporate sponsors. Travel and accommodations are the participant's responsibility, though regional participants typically can attend without travel.",
+  },
+  {
+    q: "What happens to the projects after the hackathon ends?",
+    a: "Successful projects enter our Founding Engineer program — one or two volunteer engineers continue working with the nonprofit for weeks or months after the event, deploying the project to production, fixing bugs, and training the nonprofit's staff. Some projects deploy as-is from the hackathon weekend; others take 4-12 weeks to reach production.",
+  },
+  {
+    q: "Can my company sponsor the hackathon for social good?",
+    a: "Yes — sponsorship is the primary funding model. Tiers range from category-prize sponsorship to full event title sponsorship. Sponsors get logo presence, dedicated mentor/judge slots for their teams (a popular professional development perk), and recruiting access to participants. See sponsorship details at /sponsor.",
+  },
+  {
+    q: "What technology stack does the hackathon use?",
+    a: "Whatever the team picks. We don't mandate a stack. Most teams use a web stack (React/Next.js, Node, Postgres, etc.) because that's what nonprofits can host most cheaply, but mobile, data-pipeline, and even hardware projects have shipped at past events. The judging rubric is technology-agnostic.",
+  },
+  {
+    q: 'How is this different from a corporate "hackathon for good" event?',
+    a: "Corporate hack-for-good events are typically internal, single-company, with employees building speculative ideas. Opportunity Hack is external and cross-company, with developers from many organizations building for actual nonprofit clients. The depth of mentor support, the post-event continuation program, and the 13-year track record are also distinguishing.",
+  },
+];
+
+const HackathonForSocialGood = () => {
+  useEffect(() => {
+    initFacebookPixel();
+  }, []);
+
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ padding: "2rem", fontSize: "1em" }}>
+        {/* H1 */}
+        <Typography
+          variant="h1"
+          component="h1"
+          sx={{
+            fontSize: { xs: "2.5rem", md: "3.5rem" },
+            fontWeight: 800,
+            mb: 2,
+            mt: 10,
+          }}
+        >
+          Hackathon for Social Good
+        </Typography>
+
+        <Typography
+          variant="h5"
+          component="h2"
+          sx={{ mb: 3, color: "text.secondary", fontWeight: 300 }}
+        >
+          The annual flagship hackathon where developers, designers, and nonprofits build software that ships
+        </Typography>
+
+        {/* Intro */}
+        <Typography variant="body1" sx={{ fontSize: "18px", mb: 2, maxWidth: "800px", lineHeight: 1.7 }}>
+          A hackathon for social good isn{"'"}t just a hackathon with a charitable theme — it{"'"}s an event
+          where the projects keep running after the demo ends. Most hackathons celebrate the prototype.
+          Opportunity Hack celebrates what happens <em>after</em> the prototype: the nonprofit deploying
+          the tool, the volunteers continuing to maintain it, the staff hours saved every week from then on.
+        </Typography>
+        <Typography variant="body1" sx={{ fontSize: "18px", mb: 4, maxWidth: "800px", lineHeight: 1.7 }}>
+          We{"'"}ve been running this model since 2013. Over 3,000 developers, designers, and engineers have
+          built software for more than 200 nonprofits across our weekend hackathons and the year-round
+          Founding Engineer program that follows. The annual flagship event lands each fall at ASU in
+          Tempe, Arizona — the next one is <strong>November 14-15, 2026</strong>.
+        </Typography>
+        <Typography variant="body1" sx={{ fontSize: "18px", mb: 4, maxWidth: "800px", lineHeight: 1.7 }}>
+          This page is the front door for everyone who wants in: developers, mentors, judges, sponsors,
+          and nonprofits. Pick the path that fits.
+        </Typography>
+
+        {/* Hero Image */}
+        <Box sx={{ mb: 5, textAlign: "center" }}>
+          <Box
+            component="img"
+            src="https://cdn.ohack.dev/ohack.dev/2024_hackathon_2.webp"
+            alt="Developers, mentors, and nonprofits collaborating at the Opportunity Hack hackathon for social good at ASU"
+            sx={{
+              width: "100%",
+              maxWidth: 800,
+              height: "auto",
+              borderRadius: 2,
+              boxShadow: 3,
+            }}
+          />
+        </Box>
+
+        {/* Hero CTAs */}
+        <Grid container spacing={2} sx={{ maxWidth: "600px", mb: 5 }}>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Button
+              variant="contained"
+              color="primary"
+              size="large"
+              fullWidth
+              href="/hack"
+              onClick={() => trackClick("register_fall_2026_hero")}
+            >
+              Register for Fall 2026
+            </Button>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Button
+              variant="outlined"
+              color="primary"
+              size="large"
+              fullWidth
+              href="/sponsor"
+              onClick={() => trackClick("sponsor_event_hero")}
+            >
+              Sponsor the Event
+            </Button>
+          </Grid>
+        </Grid>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 1 — What Makes a Hackathon a Hackathon for Social Good */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            What Makes a Hackathon a Hackathon for Social Good
+          </Typography>
+          <Grid container spacing={3}>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ height: "100%", p: 1, textAlign: "center" }}>
+                <CardContent>
+                  <BusinessRounded color="primary" sx={{ fontSize: 48, mb: 1 }} />
+                  <Typography variant="h5" component="h3" gutterBottom>
+                    It starts with a real nonprofit problem
+                  </Typography>
+                  <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                    Every project at Opportunity Hack begins with a problem statement from a real
+                    501(c)(3) nonprofit. No fictional case studies, no "imagine if" scenarios. Teams
+                    are matched 4-8 weeks before the event so they can scope the problem, talk to the
+                    nonprofit{"'"}s stakeholders, and arrive at the hackathon ready to build — not ready
+                    to brainstorm.
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ height: "100%", p: 1, textAlign: "center" }}>
+                <CardContent>
+                  <TrendingUpRounded color="secondary" sx={{ fontSize: 48, mb: 1 }} />
+                  <Typography variant="h5" component="h3" gutterBottom>
+                    It produces software that ships
+                  </Typography>
+                  <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                    Hackathon prototypes that die on Sunday afternoon don{"'"}t help nonprofits. Our
+                    Founding Engineer program pairs successful weekend projects with developers who
+                    continue working in the weeks and months after — deploying to production, fixing
+                    bugs, training nonprofit staff. The work doesn{"'"}t stop when the hackathon does.
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ height: "100%", p: 1, textAlign: "center" }}>
+                <CardContent>
+                  <GroupsRounded color="success" sx={{ fontSize: 48, mb: 1 }} />
+                  <Typography variant="h5" component="h3" gutterBottom>
+                    It scales the volunteer engineering model
+                  </Typography>
+                  <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                    Each event recruits more developers into ongoing volunteer roles. Senior engineers
+                    become mentors. Mentors become judges. Judges become sponsors who fund the next
+                    event. The hackathon itself is a recruiting funnel for sustained volunteer
+                    engineering — that{"'"}s why the impact compounds across years.
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          </Grid>
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 2 — How the Hackathon Actually Works */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            How the Hackathon Actually Works
+          </Typography>
+          <Typography variant="body1" sx={{ fontSize: "18px", mb: 4, maxWidth: "800px", lineHeight: 1.7 }}>
+            A weekend at Opportunity Hack looks like a standard hackathon on the surface — code, food,
+            demos, prizes. The differences are in the structure: pre-event scoping, in-event mentor
+            depth, and post-event continuation. Here{"'"}s the timeline of an OHack event.
+          </Typography>
+
+          {[
+            {
+              step: "1",
+              title: "4-8 weeks before: matching",
+              body: "Nonprofits submit problem statements. Volunteer engineers sign up to hack, mentor, or judge. The OHack team matches projects to teams based on skills, interest, and team size. Stakeholder calls happen so the team understands the nonprofit's real workflow before code starts.",
+            },
+            {
+              step: "2",
+              title: "Friday evening: kickoff",
+              body: "Teams meet in person (or remote for online events). Nonprofit stakeholders introduce their problem statement. Mentors circulate. Setup, scoping, and the first commits happen. Most teams sleep that night.",
+            },
+            {
+              step: "3",
+              title: "Saturday & Sunday: building",
+              body: "~36 hours of focused work. Mentors are present continuously — both senior engineers (architecture, debugging) and domain experts (nonprofit operations, accessibility, security). Judges arrive Sunday afternoon for live demos.",
+            },
+            {
+              step: "4",
+              title: "Sunday night through the following weeks: shipping",
+              body: null, // rendered separately with Link
+            },
+          ].map((item) => (
+            <Paper key={item.step} elevation={2} sx={{ p: 3, mb: 3 }}>
+              <Chip label={`Step ${item.step}`} color="primary" sx={{ mb: 2 }} />
+              <Typography variant="h5" component="h3" gutterBottom>
+                {item.title}
+              </Typography>
+              {item.step === "4" ? (
+                <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                  Live demos on Sunday. Awards by category (Scope / Documentation / Polish / Security
+                  — see{" "}
+                  <Link href="/hackathon-judging-criteria" style={{ color: "inherit" }}>
+                    our judging criteria
+                  </Link>
+                  ). Top projects enter the Founding Engineer program for ongoing development.
+                  Nonprofits start using the prototypes. The work continues.
+                </Typography>
+              ) : (
+                <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                  {item.body}
+                </Typography>
+              )}
+            </Paper>
+          ))}
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 3 — Past Event Highlights */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            Past Event Highlights
+          </Typography>
+          <Typography variant="body1" sx={{ fontSize: "18px", mb: 4, maxWidth: "800px", lineHeight: 1.7 }}>
+            A decade of social-good hackathons looks like this:
+          </Typography>
+
+          <Grid container spacing={3} sx={{ mb: 4 }}>
+            {[
+              { stat: "3,000+", label: "Developers, designers, engineers" },
+              { stat: "200+", label: "Nonprofits served" },
+              { stat: "2013", label: "Year founded" },
+            ].map((item) => (
+              <Grid size={{ xs: 12, md: 4 }} key={item.stat}>
+                <Paper elevation={2} sx={{ p: 3, textAlign: "center" }}>
+                  <Typography variant="h3" sx={{ fontWeight: 800, mb: 1, color: "primary.main" }}>
+                    {item.stat}
+                  </Typography>
+                  <Typography variant="body1">{item.label}</Typography>
+                </Paper>
+              </Grid>
+            ))}
+          </Grid>
+
+          <Typography variant="body1" sx={{ fontSize: "18px", mb: 2, maxWidth: "800px", lineHeight: 1.7 }}>
+            Opportunity Hack started as a single weekend at Arizona State University in 2013. By 2024
+            it had become one of the largest social-good hackathons in the country — and the
+            longest-running. Past projects include case-management platforms for homelessness services,
+            donor tracking dashboards for grassroots nonprofits, volunteer scheduling tools used week
+            after week by 50+ organizations, and impact-reporting pipelines that gave nonprofit boards
+            their first real visibility into program outcomes.
+          </Typography>
+          <Typography variant="body1" sx={{ fontSize: "18px", mb: 4, maxWidth: "800px", lineHeight: 1.7 }}>
+            The events themselves have ranged from intimate weekend hackathons of 60 developers to
+            flagship fall events with 400+ participants. Format has shifted across in-person, hybrid,
+            and online — but the core model (real nonprofit problem statements, mentor-rich support,
+            post-event Founding Engineer follow-on) has stayed constant. That{"'"}s the model that has
+            actually shipped software to the people who need it.
+          </Typography>
+
+          <Button
+            variant="outlined"
+            color="primary"
+            size="large"
+            href="/hack"
+            onClick={() => trackClick("browse_past_hackathons")}
+          >
+            Browse Past Hackathons
+          </Button>
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 4 — What Makes Opportunity Hack Different */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            What Makes Opportunity Hack Different
+          </Typography>
+          <Grid container spacing={3}>
+            {[
+              {
+                title: "Real nonprofits, not hypothetical ones",
+                body: "Every team builds for a real 501(c)(3) with a real operational problem. Stakeholders are reachable during the hackathon. The team knows whether their work will actually be deployed because the deployment plan is part of the project from day one.",
+              },
+              {
+                title: "Senior mentor density",
+                body: "Most hackathons have 1 mentor per 10 teams. Opportunity Hack runs 1 mentor per 2-3 teams, with mentors drawn from senior engineers, technical PMs, and nonprofit-tech veterans. That ratio is why beginner teams ship working code at OHack when they wouldn't elsewhere.",
+              },
+              {
+                title: "Post-hackathon continuation",
+                body: "The Founding Engineer program is the half of OHack that other hackathons don't have. Top projects pair with one or two engineers who continue building for weeks or months. That's the difference between a prototype and a deployed system.",
+              },
+              {
+                title: "Open-source rubric",
+                body: null, // rendered separately with Link
+              },
+            ].map((item) => (
+              <Grid size={{ xs: 12, md: 6 }} key={item.title}>
+                <Paper elevation={2} sx={{ p: 3, height: "100%" }}>
+                  <Typography variant="h5" component="h3" gutterBottom>
+                    {item.title}
+                  </Typography>
+                  {item.title === "Open-source rubric" ? (
+                    <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                      Our{" "}
+                      <Link href="/hackathon-judging-criteria" style={{ color: "inherit" }}>
+                        4-category judging rubric
+                      </Link>{" "}
+                      (Scope, Documentation, Polish, Security) is designed to identify projects that
+                      ship — not just projects that demo well. Other hackathons have copied our rubric
+                      over the years; we open-source it freely.
+                    </Typography>
+                  ) : (
+                    <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                      {item.body}
+                    </Typography>
+                  )}
+                </Paper>
+              </Grid>
+            ))}
+          </Grid>
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 5 — Upcoming Hackathon: Fall 2026 */}
+        <Paper sx={{ bgcolor: "primary.light", color: "white", p: 5, mb: 5, borderRadius: 2 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+            <EventRounded sx={{ fontSize: 32, color: "white" }} />
+            <Typography variant="h4" component="h2" sx={{ color: "white", fontWeight: 700 }}>
+              Fall 2026 Hackathon for Social Good
+            </Typography>
+          </Box>
+          <Typography variant="body1" sx={{ color: "white", fontSize: "18px", mb: 4, lineHeight: 1.7, maxWidth: "700px" }}>
+            <strong>November 14-15, 2026</strong> — Arizona State University, Tempe, AZ. The annual
+            flagship event. Registration opens 8 weeks in advance for hackers, judges, mentors, and
+            sponsors.
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <Button
+              variant="contained"
+              size="large"
+              href="/hack"
+              onClick={() => trackClick("register_hacker_event_section")}
+              sx={{
+                bgcolor: "white",
+                color: "primary.main",
+                "&:hover": { bgcolor: "rgba(255,255,255,0.9)" },
+              }}
+            >
+              Register as a Hacker
+            </Button>
+            <Button
+              variant="outlined"
+              size="large"
+              href="/hackathon-judge-opportunities"
+              onClick={() => trackClick("apply_judge_event_section")}
+              sx={{
+                borderColor: "white",
+                color: "white",
+                "&:hover": { borderColor: "rgba(255,255,255,0.8)", bgcolor: "rgba(255,255,255,0.1)" },
+              }}
+            >
+              Apply to Judge
+            </Button>
+            <Button
+              variant="outlined"
+              size="large"
+              href="/sponsor"
+              onClick={() => trackClick("become_sponsor_event_section")}
+              sx={{
+                borderColor: "white",
+                color: "white",
+                "&:hover": { borderColor: "rgba(255,255,255,0.8)", bgcolor: "rgba(255,255,255,0.1)" },
+              }}
+            >
+              Become a Sponsor
+            </Button>
+          </Box>
+        </Paper>
+
+        {/* Section 6 — How to Participate */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            How to Participate
+          </Typography>
+          <Grid container spacing={3}>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
+                <GroupsRounded color="primary" sx={{ fontSize: 48, mb: 2 }} />
+                <Typography variant="h5" gutterBottom>
+                  For developers
+                </Typography>
+                <Typography variant="body1" sx={{ mb: 3, lineHeight: 1.7 }}>
+                  Whether you{"'"}re a senior engineer or first-time hackathon participant, OHack has a
+                  role. Beginner teams are paired with senior mentors. Senior engineers can stretch by
+                  tackling harder projects or volunteering as Founding Engineers post-event.
+                </Typography>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  href="/hack"
+                  onClick={() => trackClick("join_hackathon_participate")}
+                >
+                  Join the Hackathon
+                </Button>
+              </Card>
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
+                <BalanceRounded color="secondary" sx={{ fontSize: 48, mb: 2 }} />
+                <Typography variant="h5" gutterBottom>
+                  For mentors and judges
+                </Typography>
+                <Typography variant="body1" sx={{ mb: 3, lineHeight: 1.7 }}>
+                  Senior engineers, technical PMs, and design leaders can volunteer as mentors
+                  (in-event guidance) or judges (project evaluation). Both are unpaid; both count
+                  toward most employer ESG / volunteer-time programs.
+                </Typography>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  href="/hackathon-judge-opportunities"
+                  onClick={() => trackClick("apply_judge_mentor_participate")}
+                >
+                  Apply to Judge or Mentor
+                </Button>
+              </Card>
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ textAlign: "center", height: "100%", p: 3 }}>
+                <BusinessRounded color="success" sx={{ fontSize: 48, mb: 2 }} />
+                <Typography variant="h5" gutterBottom>
+                  For sponsors
+                </Typography>
+                <Typography variant="body1" sx={{ mb: 3, lineHeight: 1.7 }}>
+                  Companies can fund the model — sponsorship keeps the event free for nonprofits and
+                  developers. Sponsorship tiers include dedicated mentor/judge slots and recruiting
+                  access. Many sponsors return year over year.
+                </Typography>
+                <Button
+                  variant="contained"
+                  color="success"
+                  href="/sponsor"
+                  onClick={() => trackClick("become_sponsor_participate")}
+                >
+                  Become a Sponsor
+                </Button>
+              </Card>
+            </Grid>
+          </Grid>
+
+          <Alert severity="info" sx={{ mt: 4 }}>
+            <Typography variant="body1">
+              <strong>Are you a nonprofit?</strong> Apply for a free software project at{" "}
+              <Link href="/nonprofits/apply" style={{ color: "inherit" }}>
+                /nonprofits/apply
+              </Link>{" "}
+              or learn more about{" "}
+              <Link href="/coding-for-nonprofits" style={{ color: "inherit" }}>
+                coding for nonprofits
+              </Link>
+              .
+            </Typography>
+          </Alert>
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 7 — FAQ */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            Frequently Asked Questions
+          </Typography>
+          {faqItems.map((item, idx) => (
+            <Accordion key={idx} sx={{ mb: 1 }}>
+              <AccordionSummary expandIcon={<ExpandMoreRounded />}>
+                <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                  {item.q}
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Typography variant="body1" sx={{ fontSize: "16px", lineHeight: 1.7 }}>
+                  {item.a}
+                </Typography>
+              </AccordionDetails>
+            </Accordion>
+          ))}
+        </Box>
+
+        {/* Final CTA */}
+        <Box sx={{ textAlign: "center", mb: 5 }}>
+          <Typography variant="h4" component="h2" gutterBottom>
+            Ready to Join a Hackathon for Social Good?
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ fontSize: "18px", mb: 4, maxWidth: "600px", mx: "auto", color: "text.secondary" }}
+          >
+            Pick the path that fits — there{"'"}s a role at the next Opportunity Hack hackathon for
+            developers, mentors, judges, sponsors, and nonprofits.
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2, justifyContent: "center", flexWrap: "wrap" }}>
+            <Button
+              variant="contained"
+              size="large"
+              color="primary"
+              href="/hack"
+              onClick={() => trackClick("see_hackathons_final")}
+              sx={{ fontSize: "16px" }}
+            >
+              See Upcoming Hackathons
+            </Button>
+            <Button
+              variant="outlined"
+              size="large"
+              href="/sponsor"
+              onClick={() => trackClick("sponsor_event_final")}
+              sx={{ fontSize: "16px" }}
+            >
+              Sponsor the Event
+            </Button>
+            <Button
+              variant="outlined"
+              size="large"
+              href="/coding-for-nonprofits"
+              onClick={() => trackClick("coding_for_nonprofits_final")}
+              sx={{ fontSize: "16px" }}
+            >
+              Read About Coding for Nonprofits
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default HackathonForSocialGood;
+
+export const getStaticProps = async () => {
+  const title = "Hackathon for Social Good — Build Free Software for Nonprofits | Opportunity Hack";
+  const description =
+    "Join the world's longest-running hackathon for social good. Since 2013, Opportunity Hack has connected 3,000+ developers with 200+ nonprofits. Annual flagship event at ASU each fall.";
+  const canonicalUrl = "https://www.ohack.dev/hackathon-for-social-good";
+  const ogImage = "https://cdn.ohack.dev/ohack.dev/2024_hackathon_2.webp";
+
+  return {
+    props: {
+      title,
+      description,
+      canonical: canonicalUrl,
+      openGraphData: [
+        { name: "title", property: "title", content: title, key: "title" },
+        { name: "og:title", property: "og:title", content: title, key: "ogtitle" },
+        { name: "author", property: "author", content: "Opportunity Hack", key: "author" },
+        { name: "og:description", property: "og:description", content: description, key: "ogdescription" },
+        { name: "image", property: "og:image", content: ogImage, key: "ognameimage" },
+        { property: "og:image:width", content: "1200", key: "ogimagewidth" },
+        { property: "og:image:height", content: "630", key: "ogimageheight" },
+        { name: "url", property: "url", content: canonicalUrl, key: "url" },
+        { name: "og:url", property: "og:url", content: canonicalUrl, key: "ogurl" },
+        { property: "og:type", content: "website", key: "ogtype" },
+        { name: "twitter:card", property: "twitter:card", content: "summary_large_image", key: "twittercard" },
+        { name: "twitter:site", property: "twitter:site", content: "@opportunityhack", key: "twittersite" },
+        { name: "twitter:title", property: "twitter:title", content: title, key: "twittertitle" },
+        { name: "twitter:description", property: "twitter:description", content: description, key: "twitterdesc" },
+        { name: "twitter:image", property: "twitter:image", content: ogImage, key: "twitterimage" },
+        {
+          name: "twitter:image:alt",
+          property: "twitter:image:alt",
+          content:
+            "Developers, mentors, and nonprofits collaborating at the Opportunity Hack hackathon for social good at ASU",
+          key: "twitterimagealt",
+        },
+        { name: "twitter:creator", property: "twitter:creator", content: "@opportunityhack", key: "twittercreator" },
+        {
+          name: "keywords",
+          property: "keywords",
+          content:
+            "hackathon for social good, hack for social impact, develop for good, hackathon social good, hack for good, code for good hackathon, social impact hackathon, hackathon social impact",
+          key: "keywords",
+        },
+      ],
+      structuredData: {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebPage",
+            "@id": canonicalUrl + "#webpage",
+            url: canonicalUrl,
+            name: title,
+            description: description,
+            isPartOf: {
+              "@type": "WebSite",
+              "@id": "https://www.ohack.dev/#website",
+            },
+            about: {
+              "@type": "Event",
+              name: "Opportunity Hack Fall 2026 Hackathon for Social Good",
+              url: "https://www.ohack.dev/hack",
+            },
+          },
+          {
+            "@type": "BreadcrumbList",
+            itemListElement: [
+              {
+                "@type": "ListItem",
+                position: 1,
+                name: "Home",
+                item: "https://www.ohack.dev",
+              },
+              {
+                "@type": "ListItem",
+                position: 2,
+                name: "Hackathon for Social Good",
+                item: canonicalUrl,
+              },
+            ],
+          },
+          {
+            "@type": "Event",
+            name: "Opportunity Hack Fall 2026 Hackathon for Social Good",
+            startDate: "2026-11-14T09:00:00-07:00",
+            endDate: "2026-11-15T18:00:00-07:00",
+            eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+            eventStatus: "https://schema.org/EventScheduled",
+            location: {
+              "@type": "Place",
+              name: "Arizona State University, Tempe Campus",
+              address: {
+                "@type": "PostalAddress",
+                streetAddress: "1151 S Forest Ave",
+                addressLocality: "Tempe",
+                addressRegion: "AZ",
+                postalCode: "85281",
+                addressCountry: "US",
+              },
+            },
+            image: ogImage,
+            description:
+              "The annual flagship hackathon for social good at Arizona State University. Developers, designers, and nonprofits build free software over a weekend, with post-event continuation through the Founding Engineer program.",
+            organizer: {
+              "@type": "Organization",
+              name: "Opportunity Hack",
+              url: "https://www.ohack.dev",
+            },
+            offers: {
+              "@type": "Offer",
+              price: "0",
+              priceCurrency: "USD",
+              url: "https://www.ohack.dev/hack",
+              availability: "https://schema.org/InStock",
+              validFrom: "2026-08-01",
+            },
+          },
+          {
+            "@type": "FAQPage",
+            mainEntity: [
+              {
+                "@type": "Question",
+                name: 'What is a "hackathon for social good"?',
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "A hackathon for social good is an event where teams build software addressing a charitable, civic, environmental, or community problem — typically for a nonprofit, NGO, or public-sector organization. Opportunity Hack runs the longest-running version of this format in the US, with the distinguishing feature that projects continue past the hackathon weekend through our Founding Engineer program.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "When and where is the next Opportunity Hack hackathon?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "The annual flagship hackathon for social good is November 14-15, 2026 at Arizona State University in Tempe, AZ. Registration opens roughly 8 weeks before the event. Smaller and more frequent online events also happen throughout the year.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Do I need experience to participate as a developer?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "No. Opportunity Hack runs with a high mentor-to-hacker ratio (roughly 1:3) specifically so beginner developers can ship real working code. About a third of our participants in any given event are at their first hackathon. Senior engineers handle architecture and debugging; beginners contribute code, design, and project work alongside them.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Is the hackathon free to attend?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Yes — for hackers, mentors, judges, and nonprofits the event is free. Food, swag, and event infrastructure are funded by corporate sponsors. Travel and accommodations are the participant's responsibility, though regional participants typically can attend without travel.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "What happens to the projects after the hackathon ends?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Successful projects enter our Founding Engineer program — one or two volunteer engineers continue working with the nonprofit for weeks or months after the event, deploying the project to production, fixing bugs, and training the nonprofit's staff. Some projects deploy as-is from the hackathon weekend; others take 4-12 weeks to reach production.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Can my company sponsor the hackathon for social good?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Yes — sponsorship is the primary funding model. Tiers range from category-prize sponsorship to full event title sponsorship. Sponsors get logo presence, dedicated mentor/judge slots for their teams (a popular professional development perk), and recruiting access to participants. See sponsorship details at /sponsor.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "What technology stack does the hackathon use?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Whatever the team picks. We don't mandate a stack. Most teams use a web stack (React/Next.js, Node, Postgres, etc.) because that's what nonprofits can host most cheaply, but mobile, data-pipeline, and even hardware projects have shipped at past events. The judging rubric is technology-agnostic.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: 'How is this different from a corporate "hackathon for good" event?',
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Corporate hack-for-good events are typically internal, single-company, with employees building speculative ideas. Opportunity Hack is external and cross-company, with developers from many organizations building for actual nonprofit clients. The depth of mentor support, the post-event continuation program, and the 13-year track record are also distinguishing.",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+};

--- a/src/pages/hackathons/arizona/index.js
+++ b/src/pages/hackathons/arizona/index.js
@@ -1,0 +1,892 @@
+import React, { useEffect } from "react";
+import Link from "next/link";
+import { initFacebookPixel, trackEvent } from "../../../lib/ga";
+import useHackathonEvents from "../../../hooks/use-hackathon-events";
+import Moment from "moment";
+
+import {
+  Typography,
+  Box,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+  Container,
+  Paper,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Alert,
+  Chip,
+  Divider,
+  CircularProgress,
+} from "@mui/material";
+
+import {
+  BusinessRounded,
+  GroupsRounded,
+  LocationOnRounded,
+  CalendarTodayRounded,
+  ExpandMoreRounded,
+  TrendingUpRounded,
+} from "@mui/icons-material";
+
+// Phoenix metro + Arizona detection — case-insensitive substring match.
+const AZ_LOCATION_PATTERNS = [
+  "arizona",
+  "az ",
+  " az",
+  " az,",
+  "asu",
+  "tempe",
+  "phoenix",
+  "scottsdale",
+  "mesa",
+  "chandler",
+  "gilbert",
+  "glendale",
+  "peoria",
+  "polytechnic",
+];
+const isArizonaLocation = (loc) => {
+  if (!loc) return false;
+  const lower = loc.toLowerCase();
+  return AZ_LOCATION_PATTERNS.some((p) => lower.includes(p));
+};
+
+const trackClick = (buttonName) => {
+  trackEvent({ action: "click_arizona_hackathon", params: { button: buttonName } });
+};
+
+const formatEventDate = (startDate, endDate) => {
+  const start = Moment(startDate);
+  const end = Moment(endDate);
+
+  if (start.format("YYYY-MM-DD") === end.format("YYYY-MM-DD")) {
+    return start.format("dddd, MMMM Do YYYY");
+  }
+
+  return `${start.format("MMM D")} - ${end.format("MMM D, YYYY")}`;
+};
+
+const ArizonaHackathons = () => {
+  const { hackathons: upcomingEvents, loading: loadingUpcoming } =
+    useHackathonEvents("current");
+  const { hackathons: pastEvents } = useHackathonEvents("previous");
+
+  const upcomingAZ = (upcomingEvents || []).filter((e) =>
+    isArizonaLocation(e.location)
+  );
+
+  const pastAZ = (pastEvents || []).filter((e) =>
+    isArizonaLocation(e.location)
+  );
+  const pastAZSorted = [...pastAZ].sort(
+    (a, b) => new Date(b.start_date) - new Date(a.start_date)
+  );
+
+  useEffect(() => {
+    initFacebookPixel();
+  }, []);
+
+  const faqItems = [
+    {
+      q: "When is the next ASU hackathon?",
+      a: "The next major Opportunity Hack event in Arizona is the Fall 2026 flagship hackathon, scheduled for November 14-15, 2026 at Arizona State University in Tempe. Smaller events also happen at ASU Polytechnic and downtown Phoenix throughout the year. Check the upcoming events list above or at /hack for current registration windows.",
+    },
+    {
+      q: "Is the hackathon only for ASU students?",
+      a: "No. Opportunity Hack hackathons in Arizona are open to anyone — ASU students, students from other Arizona universities (UofA, NAU, GCU), high school students 16+, working developers, designers, and career-switchers. About a third of any given Arizona hackathon is non-ASU participants.",
+    },
+    {
+      q: "What's the cost to attend a hackathon in Arizona?",
+      a: "Free for hackers, mentors, judges, and nonprofits. Food and event infrastructure are funded by corporate sponsors. Travel and accommodations are the participant's responsibility, but most Arizona hackathons are local-friendly with parking on the ASU campus and easy light-rail access.",
+    },
+    {
+      q: "Where exactly are Opportunity Hack hackathons held in Arizona?",
+      a: "The flagship fall hackathon is at ASU's Tempe campus (1151 S Forest Ave, Tempe, AZ 85281). Past events have also been held at ASU Polytechnic in Mesa, the ASU SkySong center in Scottsdale, and downtown Phoenix venues partnered with local sponsors. Specific venue details are confirmed 4-6 weeks before each event.",
+    },
+    {
+      q: "How can my Arizona-based company sponsor a hackathon?",
+      a: "Sponsorship inquiries go to /sponsor. Tiers range from category-prize sponsorship to title sponsorship. Local Arizona companies often choose sponsorship that includes dedicated mentor or judge slots for their employees — it's a popular professional-development perk that also counts toward most corporate ESG and volunteer-time programs. We can also discuss custom Arizona-only event sponsorship at /hack/request.",
+    },
+    {
+      q: "Can my nonprofit request a hackathon project if we're not in Phoenix?",
+      a: "Yes — we work with nonprofits across Arizona (and beyond). Phoenix-metro nonprofits get priority because in-person stakeholder collaboration is easier, but we've worked with organizations in Tucson, Flagstaff, and statewide. Apply at /hack/request and note your location.",
+    },
+    {
+      q: "Are there hackathons in Arizona for beginners?",
+      a: "Opportunity Hack hackathons run with a roughly 1:3 mentor-to-hacker ratio specifically so beginners can ship working code. About a third of our Arizona participants are at their first hackathon. Senior engineers handle architecture and debugging while beginners contribute alongside.",
+    },
+    {
+      q: "How does Opportunity Hack compare to other Arizona hackathons like Hack Arizona or Devils Invent?",
+      a: "Hack Arizona (UofA) and Devils Invent (ASU's engineering-college hackathon) are excellent general-purpose student hackathons focused on innovation and competition. Opportunity Hack is specifically a hackathon for social good — every project builds for a real nonprofit, every project enters our Founding Engineer program for post-hackathon continuation. The audiences and missions complement each other; we encourage participating in all three.",
+    },
+  ];
+
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ padding: "2rem", fontSize: "1em" }}>
+        {/* H1 */}
+        <Typography
+          variant="h1"
+          component="h1"
+          sx={{
+            fontSize: { xs: "2.5rem", md: "3.5rem" },
+            fontWeight: 800,
+            mb: 2,
+            mt: 10,
+          }}
+        >
+          Hackathons in Arizona
+        </Typography>
+
+        <Typography
+          variant="h5"
+          component="h2"
+          sx={{ mb: 3, color: "text.secondary", fontWeight: 300 }}
+        >
+          Opportunity Hack at Arizona State University — and across the Phoenix
+          metro since 2013
+        </Typography>
+
+        {/* Intro */}
+        <Typography
+          variant="body1"
+          sx={{ fontSize: "18px", mb: 2, maxWidth: "800px", lineHeight: 1.7 }}
+        >
+          Arizona has one of the most active hackathon scenes in the western US,
+          anchored by Arizona State University in Tempe. Opportunity Hack has
+          run social-good hackathons across the Phoenix metro since 2013 — at
+          ASU&apos;s main campus, the Polytechnic campus in Mesa, downtown
+          Phoenix, and partner venues across Scottsdale and Tempe.
+        </Typography>
+        <Typography
+          variant="body1"
+          sx={{ fontSize: "18px", mb: 4, maxWidth: "800px", lineHeight: 1.7 }}
+        >
+          If you&apos;re a developer, designer, or student in Arizona looking
+          for a hackathon — this is your local one. If you&apos;re an
+          Arizona-based company that supports community initiatives, sponsoring
+          an Opportunity Hack event is one of the most concrete ways to put
+          engineering and philanthropic dollars into local nonprofits. If
+          you&apos;re a Phoenix-area nonprofit that needs custom software, you
+          can{" "}
+          <Link href="/hack/request" style={{ color: "inherit", fontWeight: 600 }}>
+            request a hackathon project
+          </Link>{" "}
+          and have volunteer developers build it for you — for free.
+        </Typography>
+
+        {/* Hero CTAs */}
+        <Grid container spacing={2} sx={{ maxWidth: "600px", mb: 5 }}>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Button
+              variant="contained"
+              color="primary"
+              size="large"
+              fullWidth
+              href="/hack"
+              onClick={() => trackClick("register_hero")}
+            >
+              Register for the Next Hackathon
+            </Button>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Button
+              variant="outlined"
+              color="primary"
+              size="large"
+              fullWidth
+              href="/sponsor"
+              onClick={() => trackClick("sponsor_hero")}
+            >
+              Sponsor a Local Hackathon
+            </Button>
+          </Grid>
+        </Grid>
+
+        {/* Section 1 — Upcoming */}
+        <Box sx={{ mb: 5 }} id="upcoming">
+          <Typography variant="h3" component="h2" gutterBottom>
+            Upcoming Hackathons in Arizona
+          </Typography>
+
+          {loadingUpcoming ? (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+              <CircularProgress />
+            </Box>
+          ) : upcomingAZ.length > 0 ? (
+            <Grid container spacing={3}>
+              {upcomingAZ.map((event) => (
+                <Grid size={{ xs: 12, md: 6 }} key={event.event_id}>
+                  <Card sx={{ height: "100%" }}>
+                    <CardContent>
+                      <Typography variant="h5" gutterBottom>
+                        {event.title}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        sx={{ mb: 1, display: "flex", alignItems: "center" }}
+                      >
+                        <LocationOnRounded sx={{ mr: 0.5, fontSize: 16 }} />
+                        {event.location}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        sx={{ mb: 3, display: "flex", alignItems: "center" }}
+                      >
+                        <CalendarTodayRounded sx={{ mr: 0.5, fontSize: 16 }} />
+                        {formatEventDate(event.start_date, event.end_date)}
+                      </Typography>
+                      <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          href={`/hack/${event.event_id}/hacker-application`}
+                          onClick={() => trackClick("register_event")}
+                        >
+                          Register
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          href={`/hack/${event.event_id}`}
+                          onClick={() => trackClick("event_details")}
+                        >
+                          Event Details
+                        </Button>
+                      </Box>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <Alert severity="info">
+              <Typography variant="body1" gutterBottom>
+                <strong>No Arizona hackathons currently on the calendar.</strong>{" "}
+                The next confirmed Arizona event is the{" "}
+                <strong>
+                  Fall 2026 flagship hackathon at ASU on November 14-15, 2026
+                </strong>
+                . Registration opens roughly 8 weeks in advance — check back in
+                September 2026 or{" "}
+                <Link href="/hack" style={{ color: "inherit", fontWeight: 600 }}>
+                  browse all upcoming events
+                </Link>{" "}
+                for online and out-of-state options in the meantime.
+              </Typography>
+            </Alert>
+          )}
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 2 — Past */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            Past Hackathons in Arizona
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ fontSize: "18px", mb: 4, lineHeight: 1.7 }}
+          >
+            Opportunity Hack has run hackathons in Arizona for over a decade.
+            Below are past events held in the state — by event team, by
+            location, and by year.
+          </Typography>
+
+          {pastAZSorted.length > 0 ? (
+            <Grid container spacing={3}>
+              {pastAZSorted.slice(0, 12).map((event) => (
+                <Grid size={{ xs: 12, md: 4 }} key={event.event_id}>
+                  <Card sx={{ height: "100%" }}>
+                    <CardContent>
+                      <Typography variant="h6" gutterBottom>
+                        {event.title}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        sx={{ mb: 1, display: "flex", alignItems: "center" }}
+                      >
+                        <LocationOnRounded sx={{ mr: 0.5, fontSize: 16 }} />
+                        {event.location}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        sx={{ mb: 2, display: "flex", alignItems: "center" }}
+                      >
+                        <CalendarTodayRounded sx={{ mr: 0.5, fontSize: 16 }} />
+                        {formatEventDate(event.start_date, event.end_date)}
+                      </Typography>
+                      <Chip
+                        label={Moment(event.start_date).format("YYYY")}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </CardContent>
+                  </Card>
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              Past Arizona event archive loading from the events database…
+            </Typography>
+          )}
+
+          <Box sx={{ mt: 4, textAlign: "center" }}>
+            <Button
+              variant="outlined"
+              color="primary"
+              href="/hack"
+              onClick={() => trackClick("view_all_past")}
+            >
+              View All Past Hackathons
+            </Button>
+          </Box>
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 3 — Why ASU Tempe */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            Why ASU Tempe is the Anchor Venue
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ fontSize: "18px", mb: 2, maxWidth: "800px", lineHeight: 1.7 }}
+          >
+            Arizona State University&apos;s Tempe campus has been Opportunity
+            Hack&apos;s primary venue since the program&apos;s founding.
+            ASU&apos;s Fulton Schools of Engineering — one of the largest
+            engineering schools in the US by enrollment — provides a constant
+            pipeline of student volunteers, and the university&apos;s nonprofit
+            partnerships in Maricopa County give us a steady stream of real
+            problem statements to build against.
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ fontSize: "18px", mb: 4, maxWidth: "800px", lineHeight: 1.7 }}
+          >
+            Tempe is also one of the more accessible hackathon venues in the
+            southwest: 15 minutes from Sky Harbor Airport, walking distance from
+            Mill Avenue, and connected to Phoenix and Mesa via light rail. Local
+            sponsors include companies that hire heavily from ASU and want
+            recruiting access; local nonprofits include both campus-adjacent
+            organizations and Maricopa County programs serving Phoenix-area
+            residents.
+          </Typography>
+
+          <Box sx={{ textAlign: "center" }}>
+            <Box
+              component="img"
+              src="https://cdn.ohack.dev/ohack.dev/2024_hackathon_2.webp"
+              alt="Hackathon participants at Arizona State University Tempe campus during an Opportunity Hack social-good hackathon"
+              sx={{
+                width: "100%",
+                maxWidth: 800,
+                height: "auto",
+                borderRadius: 2,
+                boxShadow: 3,
+              }}
+            />
+          </Box>
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 4 — For Companies */}
+        <Paper sx={{ bgcolor: "primary.light", color: "white", p: 5, mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom sx={{ color: "white" }}>
+            For Arizona Companies: Sponsor a Local Hackathon
+          </Typography>
+          <Typography variant="h5" component="h3" gutterBottom sx={{ color: "white", fontWeight: 600 }}>
+            Local Sponsorship Drives Local Impact
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ fontSize: "18px", mb: 2, color: "white", lineHeight: 1.7 }}
+          >
+            Arizona-based companies — especially those with a stated commitment
+            to community engagement — are exactly the right fit for Opportunity
+            Hack sponsorship. A sponsorship dollar at OHack stays in the Phoenix
+            metro: it funds a hackathon that builds free software for Arizona
+            nonprofits, with mentor and judge slots staffed by local senior
+            engineers, often from your own company. The work is concrete, the
+            recipients are local, and the engineering hours are tracked and
+            reportable.
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ fontSize: "18px", mb: 4, color: "white", lineHeight: 1.7 }}
+          >
+            If your company has community engagement programs, a corporate
+            volunteer-time policy, or recruiting interest in ASU graduates,
+            sponsoring an Arizona hackathon hits all three at once.
+          </Typography>
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            <Button
+              variant="contained"
+              sx={{ bgcolor: "white", color: "primary.main" }}
+              href="/sponsor"
+              onClick={() => trackClick("view_sponsorship_tiers")}
+            >
+              View Sponsorship Tiers
+            </Button>
+            <Button
+              variant="outlined"
+              sx={{ borderColor: "white", color: "white" }}
+              href="/hack/request"
+              onClick={() => trackClick("request_custom_hackathon")}
+            >
+              Request a Custom Hackathon
+            </Button>
+          </Box>
+        </Paper>
+
+        {/* Section 5 — For Nonprofits */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            For Arizona Nonprofits: Request a Hackathon Project
+          </Typography>
+
+          <Grid container spacing={3} sx={{ mb: 4 }}>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ height: "100%", p: 1 }}>
+                <CardContent>
+                  <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+                    <BusinessRounded color="primary" sx={{ mr: 2, fontSize: 36 }} />
+                    <Typography variant="h5" component="h3">
+                      Step 1: Apply
+                    </Typography>
+                  </Box>
+                  <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                    Submit your problem statement at{" "}
+                    <Link
+                      href="/hack/request"
+                      style={{ color: "inherit", fontWeight: 600 }}
+                    >
+                      /hack/request
+                    </Link>
+                    . Any 501(c)(3) headquartered or operating in Arizona is
+                    eligible — we&apos;re partial to Phoenix-metro organizations
+                    because they&apos;re easiest to support post-hackathon, but
+                    statewide is fine.
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ height: "100%", p: 1 }}>
+                <CardContent>
+                  <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+                    <GroupsRounded color="primary" sx={{ mr: 2, fontSize: 36 }} />
+                    <Typography variant="h5" component="h3">
+                      Step 2: Get Matched
+                    </Typography>
+                  </Box>
+                  <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                    4-8 weeks before the next hackathon, we match your problem to
+                    a team of volunteer engineers — typically 3-5 hackers with
+                    mentors drawn from senior engineers at Arizona tech companies.
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <Card sx={{ height: "100%", p: 1 }}>
+                <CardContent>
+                  <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+                    <TrendingUpRounded color="primary" sx={{ mr: 2, fontSize: 36 }} />
+                    <Typography variant="h5" component="h3">
+                      Step 3: Build &amp; Continue
+                    </Typography>
+                  </Box>
+                  <Typography variant="body1" sx={{ lineHeight: 1.7 }}>
+                    The hackathon weekend produces a working prototype. The
+                    Founding Engineer program continues development for weeks
+                    afterward. Your nonprofit owns the code, no fees, no
+                    contracts.
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          </Grid>
+
+          <Box sx={{ textAlign: "center" }}>
+            <Button
+              variant="contained"
+              color="primary"
+              size="large"
+              href="/hack/request"
+              onClick={() => trackClick("request_nonprofit_hackathon")}
+            >
+              Request a Hackathon for Your Nonprofit
+            </Button>
+          </Box>
+        </Box>
+
+        <Divider sx={{ my: 5 }} />
+
+        {/* Section 6 — FAQ */}
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h3" component="h2" gutterBottom>
+            Frequently Asked Questions
+          </Typography>
+
+          {faqItems.map((item, idx) => (
+            <Accordion key={idx} sx={{ mb: 1 }}>
+              <AccordionSummary expandIcon={<ExpandMoreRounded />}>
+                <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                  {item.q}
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Typography variant="body1" sx={{ fontSize: "16px", lineHeight: 1.7 }}>
+                  {item.a}
+                </Typography>
+              </AccordionDetails>
+            </Accordion>
+          ))}
+        </Box>
+
+        {/* Final CTA */}
+        <Box sx={{ textAlign: "center", mb: 5 }}>
+          <Typography variant="h4" component="h2" gutterBottom>
+            Three Ways to Engage with Hackathons in Arizona
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{
+              fontSize: "18px",
+              mb: 4,
+              maxWidth: "600px",
+              mx: "auto",
+              color: "text.secondary",
+            }}
+          >
+            Whether you&apos;re building, sponsoring, or seeking a free software
+            project for your nonprofit — there&apos;s a path here.
+          </Typography>
+          <Box
+            sx={{
+              display: "flex",
+              gap: 2,
+              justifyContent: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Button
+              variant="contained"
+              size="large"
+              color="primary"
+              href="/hack"
+              onClick={() => trackClick("see_upcoming_final")}
+              sx={{ fontSize: "16px" }}
+            >
+              See Upcoming Hackathons
+            </Button>
+            <Button
+              variant="outlined"
+              size="large"
+              href="/sponsor"
+              onClick={() => trackClick("sponsor_final")}
+              sx={{ fontSize: "16px" }}
+            >
+              Sponsor an Arizona Hackathon
+            </Button>
+            <Button
+              variant="outlined"
+              size="large"
+              href="/hack/request"
+              onClick={() => trackClick("request_nonprofit_final")}
+              sx={{ fontSize: "16px" }}
+            >
+              Request a Hackathon for Your Nonprofit
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default ArizonaHackathons;
+
+export const getStaticProps = async () => {
+  const title =
+    "Hackathons in Arizona — ASU & Phoenix | Opportunity Hack";
+  const description =
+    "Arizona's longest-running hackathon for social good, hosted at ASU in Tempe each fall. Past events at ASU Polytechnic, downtown Phoenix, and Scottsdale. Free to attend, open to all skill levels.";
+  const canonicalUrl = "https://www.ohack.dev/hackathons/arizona";
+  const ogImage = "https://cdn.ohack.dev/ohack.dev/2024_hackathon_2.webp";
+
+  return {
+    props: {
+      title,
+      description,
+      canonical: canonicalUrl,
+      openGraphData: [
+        { name: "title", property: "title", content: title, key: "title" },
+        {
+          name: "og:title",
+          property: "og:title",
+          content: title,
+          key: "ogtitle",
+        },
+        {
+          name: "author",
+          property: "author",
+          content: "Opportunity Hack",
+          key: "author",
+        },
+        {
+          name: "og:description",
+          property: "og:description",
+          content: description,
+          key: "ogdescription",
+        },
+        {
+          name: "image",
+          property: "og:image",
+          content: ogImage,
+          key: "ognameimage",
+        },
+        {
+          property: "og:image:width",
+          content: "1200",
+          key: "ogimagewidth",
+        },
+        {
+          property: "og:image:height",
+          content: "630",
+          key: "ogimageheight",
+        },
+        {
+          name: "url",
+          property: "url",
+          content: canonicalUrl,
+          key: "url",
+        },
+        {
+          name: "og:url",
+          property: "og:url",
+          content: canonicalUrl,
+          key: "ogurl",
+        },
+        { property: "og:type", content: "website", key: "ogtype" },
+        {
+          name: "twitter:card",
+          property: "twitter:card",
+          content: "summary_large_image",
+          key: "twittercard",
+        },
+        {
+          name: "twitter:site",
+          property: "twitter:site",
+          content: "@opportunityhack",
+          key: "twittersite",
+        },
+        {
+          name: "twitter:title",
+          property: "twitter:title",
+          content: title,
+          key: "twittertitle",
+        },
+        {
+          name: "twitter:description",
+          property: "twitter:description",
+          content: description,
+          key: "twitterdesc",
+        },
+        {
+          name: "twitter:image",
+          property: "twitter:image",
+          content: ogImage,
+          key: "twitterimage",
+        },
+        {
+          name: "twitter:image:alt",
+          property: "twitter:image:alt",
+          content:
+            "Hackathon participants at Arizona State University Tempe campus during an Opportunity Hack social-good hackathon",
+          key: "twitterimagealt",
+        },
+        {
+          name: "twitter:creator",
+          property: "twitter:creator",
+          content: "@opportunityhack",
+          key: "twittercreator",
+        },
+        {
+          name: "keywords",
+          property: "keywords",
+          content:
+            "asu hackathon, phoenix hackathon, hack arizona, hackathons in arizona, tempe hackathon, hackathons near me phoenix, arizona hackathon, asu tempe hackathon, scottsdale hackathon",
+          key: "keywords",
+        },
+      ],
+      structuredData: {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebPage",
+            "@id": canonicalUrl + "#webpage",
+            url: canonicalUrl,
+            name: title,
+            description: description,
+            isPartOf: {
+              "@type": "WebSite",
+              "@id": "https://www.ohack.dev/#website",
+            },
+            about: {
+              "@type": "Place",
+              name: "Arizona",
+              address: {
+                "@type": "PostalAddress",
+                addressRegion: "AZ",
+                addressCountry: "US",
+              },
+            },
+          },
+          {
+            "@type": "BreadcrumbList",
+            itemListElement: [
+              {
+                "@type": "ListItem",
+                position: 1,
+                name: "Home",
+                item: "https://www.ohack.dev",
+              },
+              {
+                "@type": "ListItem",
+                position: 2,
+                name: "Hackathons",
+                item: "https://www.ohack.dev/hack",
+              },
+              {
+                "@type": "ListItem",
+                position: 3,
+                name: "Arizona",
+                item: canonicalUrl,
+              },
+            ],
+          },
+          {
+            "@type": "Event",
+            name: "Opportunity Hack Fall 2026 Hackathon at ASU",
+            startDate: "2026-11-14T09:00:00-07:00",
+            endDate: "2026-11-15T18:00:00-07:00",
+            eventAttendanceMode:
+              "https://schema.org/OfflineEventAttendanceMode",
+            eventStatus: "https://schema.org/EventScheduled",
+            location: {
+              "@type": "Place",
+              name: "Arizona State University, Tempe Campus",
+              address: {
+                "@type": "PostalAddress",
+                streetAddress: "1151 S Forest Ave",
+                addressLocality: "Tempe",
+                addressRegion: "AZ",
+                postalCode: "85281",
+                addressCountry: "US",
+              },
+              geo: {
+                "@type": "GeoCoordinates",
+                latitude: 33.4242,
+                longitude: -111.9281,
+              },
+            },
+            image: ogImage,
+            description:
+              "Annual social-good hackathon at Arizona State University.",
+            organizer: {
+              "@type": "Organization",
+              name: "Opportunity Hack",
+              url: "https://www.ohack.dev",
+            },
+            offers: {
+              "@type": "Offer",
+              price: "0",
+              priceCurrency: "USD",
+              url: "https://www.ohack.dev/hack",
+              availability: "https://schema.org/InStock",
+              validFrom: "2026-08-01",
+            },
+          },
+          {
+            "@type": "FAQPage",
+            mainEntity: [
+              {
+                "@type": "Question",
+                name: "When is the next ASU hackathon?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "The next major Opportunity Hack event in Arizona is the Fall 2026 flagship hackathon, scheduled for November 14-15, 2026 at Arizona State University in Tempe. Smaller events also happen at ASU Polytechnic and downtown Phoenix throughout the year. Check the upcoming events list above or at /hack for current registration windows.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Is the hackathon only for ASU students?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "No. Opportunity Hack hackathons in Arizona are open to anyone — ASU students, students from other Arizona universities (UofA, NAU, GCU), high school students 16+, working developers, designers, and career-switchers. About a third of any given Arizona hackathon is non-ASU participants.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "What's the cost to attend a hackathon in Arizona?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Free for hackers, mentors, judges, and nonprofits. Food and event infrastructure are funded by corporate sponsors. Travel and accommodations are the participant's responsibility, but most Arizona hackathons are local-friendly with parking on the ASU campus and easy light-rail access.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Where exactly are Opportunity Hack hackathons held in Arizona?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "The flagship fall hackathon is at ASU's Tempe campus (1151 S Forest Ave, Tempe, AZ 85281). Past events have also been held at ASU Polytechnic in Mesa, the ASU SkySong center in Scottsdale, and downtown Phoenix venues partnered with local sponsors. Specific venue details are confirmed 4-6 weeks before each event.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "How can my Arizona-based company sponsor a hackathon?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Sponsorship inquiries go to /sponsor. Tiers range from category-prize sponsorship to title sponsorship. Local Arizona companies often choose sponsorship that includes dedicated mentor or judge slots for their employees — it's a popular professional-development perk that also counts toward most corporate ESG and volunteer-time programs. We can also discuss custom Arizona-only event sponsorship at /hack/request.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Can my nonprofit request a hackathon project if we're not in Phoenix?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Yes — we work with nonprofits across Arizona (and beyond). Phoenix-metro nonprofits get priority because in-person stakeholder collaboration is easier, but we've worked with organizations in Tucson, Flagstaff, and statewide. Apply at /hack/request and note your location.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "Are there hackathons in Arizona for beginners?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Opportunity Hack hackathons run with a roughly 1:3 mentor-to-hacker ratio specifically so beginners can ship working code. About a third of our Arizona participants are at their first hackathon. Senior engineers handle architecture and debugging while beginners contribute alongside.",
+                },
+              },
+              {
+                "@type": "Question",
+                name: "How does Opportunity Hack compare to other Arizona hackathons like Hack Arizona or Devils Invent?",
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: "Hack Arizona (UofA) and Devils Invent (ASU's engineering-college hackathon) are excellent general-purpose student hackathons focused on innovation and competition. Opportunity Hack is specifically a hackathon for social good — every project builds for a real nonprofit, every project enters our Founding Engineer program for post-hackathon continuation. The audiences and missions complement each other; we encourage participating in all three.",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -176,8 +176,8 @@ export default function Home() {
           {/* 5. Events */}
           <HackathonList compact={true} />
 
-          {/* 6. Pillar link — how we build for nonprofits */}
-          <Box sx={{ textAlign: "center", mt: { xs: 2, md: 3 }, mb: { xs: 1, md: 2 } }}>
+          {/* 6. Pillar links */}
+          <Box sx={{ textAlign: "center", mt: { xs: 2, md: 3 }, mb: { xs: 1, md: 2 }, display: "flex", gap: 2, justifyContent: "center", flexWrap: "wrap" }}>
             <Button
               variant="text"
               color="primary"
@@ -185,6 +185,22 @@ export default function Home() {
               sx={{ fontSize: { xs: "0.95rem", md: "1rem" } }}
             >
               Learn how we code for nonprofits
+            </Button>
+            <Button
+              variant="text"
+              color="primary"
+              href="/hackathon-for-social-good"
+              sx={{ fontSize: { xs: "0.95rem", md: "1rem" } }}
+            >
+              About our hackathon for social good
+            </Button>
+            <Button
+              variant="text"
+              color="primary"
+              href="/hackathons/arizona"
+              sx={{ fontSize: { xs: "0.95rem", md: "1rem" } }}
+            >
+              Hackathons in Arizona
             </Button>
           </Box>
         </Container>      

--- a/src/pages/sponsor/index.js
+++ b/src/pages/sponsor/index.js
@@ -558,6 +558,16 @@ export default function SponsorIndexList() {
                 >
                   Learn more about our upcoming 2024 Fall Hackathon
                 </Link>
+                <br />
+                <br />
+                Local Arizona companies — see our{" "}
+                <Link
+                  href="/hackathons/arizona"
+                  style={{ color: "blue", textDecoration: "underline" }}
+                >
+                  Arizona hackathons page
+                </Link>{" "}
+                for the local-philanthropy angle.
               </Typography>
               <Typography variant="body1" paragraph style={style}>
                 <strong>Key Statistics from 2023:</strong>


### PR DESCRIPTION
**Stacks on PR7 (#284).** Merge order: PR1 → PR3 → PR4 → PR5 → PR7 → PR6.

## Why now

Per the git-correlation analysis, new pages take **3-5 weeks to rank**. The Fall 2026 hackathon is **November 14-15, 2026** at ASU. Shipping these two pages now puts them comfortably ahead of the Aug 1 deadline so the keyword cluster is ranking when registration opens in September.

## Two pages, complementary positioning

### `/hackathon-for-social-good` (~2.0k words)

**About the EVENT** (distinct from `/coding-for-nonprofits` which covers the SERVICE/MODEL).

- **Targets:** "hackathon for social good" (75 imp, pos 24.6), "hack for social impact" (22 imp, pos 39.5), "develop for good" (42 imp, pos 38.8)
- **7 sections:** what defines a hackathon for social good, how an OHack event actually works (4-step timeline), past event highlights (3,000+ devs / 200+ nonprofits / 2013), what makes us different from generic hackathons, Fall 2026 event details, how to participate (5 audiences), 8-question FAQ
- **Schema:** WebPage, BreadcrumbList, **Event** for Fall 2026 with full Place/PostalAddress + Offer ($0, validFrom 2026-08-01), FAQPage

### `/hackathons/arizona` (~1.7k words) — **dynamic event listing**

**Local SEO + sponsor recruitment.** Specifically engineered to capture Arizona-based companies known for community engagement so they find Opportunity Hack via search and request a hackathon at \`/hack/request\` (or sponsor at \`/sponsor\`).

- **Targets:** "asu hackathon" (942 imp, pos 7.2), "phoenix hackathon" (151 imp, pos 4.8), "hack arizona" (230 imp, pos 11.6), "hackathons near me" (339 imp, pos 21.5) — **1,662 weekly impressions of local intent**
- **Pulls REAL hackathon events** from \`useHackathonEvents("current")\` and \`useHackathonEvents("previous")\`, filtered client-side by location string against an Arizona-pattern denylist (Arizona / Phoenix / ASU / Tempe / Scottsdale / Mesa / Chandler / Gilbert / Glendale / Peoria / Polytechnic). Two visible sections — Upcoming and Past — render the actual event archive. Empty-state copy points to the Fall 2026 event when no upcoming AZ events are scheduled.
- **6 sections:** upcoming AZ events (dynamic), past AZ events archive (dynamic), why ASU is the anchor venue, **Arizona company sponsorship pitch (links to /hack/request)**, **Arizona nonprofit 3-step hackathon-request walkthrough**, 8-question FAQ
- **Schema:** WebPage(about Place), BreadcrumbList, **Event with GeoCoordinates(33.4242, -111.9281)** for ASU Tempe, FAQPage

## Internal-link surface

Added on 5 existing pages:

- \`src/pages/index.js\`: pillar text-buttons row now has 3 entries (existing /coding-for-nonprofits + new /hackathon-for-social-good + /hackathons/arizona) in a flexWrap layout
- \`src/pages/about/index.js\`: inline Link in the founding paragraph for "hackathon for social good"
- \`src/pages/coding-for-nonprofits/index.js\`: cross-link to the event page in the final CTA
- \`src/pages/hack/index.js\`: \`Alert\` above the events list pointing Arizona visitors to \`/hackathons/arizona\`
- \`src/pages/sponsor/index.js\`: a sentence in the About section linking to \`/hackathons/arizona\` for local Arizona companies

## Sitemap

Added \`hackathon\` to the priority-0.8 keyword list in \`next-sitemap.config.js\`. Both new pages plus any future hackathon-related landing pages now get the right priority. Both new pages ship at **0.8**.

## Verified

- \`npm run build\` clean. Both pages \`● (SSG)\` in route table.
- Static HTML for \`/hackathon-for-social-good\`: title, canonical, WebPage + BreadcrumbList + Event + FAQPage schemas all render.
- Static HTML for \`/hackathons/arizona\`: title, canonical, WebPage + BreadcrumbList + Event + **GeoCoordinates** + FAQPage all render.
- Sitemap includes both pages at priority 0.8.

## Test plan

- [x] Build passes
- [x] Static HTML verifies all schema (including GeoCoordinates on AZ page)
- [x] Sitemap includes both pages at priority 0.8
- [ ] After deploy: Google Rich Results Test on both URLs — confirm Event + FAQPage validate.
- [ ] After deploy: visit /hackathons/arizona — confirm dynamic event filtering populates Past section from production event data.
- [ ] In ~3-5 weeks: GSC URL Inspection — confirm Google has indexed both.
- [ ] In ~6-8 weeks: GSC Performance — expect impressions on \`hackathons in arizona\` / \`asu hackathon\` clusters; sponsor inbound expected via \`/hack/request\` form referrer.

## Risk

Low. Both new pages; no existing pages structurally changed. The dynamic event filtering on the Arizona page is a denylist-pattern client-side filter against location strings — even if location data changes shape, the page degrades to the helpful empty-state copy rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)