### PR TITLE
Add hackathon planning board — /hack/[event_id]/plan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@date-io/date-fns": "^3.2.1",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@hello-pangea/dnd": "^18.0.1",
@@ -706,6 +709,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   ],
   "dependencies": {
     "@date-io/date-fns": "^3.2.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@hello-pangea/dnd": "^18.0.1",

--- a/src/components/Planning/HackersStat.js
+++ b/src/components/Planning/HackersStat.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { Box, Chip, CircularProgress, Link } from "@mui/material";
+import NextLink from "next/link";
+
+const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+export default function HackersStat({ eventId, targetCount }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!eventId) return;
+    fetch(`${API}/api/messages/hackathon/${eventId}`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((d) => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [eventId]);
+
+  if (loading) return <CircularProgress size={14} />;
+
+  const applied = data?.hacker_count ?? data?.hackers?.length ?? 0;
+  const capacity = targetCount ?? 90;
+  const pct = capacity > 0 ? applied / capacity : 1;
+  const color = pct >= 1 ? "error" : pct >= 0.8 ? "warning" : "success";
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
+      <Chip label={`Applied: ${applied}`} size="small" color={color} />
+      <Chip label={`Capacity: ${capacity}`} size="small" variant="outlined" />
+      <Link component={NextLink} href="/admin/hackathons" fontSize="small">
+        Open in admin ↗
+      </Link>
+    </Box>
+  );
+}

--- a/src/components/Planning/JudgesStat.js
+++ b/src/components/Planning/JudgesStat.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { Box, Chip, CircularProgress, Link, Tooltip } from "@mui/material";
+import NextLink from "next/link";
+
+const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+export default function JudgesStat({ eventId, targetCount }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!eventId) return;
+    fetch(`${API}/api/messages/volunteer/${eventId}?type=judge`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((d) => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [eventId]);
+
+  if (loading) return <CircularProgress size={14} />;
+  if (!data) return null;
+
+  const applied = Array.isArray(data) ? data.length : (data.count ?? 0);
+  const selected = Array.isArray(data) ? data.filter((v) => v.checked_in || v.accepted).length : 0;
+  const goal = targetCount ?? 15;
+  const pct = goal > 0 ? applied / goal : 1;
+  const color = pct >= 1 ? "success" : pct >= 0.8 ? "warning" : "error";
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
+      <Chip label={`Applied: ${applied}`} size="small" color={color} />
+      {selected > 0 && <Chip label={`Selected: ${selected}`} size="small" />}
+      <Chip label={`Goal: ${goal}`} size="small" variant="outlined" />
+      <Link component={NextLink} href={`/admin/volunteer?type=judge`} fontSize="small">
+        Open in admin ↗
+      </Link>
+    </Box>
+  );
+}

--- a/src/components/Planning/MentorsStat.js
+++ b/src/components/Planning/MentorsStat.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { Box, Chip, CircularProgress, Link } from "@mui/material";
+import NextLink from "next/link";
+
+const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+export default function MentorsStat({ eventId, targetCount }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!eventId) return;
+    fetch(`${API}/api/messages/volunteer/${eventId}?type=mentor`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((d) => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [eventId]);
+
+  if (loading) return <CircularProgress size={14} />;
+  if (!data) return null;
+
+  const applied = Array.isArray(data) ? data.length : (data.count ?? 0);
+  const goal = targetCount ?? 20;
+  const pct = goal > 0 ? applied / goal : 1;
+  const color = pct >= 1 ? "success" : pct >= 0.8 ? "warning" : "error";
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
+      <Chip label={`Applied: ${applied}`} size="small" color={color} />
+      <Chip label={`Goal: ${goal}`} size="small" variant="outlined" />
+      <Link component={NextLink} href="/admin/volunteer?type=mentor" fontSize="small">
+        Open in admin ↗
+      </Link>
+    </Box>
+  );
+}

--- a/src/components/Planning/NonprofitsStat.js
+++ b/src/components/Planning/NonprofitsStat.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { Box, Chip, CircularProgress, Link } from "@mui/material";
+import NextLink from "next/link";
+
+const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+export default function NonprofitsStat({ eventId, targetCount }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!eventId) return;
+    fetch(`${API}/api/messages/hackathon/${eventId}`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((d) => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [eventId]);
+
+  if (loading) return <CircularProgress size={14} />;
+
+  const confirmed = data?.nonprofits?.length ?? 0;
+  const goal = targetCount ?? 8;
+  const over = confirmed > goal;
+  const color = confirmed >= goal ? "success" : confirmed >= goal * 0.8 ? "warning" : "error";
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
+      <Chip label={`Confirmed: ${confirmed}${over ? " (over goal!)" : ""}`} size="small" color={color} />
+      <Chip label={`Goal: ${goal}`} size="small" variant="outlined" />
+      <Link component={NextLink} href="/admin/nonprofit" fontSize="small">
+        Open in admin ↗
+      </Link>
+    </Box>
+  );
+}

--- a/src/components/Planning/PlanningBoard.js
+++ b/src/components/Planning/PlanningBoard.js
@@ -1,0 +1,192 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  InputBase,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Add, Close } from "@mui/icons-material";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCorners,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+import PlanningList from "./PlanningList";
+import PlanningCard from "./PlanningCard";
+
+// LexoRank-style: place a card between two existing positions
+function positionBetween(before, after) {
+  if (!before && !after) return "p0500";
+  if (!before) return `p${(parseInt(after.slice(1)) / 2).toFixed(0).padStart(4, "0")}`;
+  if (!after) return `p${(parseInt(before.slice(1)) + 1000).toFixed(0).padStart(4, "0")}`;
+  const mid = Math.round((parseInt(before.slice(1)) + parseInt(after.slice(1))) / 2);
+  return `p${mid.toFixed(0).padStart(4, "0")}`;
+}
+
+export default function PlanningBoard({
+  board,
+  canWrite,
+  onCardClick,
+  createCard,
+  updateCard,
+  moveCard,
+  createList,
+}) {
+  const [activeCard, setActiveCard] = useState(null);
+  const [addingList, setAddingList] = useState(false);
+  const [newListTitle, setNewListTitle] = useState("");
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
+
+  if (!board) return <CircularProgress />;
+
+  const { lists = [], cards = [], labels = [] } = board;
+
+  const sortedLists = [...lists].sort((a, b) =>
+    (a.position || "").localeCompare(b.position || "")
+  );
+
+  function cardsForList(listId) {
+    return cards
+      .filter((c) => c.list_id === listId && !c.archived)
+      .sort((a, b) => (a.position || "").localeCompare(b.position || ""));
+  }
+
+  function handleDragStart(event) {
+    const card = cards.find((c) => c.id === event.active.id);
+    setActiveCard(card || null);
+  }
+
+  function handleDragEnd(event) {
+    setActiveCard(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    // Determine target list: over.id is either a card or a list
+    const overCard = cards.find((c) => c.id === over.id);
+    const targetListId = overCard ? overCard.list_id : over.id;
+    const sourceCard = cards.find((c) => c.id === active.id);
+    if (!sourceCard) return;
+
+    const targetCards = cardsForList(targetListId);
+    const overIndex = targetCards.findIndex((c) => c.id === over.id);
+    const prevCard = targetCards[overIndex - 1];
+    const nextCard = targetCards[overIndex];
+    const newPosition = positionBetween(prevCard?.position, nextCard?.position);
+
+    moveCard(active.id, targetListId, newPosition, sourceCard.updated_at);
+  }
+
+  async function handleAddList() {
+    const title = newListTitle.trim();
+    if (!title) return;
+    await createList(title);
+    setNewListTitle("");
+    setAddingList(false);
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          gap: 2,
+          overflowX: "auto",
+          pb: 2,
+          alignItems: "flex-start",
+        }}
+      >
+        {sortedLists.map((list) => (
+          <PlanningList
+            key={list.id}
+            list={list}
+            cards={cardsForList(list.id)}
+            labels={labels}
+            canWrite={canWrite}
+            onCardClick={onCardClick}
+            onCreateCard={createCard}
+          />
+        ))}
+
+        {canWrite && (
+          <Box sx={{ minWidth: 272 }}>
+            {addingList ? (
+              <Box
+                sx={{
+                  bgcolor: "grey.100",
+                  borderRadius: 2,
+                  p: 1,
+                }}
+              >
+                <InputBase
+                  autoFocus
+                  fullWidth
+                  placeholder="List title…"
+                  value={newListTitle}
+                  onChange={(e) => setNewListTitle(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleAddList();
+                    if (e.key === "Escape") setAddingList(false);
+                  }}
+                  sx={{
+                    bgcolor: "white",
+                    borderRadius: 1,
+                    p: 1,
+                    mb: 0.5,
+                    border: "1px solid",
+                    borderColor: "primary.main",
+                  }}
+                />
+                <Stack direction="row" spacing={1}>
+                  <Button size="small" variant="contained" onClick={handleAddList}>
+                    Add list
+                  </Button>
+                  <IconButton size="small" onClick={() => setAddingList(false)}>
+                    <Close />
+                  </IconButton>
+                </Stack>
+              </Box>
+            ) : (
+              <Box
+                onClick={() => setAddingList(true)}
+                sx={{
+                  bgcolor: "rgba(255,255,255,0.24)",
+                  borderRadius: 2,
+                  p: 1.5,
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  "&:hover": { bgcolor: "rgba(255,255,255,0.4)" },
+                }}
+              >
+                <Add sx={{ mr: 1 }} />
+                <Typography variant="body2">Add a list</Typography>
+              </Box>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      <DragOverlay>
+        {activeCard && (
+          <PlanningCard card={activeCard} labels={labels} canWrite={false} />
+        )}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/src/components/Planning/PlanningBudgetWidget.js
+++ b/src/components/Planning/PlanningBudgetWidget.js
@@ -1,0 +1,120 @@
+import { Box, LinearProgress, Stack, Tooltip, Typography } from "@mui/material";
+
+const BUCKETS = ["food", "prize", "swag"];
+const BUCKET_LABELS = { food: "Food", prize: "Prize", swag: "Swag" };
+
+function BucketBar({ bucket, goal, raised, earmarked, spent }) {
+  const max = Math.max(goal, earmarked, 1);
+  const raisedPct = Math.min((raised / max) * 100, 100);
+  const earmarkedPct = Math.min((earmarked / max) * 100, 100);
+  const spentPct = Math.min((spent / max) * 100, 100);
+
+  const overCommitted = earmarked > goal;
+  const color = raised >= earmarked ? "success" : overCommitted ? "error" : "warning";
+
+  const fmt = (cents) => `$${(cents / 100).toLocaleString()}`;
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 0.5 }}>
+        <Typography variant="body2" fontWeight={600}>
+          {BUCKET_LABELS[bucket]}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          Raised {fmt(raised)} · Plan {fmt(earmarked)} · Spent {fmt(spent)} · Goal {fmt(goal)}
+        </Typography>
+      </Stack>
+
+      <Tooltip title={`Raised: ${fmt(raised)} of ${fmt(goal)} goal`}>
+        <LinearProgress
+          variant="determinate"
+          value={raisedPct}
+          color={color}
+          sx={{ height: 8, borderRadius: 1, mb: 0.5 }}
+        />
+      </Tooltip>
+      <Tooltip title={`Earmarked (planned spend): ${fmt(earmarked)}`}>
+        <LinearProgress
+          variant="determinate"
+          value={earmarkedPct}
+          color="info"
+          sx={{ height: 5, borderRadius: 1, mb: 0.5, opacity: 0.7 }}
+        />
+      </Tooltip>
+      <Tooltip title={`Spent (paid): ${fmt(spent)}`}>
+        <LinearProgress
+          variant="determinate"
+          value={spentPct}
+          color="secondary"
+          sx={{ height: 5, borderRadius: 1, opacity: 0.5 }}
+        />
+      </Tooltip>
+    </Box>
+  );
+}
+
+/**
+ * PlanningBudgetWidget — shows Goal/Raised/Earmarked/Spent per bucket.
+ *
+ * Props:
+ *   cards: all planning cards (used to compute earmarked/spent sums)
+ *   donationGoals: hackathon.donation_goals (keyed by bucket)
+ *   donationCurrent: hackathon.donation_current (keyed by bucket)
+ */
+export default function PlanningBudgetWidget({ cards = [], donationGoals = {}, donationCurrent = {} }) {
+  function getGoalCents(bucket) {
+    const val = donationGoals[bucket];
+    if (!val) return 0;
+    // donation_goals values may be strings like "$5000" or numbers
+    return typeof val === "number" ? val * 100 : parseInt(String(val).replace(/\D/g, "")) * 100 || 0;
+  }
+
+  function getRaisedCents(bucket) {
+    const val = donationCurrent[bucket];
+    if (!val) return 0;
+    return typeof val === "number" ? val * 100 : parseInt(String(val).replace(/\D/g, "")) * 100 || 0;
+  }
+
+  function sumBudget(bucket, states = null) {
+    return cards
+      .filter((c) => {
+        const b = c.budget;
+        if (!b || b.bucket !== bucket) return false;
+        if (states && !states.includes(b.state)) return false;
+        return true;
+      })
+      .reduce((sum, c) => sum + (c.budget.amount_cents || 0), 0);
+  }
+
+  return (
+    <Box>
+      <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+        Budget overview
+      </Typography>
+      {BUCKETS.map((bucket) => (
+        <BucketBar
+          key={bucket}
+          bucket={bucket}
+          goal={getGoalCents(bucket)}
+          raised={getRaisedCents(bucket)}
+          earmarked={sumBudget(bucket)}
+          spent={sumBudget(bucket, ["paid"])}
+        />
+      ))}
+      <Stack direction="row" spacing={2}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Box sx={{ width: 12, height: 8, borderRadius: 1, bgcolor: "success.main" }} />
+          <Typography variant="caption">Raised</Typography>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Box sx={{ width: 12, height: 8, borderRadius: 1, bgcolor: "info.main", opacity: 0.7 }} />
+          <Typography variant="caption">Earmarked (plan)</Typography>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Box sx={{ width: 12, height: 8, borderRadius: 1, bgcolor: "secondary.main", opacity: 0.5 }} />
+          <Typography variant="caption">Spent</Typography>
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/Planning/PlanningCard.js
+++ b/src/components/Planning/PlanningCard.js
@@ -1,0 +1,140 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  AttachFile,
+  CalendarToday,
+  CheckBox,
+  Comment,
+} from "@mui/icons-material";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+function DueDateChip({ dueDate }) {
+  if (!dueDate) return null;
+  const due = new Date(dueDate);
+  const now = new Date();
+  const overdue = due < now;
+  return (
+    <Chip
+      icon={<CalendarToday />}
+      label={due.toLocaleDateString()}
+      size="small"
+      color={overdue ? "error" : "default"}
+      sx={{ fontSize: "0.7rem" }}
+    />
+  );
+}
+
+function BudgetChip({ budget }) {
+  if (!budget) return null;
+  const amount = (budget.amount_cents / 100).toFixed(0);
+  const color = budget.state === "paid" ? "success" : budget.state === "committed" ? "warning" : "default";
+  return (
+    <Chip
+      label={`$${amount} · ${budget.bucket} · ${budget.state}`}
+      size="small"
+      color={color}
+      sx={{ fontSize: "0.7rem" }}
+    />
+  );
+}
+
+export default function PlanningCard({ card, labels = [], canWrite, onClick }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: card.id, disabled: !canWrite });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const cardLabels = (card.labels || [])
+    .map((lid) => labels.find((l) => l.id === lid))
+    .filter(Boolean);
+
+  const checklistTotal = (card.checklists || []).reduce(
+    (sum, cl) => sum + (cl.items || []).length,
+    0
+  );
+  const checklistDone = (card.checklists || []).reduce(
+    (sum, cl) => sum + (cl.items || []).filter((i) => i.done).length,
+    0
+  );
+
+  return (
+    <Box ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <Card
+        variant="outlined"
+        onClick={() => onClick && onClick(card)}
+        sx={{
+          mb: 1,
+          cursor: canWrite ? "grab" : "pointer",
+          "&:hover": { boxShadow: 2 },
+        }}
+      >
+        {cardLabels.length > 0 && (
+          <Box sx={{ display: "flex", gap: 0.5, p: 0.5, flexWrap: "wrap" }}>
+            {cardLabels.map((label) => (
+              <Box
+                key={label.id}
+                sx={{
+                  width: 32,
+                  height: 8,
+                  borderRadius: 1,
+                  bgcolor: label.color,
+                }}
+              />
+            ))}
+          </Box>
+        )}
+        <CardContent sx={{ py: 1, "&:last-child": { pb: 1 } }}>
+          <Typography variant="body2" sx={{ mb: 1, wordBreak: "break-word" }}>
+            {card.title}
+          </Typography>
+
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+            <DueDateChip dueDate={card.due_date} />
+            <BudgetChip budget={card.budget} />
+
+            {checklistTotal > 0 && (
+              <Chip
+                icon={<CheckBox />}
+                label={`${checklistDone}/${checklistTotal}`}
+                size="small"
+                color={checklistDone === checklistTotal ? "success" : "default"}
+                sx={{ fontSize: "0.7rem" }}
+              />
+            )}
+
+            {card.comment_count > 0 && (
+              <Chip
+                icon={<Comment />}
+                label={card.comment_count}
+                size="small"
+                sx={{ fontSize: "0.7rem" }}
+              />
+            )}
+
+            {(card.attachments || []).length > 0 && (
+              <Chip
+                icon={<AttachFile />}
+                label={(card.attachments || []).length}
+                size="small"
+                sx={{ fontSize: "0.7rem" }}
+              />
+            )}
+          </Stack>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/src/components/Planning/PlanningCardConflictDialog.js
+++ b/src/components/Planning/PlanningCardConflictDialog.js
@@ -1,0 +1,157 @@
+/**
+ * 412 conflict resolution dialog.
+ *
+ * Shows three options when a card PATCH returns 412 (another editor changed the same field):
+ *   Mine    — force-save the user's version (PATCH with force=1)
+ *   Theirs  — discard local draft, reload server state
+ *   Side-by-side — display both values so the user can manually merge
+ *
+ * localStorage draft preservation: if the user closes without choosing,
+ * their draft is preserved at localStorage key "plan_draft:{card_id}:{field}".
+ */
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Grid,
+  Typography,
+} from "@mui/material";
+
+const DRAFT_KEY = (cardId, field) => `plan_draft:${cardId}:${field}`;
+
+export function saveDraftToStorage(cardId, field, value) {
+  try {
+    localStorage.setItem(DRAFT_KEY(cardId, field), JSON.stringify(value));
+  } catch {}
+}
+
+export function loadDraftFromStorage(cardId, field) {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY(cardId, field));
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDraftFromStorage(cardId, field) {
+  try {
+    localStorage.removeItem(DRAFT_KEY(cardId, field));
+  } catch {}
+}
+
+/**
+ * Props:
+ *   cardId       — string
+ *   field        — which field conflicted (e.g. "description")
+ *   myValue      — the value the user typed
+ *   theirValue   — the current server value
+ *   onMine       — async fn(value) → call force-PATCH, return result
+ *   onTheirs     — fn() → discard local, reload
+ *   onClose      — fn() → close without deciding (draft is preserved)
+ */
+export default function PlanningCardConflictDialog({
+  cardId,
+  field,
+  myValue,
+  theirValue,
+  onMine,
+  onTheirs,
+  onClose,
+}) {
+  const [view, setView] = useState("choose"); // "choose" | "sidebyside"
+  const [loading, setLoading] = useState(false);
+
+  // Persist draft on mount so closing without choosing doesn't lose work
+  useEffect(() => {
+    saveDraftToStorage(cardId, field, myValue);
+  }, [cardId, field, myValue]);
+
+  async function handleMine() {
+    setLoading(true);
+    await onMine(myValue);
+    clearDraftFromStorage(cardId, field);
+    setLoading(false);
+    onClose();
+  }
+
+  function handleTheirs() {
+    clearDraftFromStorage(cardId, field);
+    onTheirs();
+    onClose();
+  }
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Editing conflict</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Another editor changed <strong>{field}</strong> while you were editing.
+          Choose how to resolve:
+        </Typography>
+
+        {view === "sidebyside" ? (
+          <Grid container spacing={2}>
+            <Grid item xs={6}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>Your version</Typography>
+              <Box
+                sx={{
+                  p: 1,
+                  bgcolor: "warning.50",
+                  border: "1px solid",
+                  borderColor: "warning.300",
+                  borderRadius: 1,
+                  minHeight: 100,
+                  whiteSpace: "pre-wrap",
+                  fontSize: "0.875rem",
+                }}
+              >
+                {String(myValue ?? "")}
+              </Box>
+            </Grid>
+            <Grid item xs={6}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>Their version (server)</Typography>
+              <Box
+                sx={{
+                  p: 1,
+                  bgcolor: "info.50",
+                  border: "1px solid",
+                  borderColor: "info.300",
+                  borderRadius: 1,
+                  minHeight: 100,
+                  whiteSpace: "pre-wrap",
+                  fontSize: "0.875rem",
+                }}
+              >
+                {String(theirValue ?? "")}
+              </Box>
+            </Grid>
+          </Grid>
+        ) : (
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            Your draft is preserved. Click <strong>Mine</strong> to overwrite,{" "}
+            <strong>Theirs</strong> to discard your changes, or{" "}
+            <strong>Side-by-side</strong> to compare both versions.
+          </Typography>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={() => setView("sidebyside")} disabled={view === "sidebyside"}>
+          Side-by-side
+        </Button>
+        <Button onClick={handleTheirs} color="secondary">
+          Use theirs
+        </Button>
+        <Button onClick={handleMine} variant="contained" disabled={loading}>
+          {loading ? "Saving…" : "Use mine"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/Planning/PlanningCardDialog.js
+++ b/src/components/Planning/PlanningCardDialog.js
@@ -1,0 +1,414 @@
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  IconButton,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Archive, AttachFile, Close, Delete } from "@mui/icons-material";
+import ReactMarkdown from "react-markdown";
+import PlanningPublicNotice from "./PlanningPublicNotice";
+import PlanningCardKindRenderer from "./PlanningCardKindRenderer";
+
+const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // 10 MB
+
+const ALLOWED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
+
+function slugifyFilename(name) {
+  const ext = name.split(".").pop().toLowerCase();
+  const base = name
+    .slice(0, name.lastIndexOf("."))
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 60);
+  return `${base}.${ext}`;
+}
+
+export default function PlanningCardDialog({
+  card: initialCard,
+  comments: initialComments = [],
+  labels = [],
+  canWrite,
+  canComment,
+  eventId,
+  onClose,
+  onUpdate,
+  onArchive,
+  onCreateComment,
+  onDeleteComment,
+  onCreateLabel,
+}) {
+  const [card, setCard] = useState(initialCard);
+  const [comments, setComments] = useState(initialComments);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [title, setTitle] = useState(initialCard.title);
+  const [description, setDescription] = useState(initialCard.description || "");
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [commentBody, setCommentBody] = useState("");
+  const [submittingComment, setSubmittingComment] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState("");
+
+  // Sync updates back
+  useEffect(() => { setCard(initialCard); }, [initialCard]);
+  useEffect(() => { setComments(initialComments); }, [initialComments]);
+
+  async function saveTitle() {
+    const t = title.trim();
+    if (t && t !== card.title) {
+      const result = await onUpdate({ title: t });
+      if (result?.conflict) {
+        alert("Another editor updated this card. Please reload.");
+      }
+    }
+    setEditingTitle(false);
+  }
+
+  async function saveDescription() {
+    if (description !== card.description) {
+      await onUpdate({ description });
+    }
+    setEditingDesc(false);
+  }
+
+  async function handleChecklistToggle(clIdx, itemIdx, done) {
+    const updated = card.checklists.map((cl, ci) =>
+      ci !== clIdx
+        ? cl
+        : {
+            ...cl,
+            items: cl.items.map((it, ii) =>
+              ii !== itemIdx ? it : { ...it, done }
+            ),
+          }
+    );
+    await onUpdate({ checklists: updated });
+    setCard((prev) => ({ ...prev, checklists: updated }));
+  }
+
+  async function handleCommentSubmit() {
+    if (!commentBody.trim()) return;
+    setSubmittingComment(true);
+    const result = await onCreateComment(commentBody.trim());
+    if (result?.ok) {
+      setComments((prev) => [...prev, result.data]);
+      setCommentBody("");
+    }
+    setSubmittingComment(false);
+  }
+
+  async function handleFileUpload(file) {
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      setUploadError("Only PNG, JPG, WebP, and GIF images are supported in v1.");
+      return;
+    }
+    if (file.size > MAX_ATTACHMENT_BYTES) {
+      setUploadError("File too large (max 10 MB).");
+      return;
+    }
+    if ((card.attachments || []).length >= 20) {
+      setUploadError("Maximum 20 attachments per card.");
+      return;
+    }
+
+    setUploading(true);
+    setUploadError("");
+    const form = new FormData();
+    form.append("file", file);
+    form.append("directory", `hackathons/${eventId}/planning/cards/${card.id}`);
+    form.append("filename", slugifyFilename(file.name));
+
+    try {
+      const res = await fetch(`${API}/api/messages/upload-image`, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) throw new Error("Upload failed");
+      const { url } = await res.json();
+      const newAttachment = {
+        id: crypto.randomUUID(),
+        url,
+        name: file.name,
+        size: file.size,
+        content_type: file.type,
+        uploaded_at: new Date().toISOString(),
+      };
+      const updatedAttachments = [...(card.attachments || []), newAttachment];
+      await onUpdate({ attachments: updatedAttachments });
+      setCard((prev) => ({ ...prev, attachments: updatedAttachments }));
+    } catch (e) {
+      setUploadError(e.message);
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  const cardLabels = (card.labels || [])
+    .map((lid) => labels.find((l) => l.id === lid))
+    .filter(Boolean);
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="md" fullWidth scroll="paper">
+      <DialogTitle sx={{ pr: 6 }}>
+        {editingTitle && canWrite ? (
+          <TextField
+            autoFocus
+            fullWidth
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onBlur={saveTitle}
+            onKeyDown={(e) => { if (e.key === "Enter") saveTitle(); }}
+            size="small"
+          />
+        ) : (
+          <Typography
+            variant="h6"
+            onClick={() => canWrite && setEditingTitle(true)}
+            sx={{ cursor: canWrite ? "pointer" : "default" }}
+          >
+            {card.title}
+          </Typography>
+        )}
+        {cardLabels.map((l) => (
+          <Chip
+            key={l.id}
+            label={l.name}
+            size="small"
+            sx={{ bgcolor: l.color, ml: 0.5 }}
+          />
+        ))}
+        <IconButton onClick={onClose} size="small" sx={{ position: "absolute", top: 8, right: 8 }}>
+          <Close />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <PlanningPublicNotice />
+
+        {/* Live data strip for non-freetext kinds */}
+        {card.kind && card.kind !== "freetext" && (
+          <Box sx={{ mb: 2 }}>
+            <PlanningCardKindRenderer card={card} eventId={eventId} />
+          </Box>
+        )}
+
+        {/* Description */}
+        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>
+          Description
+        </Typography>
+        {editingDesc && canWrite ? (
+          <TextField
+            autoFocus
+            fullWidth
+            multiline
+            minRows={4}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            onBlur={saveDescription}
+            sx={{ mb: 2 }}
+          />
+        ) : (
+          <Box
+            onClick={() => canWrite && setEditingDesc(true)}
+            sx={{
+              mb: 2,
+              p: 1,
+              borderRadius: 1,
+              minHeight: 60,
+              cursor: canWrite ? "pointer" : "default",
+              bgcolor: "grey.50",
+              "&:hover": canWrite ? { bgcolor: "grey.100" } : {},
+            }}
+          >
+            {card.description ? (
+              <ReactMarkdown>{card.description}</ReactMarkdown>
+            ) : (
+              <Typography color="text.secondary" variant="body2">
+                {canWrite ? "Click to add a description…" : "No description."}
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        {/* Checklists */}
+        {(card.checklists || []).map((cl, clIdx) => (
+          <Box key={cl.id || clIdx} sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+              ☑ {cl.title}
+              <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                {cl.items.filter((i) => i.done).length}/{cl.items.length}
+              </Typography>
+            </Typography>
+            <LinearProgress
+              variant="determinate"
+              value={cl.items.length > 0 ? (cl.items.filter((i) => i.done).length / cl.items.length) * 100 : 0}
+              sx={{ mb: 1, borderRadius: 1 }}
+            />
+            {cl.items.map((item, itemIdx) => (
+              <FormControlLabel
+                key={item.id || itemIdx}
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={!!item.done}
+                    disabled={!canWrite}
+                    onChange={(e) => handleChecklistToggle(clIdx, itemIdx, e.target.checked)}
+                  />
+                }
+                label={item.text}
+                sx={{ display: "block" }}
+              />
+            ))}
+          </Box>
+        ))}
+
+        {/* Budget */}
+        {card.budget && (
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>
+              Budget
+            </Typography>
+            <Chip
+              label={`$${(card.budget.amount_cents / 100).toFixed(0)} · ${card.budget.bucket} · ${card.budget.state}`}
+              size="small"
+              color={card.budget.state === "paid" ? "success" : card.budget.state === "committed" ? "warning" : "default"}
+            />
+            {card.budget.vendor && (
+              <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                {card.budget.vendor}
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        {/* Attachments */}
+        <Divider sx={{ my: 2 }} />
+        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>
+          Attachments ({(card.attachments || []).length})
+        </Typography>
+        {(card.attachments || []).map((att) => (
+          <Box key={att.id} sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+            <AttachFile fontSize="small" />
+            <a href={att.url} target="_blank" rel="noopener noreferrer">
+              {att.name}
+            </a>
+            <Typography variant="caption" color="text.secondary">
+              ({Math.round(att.size / 1024)} KB)
+            </Typography>
+          </Box>
+        ))}
+        {canWrite && (
+          <Box sx={{ mt: 1 }}>
+            <PlanningPublicNotice />
+            {uploadError && <Alert severity="error" sx={{ mb: 1 }}>{uploadError}</Alert>}
+            <Button
+              variant="outlined"
+              size="small"
+              component="label"
+              startIcon={<AttachFile />}
+              disabled={uploading}
+            >
+              {uploading ? "Uploading…" : "Attach image"}
+              <input
+                type="file"
+                hidden
+                accept="image/png,image/jpeg,image/webp,image/gif"
+                onChange={(e) => e.target.files?.[0] && handleFileUpload(e.target.files[0])}
+              />
+            </Button>
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+              PNG, JPG, WebP, GIF only (v1). Max 10 MB.
+            </Typography>
+          </Box>
+        )}
+
+        {/* Comments */}
+        <Divider sx={{ my: 2 }} />
+        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+          Comments ({comments.length})
+        </Typography>
+        {comments.filter((c) => !c.deleted_at && c.body !== "[deleted]").map((c) => (
+          <Box
+            key={c.id}
+            sx={{ mb: 1, pl: 1, borderLeft: "2px solid", borderColor: "divider" }}
+          >
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Typography variant="caption" color="text.secondary">
+                {(c.author?.name || c.author?.user_id || "Someone").trim()} ·{" "}
+                {new Date(c.created_at).toLocaleString()}
+              </Typography>
+              {canWrite && (
+                <Tooltip title="Delete comment">
+                  <IconButton size="small" onClick={() => onDeleteComment(c.id)}>
+                    <Delete fontSize="inherit" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Stack>
+            <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+              {c.body}
+            </Typography>
+          </Box>
+        ))}
+        {canComment && (
+          <Box sx={{ mt: 1 }}>
+            <PlanningPublicNotice collapsible />
+            <Stack direction="row" spacing={1} alignItems="flex-end">
+              <TextField
+                fullWidth
+                multiline
+                minRows={2}
+                placeholder="Add a comment…"
+                value={commentBody}
+                onChange={(e) => setCommentBody(e.target.value)}
+                size="small"
+              />
+              <Button
+                variant="contained"
+                size="small"
+                onClick={handleCommentSubmit}
+                disabled={submittingComment || !commentBody.trim()}
+              >
+                Post
+              </Button>
+            </Stack>
+          </Box>
+        )}
+
+        {/* Archive */}
+        {canWrite && (
+          <>
+            <Divider sx={{ my: 2 }} />
+            <Button
+              startIcon={<Archive />}
+              color="error"
+              size="small"
+              onClick={onArchive}
+            >
+              Archive card
+            </Button>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/Planning/PlanningCardKindRenderer.js
+++ b/src/components/Planning/PlanningCardKindRenderer.js
@@ -1,0 +1,27 @@
+import dynamic from "next/dynamic";
+
+const JudgesStat = dynamic(() => import("./JudgesStat"), { ssr: false });
+const MentorsStat = dynamic(() => import("./MentorsStat"), { ssr: false });
+const HackersStat = dynamic(() => import("./HackersStat"), { ssr: false });
+const NonprofitsStat = dynamic(() => import("./NonprofitsStat"), { ssr: false });
+const TeamsStat = dynamic(() => import("./TeamsStat"), { ssr: false });
+
+export default function PlanningCardKindRenderer({ card, eventId }) {
+  const { kind, target_count: targetCount } = card;
+  const props = { eventId, targetCount };
+
+  switch (kind) {
+    case "judges":
+      return <JudgesStat {...props} />;
+    case "mentors":
+      return <MentorsStat {...props} />;
+    case "hackers":
+      return <HackersStat {...props} />;
+    case "nonprofits":
+      return <NonprofitsStat {...props} />;
+    case "teams":
+      return <TeamsStat eventId={eventId} />;
+    default:
+      return null;
+  }
+}

--- a/src/components/Planning/PlanningEditorsManager.js
+++ b/src/components/Planning/PlanningEditorsManager.js
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Delete, PersonAdd } from "@mui/icons-material";
+
+export default function PlanningEditorsManager({ editors = [], onUpdateEditors }) {
+  const [newEditorId, setNewEditorId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleAdd() {
+    const id = newEditorId.trim();
+    if (!id) return;
+    setLoading(true);
+    setError("");
+    const result = await onUpdateEditors([id], []);
+    if (result?.ok) {
+      setNewEditorId("");
+    } else {
+      setError(result?.error || "Failed to add editor");
+    }
+    setLoading(false);
+  }
+
+  async function handleRemove(userId) {
+    setLoading(true);
+    await onUpdateEditors([], [userId]);
+    setLoading(false);
+  }
+
+  return (
+    <Box>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        Board editors
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        Editors can create, edit, and move cards. Admins always have full access.
+      </Typography>
+
+      <Stack spacing={1} sx={{ mb: 2 }}>
+        {editors.length === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            No editors yet.
+          </Typography>
+        )}
+        {editors.map((userId) => (
+          <Stack key={userId} direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="body2" sx={{ fontFamily: "monospace", fontSize: "0.75rem" }}>
+              {userId}
+            </Typography>
+            <IconButton size="small" onClick={() => handleRemove(userId)} disabled={loading}>
+              <Delete fontSize="small" />
+            </IconButton>
+          </Stack>
+        ))}
+      </Stack>
+
+      <Stack direction="row" spacing={1}>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder="PropelAuth user ID"
+          value={newEditorId}
+          onChange={(e) => setNewEditorId(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+        />
+        <Button
+          startIcon={loading ? <CircularProgress size={14} /> : <PersonAdd />}
+          variant="outlined"
+          onClick={handleAdd}
+          disabled={loading || !newEditorId.trim()}
+          size="small"
+        >
+          Add
+        </Button>
+      </Stack>
+      {error && (
+        <Typography color="error" variant="caption" sx={{ mt: 0.5 }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/src/components/Planning/PlanningList.js
+++ b/src/components/Planning/PlanningList.js
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import {
+  Box,
+  IconButton,
+  InputBase,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Add, Close } from "@mui/icons-material";
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import PlanningCard from "./PlanningCard";
+
+export default function PlanningList({
+  list,
+  cards = [],
+  labels = [],
+  canWrite,
+  onCardClick,
+  onCreateCard,
+}) {
+  const [addingCard, setAddingCard] = useState(false);
+  const [newCardTitle, setNewCardTitle] = useState("");
+
+  const { setNodeRef, isOver } = useDroppable({ id: list.id });
+
+  const handleAddCard = async () => {
+    const title = newCardTitle.trim();
+    if (!title) return;
+    await onCreateCard(list.id, title);
+    setNewCardTitle("");
+    setAddingCard(false);
+  };
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        bgcolor: "grey.100",
+        borderRadius: 2,
+        p: 1,
+        minWidth: 272,
+        maxWidth: 272,
+        display: "flex",
+        flexDirection: "column",
+        maxHeight: "calc(100vh - 200px)",
+        outline: isOver ? "2px solid" : "none",
+        outlineColor: "primary.main",
+      }}
+    >
+      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, px: 0.5 }}>
+        {list.title}
+        <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+          {cards.length}
+        </Typography>
+      </Typography>
+
+      <Box ref={setNodeRef} sx={{ flex: 1, overflowY: "auto", pb: 1 }}>
+        <SortableContext
+          items={cards.map((c) => c.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {cards.map((card) => (
+            <PlanningCard
+              key={card.id}
+              card={card}
+              labels={labels}
+              canWrite={canWrite}
+              onClick={onCardClick}
+            />
+          ))}
+        </SortableContext>
+      </Box>
+
+      {canWrite && (
+        <>
+          {addingCard ? (
+            <Box>
+              <InputBase
+                autoFocus
+                multiline
+                fullWidth
+                placeholder="Card title…"
+                value={newCardTitle}
+                onChange={(e) => setNewCardTitle(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleAddCard();
+                  }
+                  if (e.key === "Escape") setAddingCard(false);
+                }}
+                sx={{
+                  bgcolor: "white",
+                  borderRadius: 1,
+                  p: 1,
+                  mb: 0.5,
+                  border: "1px solid",
+                  borderColor: "primary.main",
+                  fontSize: "0.875rem",
+                }}
+              />
+              <Stack direction="row" spacing={1}>
+                <IconButton size="small" onClick={handleAddCard} color="primary">
+                  <Add />
+                </IconButton>
+                <IconButton size="small" onClick={() => setAddingCard(false)}>
+                  <Close />
+                </IconButton>
+              </Stack>
+            </Box>
+          ) : (
+            <Box
+              onClick={() => setAddingCard(true)}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                cursor: "pointer",
+                color: "text.secondary",
+                "&:hover": { color: "text.primary" },
+                p: 0.5,
+                borderRadius: 1,
+              }}
+            >
+              <Add fontSize="small" sx={{ mr: 0.5 }} />
+              <Typography variant="caption">Add a card</Typography>
+            </Box>
+          )}
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/src/components/Planning/PlanningPublicNotice.js
+++ b/src/components/Planning/PlanningPublicNotice.js
@@ -1,0 +1,12 @@
+import { Alert, AlertTitle } from "@mui/material";
+
+export default function PlanningPublicNotice({ collapsible = false }) {
+  return (
+    <Alert severity="info" sx={{ mb: 2 }}>
+      <AlertTitle>This planning board is public</AlertTitle>
+      Anything you upload, comment, or write here will be visible to everyone on ohack.dev —
+      including search engines. Don&apos;t share confidential nonprofit details, personal contact
+      info, or unreleased budget figures.
+    </Alert>
+  );
+}

--- a/src/components/Planning/PlanningRunOfShowSyncDialog.js
+++ b/src/components/Planning/PlanningRunOfShowSyncDialog.js
@@ -1,0 +1,143 @@
+/**
+ * Confirm dialog for syncing Run of Show cards to hackathon.countdowns.
+ *
+ * Shows a diff preview (incoming planning entries vs preserved manual entries)
+ * and requires explicit user confirmation before calling /run-of-show/sync.
+ */
+import React from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Check, Lock, Schedule } from "@mui/icons-material";
+
+function CountdownRow({ entry, source }) {
+  return (
+    <Stack direction="row" alignItems="center" spacing={1} sx={{ py: 0.5 }}>
+      {source === "planning" ? (
+        <Schedule fontSize="small" color="primary" />
+      ) : (
+        <Lock fontSize="small" color="action" />
+      )}
+      <Typography variant="body2" sx={{ fontWeight: 500, minWidth: 80 }}>
+        {entry.time ? new Date(entry.time).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "—"}
+      </Typography>
+      <Typography variant="body2">{entry.name}</Typography>
+      {source !== "planning" && (
+        <Chip label="preserved" size="small" variant="outlined" sx={{ ml: "auto" }} />
+      )}
+    </Stack>
+  );
+}
+
+export default function PlanningRunOfShowSyncDialog({
+  eventId,
+  accessToken,
+  orgId,
+  diff,
+  onSynced,
+  onClose,
+}) {
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState("");
+
+  async function handleSync() {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/planning/${eventId}/run-of-show/sync`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            "content-type": "application/json",
+            "X-Org-Id": orgId,
+          },
+        }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const result = await res.json();
+      onSynced(result);
+      onClose();
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const incoming = diff?.incoming || [];
+  const preserved = diff?.preserved || [];
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Sync Run of Show to public timeline</DialogTitle>
+      <DialogContent>
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          This will replace{" "}
+          <strong>{diff?.current_planning_count ?? "?"} existing planning entries</strong> with{" "}
+          <strong>{incoming.length} entries from the board</strong>. Manual entries are preserved.
+        </Typography>
+
+        {incoming.length > 0 && (
+          <>
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+              From board ({incoming.length})
+            </Typography>
+            <Box sx={{ bgcolor: "primary.50", borderRadius: 1, p: 1, mb: 2 }}>
+              {incoming.map((e, i) => (
+                <CountdownRow key={i} entry={e} source="planning" />
+              ))}
+            </Box>
+          </>
+        )}
+
+        {preserved.length > 0 && (
+          <>
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+              Preserved manual entries ({preserved.length})
+            </Typography>
+            <Box sx={{ bgcolor: "grey.100", borderRadius: 1, p: 1, mb: 2 }}>
+              {preserved.map((e, i) => (
+                <CountdownRow key={i} entry={e} source="manual" />
+              ))}
+            </Box>
+          </>
+        )}
+
+        {incoming.length === 0 && (
+          <Alert severity="warning">
+            No Run of Show cards with sync_to_countdowns enabled. Mark cards in a Run of Show list
+            and set sync_to_countdowns = true before syncing.
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSync}
+          variant="contained"
+          disabled={loading || incoming.length === 0}
+          startIcon={loading ? <CircularProgress size={14} /> : <Check />}
+        >
+          Confirm sync
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+

--- a/src/components/Planning/PlanningSlackSettings.js
+++ b/src/components/Planning/PlanningSlackSettings.js
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Send } from "@mui/icons-material";
+
+export default function PlanningSlackSettings({ planning = {}, onUpdateConfig, onSlackNotify }) {
+  const slack = planning.slack || {};
+  const [channel, setChannel] = useState((slack.channel || "").replace(/^#/, ""));
+  const [notify, setNotify] = useState(!!slack.notify_on_card_change);
+  const [saving, setSaving] = useState(false);
+  const [sending, setSending] = useState(false);
+
+  async function handleSave() {
+    setSaving(true);
+    await onUpdateConfig({
+      slack: { channel: channel.replace(/^#/, ""), notify_on_card_change: notify },
+    });
+    setSaving(false);
+  }
+
+  async function handleSendNow() {
+    setSending(true);
+    await onSlackNotify();
+    setSending(false);
+  }
+
+  return (
+    <Box>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        Slack integration
+      </Typography>
+
+      <Stack spacing={2}>
+        <TextField
+          label="Slack channel (no #)"
+          size="small"
+          value={channel}
+          onChange={(e) => setChannel(e.target.value.replace(/^#/, ""))}
+          placeholder="2026-fall-plan"
+          helperText="Members can join via the 'Join Slack' button on the planning board."
+        />
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={notify}
+              onChange={(e) => setNotify(e.target.checked)}
+            />
+          }
+          label="Send card-change digests to this channel"
+        />
+
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleSave}
+            disabled={saving}
+            startIcon={saving ? <CircularProgress size={14} /> : null}
+          >
+            Save Slack settings
+          </Button>
+
+          {slack.channel && (
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={handleSendNow}
+              disabled={sending}
+              startIcon={sending ? <CircularProgress size={14} /> : <Send />}
+            >
+              Send digest now
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/Planning/PlanningSponsorPipelineView.js
+++ b/src/components/Planning/PlanningSponsorPipelineView.js
@@ -1,0 +1,85 @@
+import { Box, Chip, Paper, Stack, Typography } from "@mui/material";
+
+const STATUSES = ["prospect", "contacted", "in-discussion", "committed", "declined", "no-response"];
+const STATUS_COLORS = {
+  prospect: "default",
+  contacted: "primary",
+  "in-discussion": "warning",
+  committed: "success",
+  declined: "error",
+  "no-response": "default",
+};
+
+function fmt(cents) {
+  return cents > 0 ? `$${(cents / 100).toLocaleString()}` : null;
+}
+
+export default function PlanningSponsorPipelineView({ cards = [], onCardClick }) {
+  const sponsorCards = cards.filter((c) => c.kind === "sponsor_prospect" && !c.archived);
+
+  function byStatus(status) {
+    return sponsorCards.filter((c) => c.sponsor?.outreach_status === status);
+  }
+
+  return (
+    <Box sx={{ display: "flex", gap: 2, overflowX: "auto", pb: 2 }}>
+      {STATUSES.map((status) => {
+        const group = byStatus(status);
+        const totalPledge = group.reduce(
+          (sum, c) => sum + (c.sponsor?.pledge_amount_cents || 0),
+          0
+        );
+        return (
+          <Paper
+            key={status}
+            elevation={0}
+            sx={{ bgcolor: "grey.100", borderRadius: 2, p: 1, minWidth: 200 }}
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+              {status.charAt(0).toUpperCase() + status.slice(1).replace("-", " ")}
+              <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                ({group.length})
+              </Typography>
+            </Typography>
+            {totalPledge > 0 && (
+              <Typography variant="caption" color="success.main">
+                {fmt(totalPledge)} pledged
+              </Typography>
+            )}
+            <Stack spacing={1} sx={{ mt: 1 }}>
+              {group.map((card) => (
+                <Paper
+                  key={card.id}
+                  variant="outlined"
+                  sx={{ p: 1, cursor: "pointer", "&:hover": { boxShadow: 1 } }}
+                  onClick={() => onCardClick && onCardClick(card)}
+                >
+                  <Typography variant="body2" fontWeight={500}>
+                    {card.sponsor?.company || card.title}
+                  </Typography>
+                  {card.sponsor?.tier && (
+                    <Chip
+                      label={card.sponsor.tier}
+                      size="small"
+                      sx={{ mt: 0.5 }}
+                    />
+                  )}
+                  {card.sponsor?.pledge_amount_cents > 0 && (
+                    <Typography variant="caption" color="text.secondary" display="block">
+                      {fmt(card.sponsor.pledge_amount_cents)}
+                    </Typography>
+                  )}
+                  {card.sponsor?.next_action && (
+                    <Typography variant="caption" color="text.secondary" display="block">
+                      → {card.sponsor.next_action}
+                    </Typography>
+                  )}
+                </Paper>
+              ))}
+            </Stack>
+          </Paper>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/components/Planning/TeamsStat.js
+++ b/src/components/Planning/TeamsStat.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { Box, Chip, CircularProgress, Link } from "@mui/material";
+import NextLink from "next/link";
+
+const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+export default function TeamsStat({ eventId }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!eventId) return;
+    fetch(`${API}/api/messages/hackathon/${eventId}`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((d) => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [eventId]);
+
+  if (loading) return <CircularProgress size={14} />;
+
+  const count = data?.teams?.length ?? 0;
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
+      <Chip label={`Teams formed: ${count}`} size="small" color={count > 0 ? "success" : "default"} />
+      <Link component={NextLink} href="/admin/hackathons" fontSize="small">
+        Open in admin ↗
+      </Link>
+    </Box>
+  );
+}

--- a/src/components/admin/HackathonDuplicator.js
+++ b/src/components/admin/HackathonDuplicator.js
@@ -44,6 +44,15 @@ const HackathonDuplicator = ({
         swag: "0",
         thank_you: "",
       },
+      // Planning board: subcollections are not copied to the duplicate.
+      // Reset to defaults so the new event starts disabled with no orphaned editors / Slack settings.
+      planning: {
+        enabled: false,
+        editors: [],
+        slack: { channel: "", notify_on_card_change: false },
+        template_seeded: false,
+        budget_widget_on_event_page: false,
+      },
     };
 
     setNewHackathon(duplicatedHackathon);

--- a/src/hooks/use-planning-board.js
+++ b/src/hooks/use-planning-board.js
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuthInfo } from "@propelauth/react";
+
+const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+const HOT_INTERVAL = 6000;
+const COLD_INTERVAL = 30000;
+const HOT_WINDOW_MS = 60000;
+
+function buildHeaders(accessToken, orgId) {
+  const h = { "content-type": "application/json" };
+  if (accessToken) h["authorization"] = `Bearer ${accessToken}`;
+  if (orgId) h["X-Org-Id"] = orgId;
+  return h;
+}
+
+export function usePlanningBoard(eventId) {
+  const { accessToken, orgHelper, user } = useAuthInfo();
+  const orgId = orgHelper?.getOrgs()?.[0]?.orgId;
+
+  const [board, setBoard] = useState(null); // { lists, cards, labels, planning }
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const etagRef = useRef(null);
+  const lastMutationRef = useRef(null);
+  const pollRef = useRef(null);
+
+  const isHot = useCallback(() => {
+    return lastMutationRef.current && Date.now() - lastMutationRef.current < HOT_WINDOW_MS;
+  }, []);
+
+  const fetchBoard = useCallback(async () => {
+    if (!eventId) return;
+    try {
+      const headers = {};
+      if (etagRef.current) headers["If-None-Match"] = etagRef.current;
+
+      const res = await fetch(`${API}/api/planning/${eventId}`, { headers });
+      if (res.status === 304) return; // no change
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const etag = res.headers.get("ETag");
+      if (etag) etagRef.current = etag;
+
+      const data = await res.json();
+      setBoard(data);
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  // Initial fetch + adaptive polling
+  useEffect(() => {
+    if (!eventId) return;
+    fetchBoard();
+
+    const tick = () => {
+      if (document.visibilityState !== "visible") return;
+      fetchBoard();
+    };
+
+    const schedule = () => {
+      clearInterval(pollRef.current);
+      pollRef.current = setInterval(tick, isHot() ? HOT_INTERVAL : COLD_INTERVAL);
+    };
+
+    schedule();
+    const visibilityHandler = () => {
+      if (document.visibilityState === "visible") {
+        fetchBoard();
+        schedule();
+      }
+    };
+    document.addEventListener("visibilitychange", visibilityHandler);
+
+    return () => {
+      clearInterval(pollRef.current);
+      document.removeEventListener("visibilitychange", visibilityHandler);
+    };
+  }, [eventId, fetchBoard, isHot]);
+
+  // ---------- mutation helpers ----------
+
+  function markMutated() {
+    lastMutationRef.current = Date.now();
+    clearInterval(pollRef.current);
+    pollRef.current = setInterval(fetchBoard, HOT_INTERVAL);
+  }
+
+  async function mutate(method, path, body, optimisticFn) {
+    // Optimistic update
+    const prev = board;
+    if (optimisticFn) setBoard((b) => optimisticFn(b));
+
+    try {
+      const res = await fetch(`${API}/api/planning/${eventId}${path}`, {
+        method,
+        headers: buildHeaders(accessToken, orgId),
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      if (res.status === 412) {
+        // Conflict — rollback and return the conflict payload
+        if (prev) setBoard(prev);
+        const data = await res.json();
+        return { conflict: true, data };
+      }
+
+      if (!res.ok) {
+        if (prev) setBoard(prev);
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `HTTP ${res.status}`);
+      }
+
+      const result = await res.json();
+      markMutated();
+      await fetchBoard(); // sync server state
+      return { ok: true, data: result };
+    } catch (err) {
+      if (prev) setBoard(prev);
+      return { ok: false, error: err.message };
+    }
+  }
+
+  // ---------- list operations ----------
+
+  const createList = (title) => mutate("POST", "/lists", { title });
+
+  const updateList = (listId, updates, currentUpdatedAt) =>
+    mutate(
+      "PATCH",
+      `/lists/${listId}`,
+      updates,
+      null,
+      currentUpdatedAt ? { "If-Match": currentUpdatedAt } : undefined
+    );
+
+  // ---------- card operations ----------
+
+  const createCard = (listId, title, extra = {}) =>
+    mutate("POST", "/cards", { list_id: listId, title, ...extra });
+
+  const updateCard = (cardId, updates, currentUpdatedAt) => {
+    const headers = currentUpdatedAt ? { "If-Match": currentUpdatedAt } : undefined;
+    return mutateWithHeaders("PATCH", `/cards/${cardId}`, updates, headers);
+  };
+
+  const archiveCard = (cardId) => mutate("DELETE", `/cards/${cardId}`);
+
+  const moveCard = (cardId, listId, position, currentUpdatedAt) =>
+    updateCard(cardId, { list_id: listId, position }, currentUpdatedAt);
+
+  // ---------- comment operations ----------
+
+  const createComment = (cardId, body) =>
+    mutate("POST", `/cards/${cardId}/comments`, { body });
+
+  const deleteComment = (commentId) =>
+    mutate("DELETE", `/comments/${commentId}`);
+
+  // ---------- label operations ----------
+
+  const createLabel = (name, color) =>
+    mutate("POST", "/labels", { name, color });
+
+  const updateLabel = (labelId, updates) =>
+    mutate("PATCH", `/labels/${labelId}`, updates);
+
+  // ---------- admin operations ----------
+
+  const updateEditors = (add, remove) =>
+    mutate("PATCH", "/editors", { add, remove });
+
+  const updateConfig = (config) =>
+    mutate("PATCH", "/config", config);
+
+  const seedTemplate = () =>
+    mutate("POST", "/seed-template");
+
+  const slackNotify = () =>
+    mutate("POST", "/slack/notify");
+
+  // ---------- helper for custom headers ----------
+
+  async function mutateWithHeaders(method, path, body, extraHeaders = {}) {
+    const prev = board;
+    try {
+      const res = await fetch(`${API}/api/planning/${eventId}${path}`, {
+        method,
+        headers: { ...buildHeaders(accessToken, orgId), ...extraHeaders },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      if (res.status === 412) {
+        const data = await res.json();
+        return { conflict: true, data };
+      }
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `HTTP ${res.status}`);
+      }
+
+      const result = await res.json();
+      markMutated();
+      await fetchBoard();
+      return { ok: true, data: result };
+    } catch (err) {
+      if (prev) setBoard(prev);
+      return { ok: false, error: err.message };
+    }
+  }
+
+  // ---------- derived permissions ----------
+
+  const planning = board?.planning || {};
+  const canWrite = (() => {
+    if (!user) return false;
+    try {
+      const isAdmin = orgHelper
+        ?.getOrgs()
+        ?.some((org) => org.hasPermission("volunteer.admin"));
+      if (isAdmin) return true;
+      const editors = planning.editors || [];
+      return editors.includes(user.userId);
+    } catch {
+      return false;
+    }
+  })();
+  const canComment = !!user;
+
+  return {
+    board,
+    loading,
+    error,
+    canWrite,
+    canComment,
+    refetch: fetchBoard,
+    // mutations
+    createList,
+    updateList,
+    createCard,
+    updateCard,
+    archiveCard,
+    moveCard,
+    createComment,
+    deleteComment,
+    createLabel,
+    updateLabel,
+    updateEditors,
+    updateConfig,
+    seedTemplate,
+    slackNotify,
+  };
+}

--- a/src/lib/lexorank.js
+++ b/src/lib/lexorank.js
@@ -1,0 +1,75 @@
+/**
+ * Minimal LexoRank-style position strings for planning board ordering.
+ *
+ * Positions are strings like "p0000500" — sortable lexicographically.
+ * The "p" prefix keeps them non-numeric and prevents JS auto-coercion.
+ *
+ * Operations:
+ *   between(a, b)  — string that sorts between a and b
+ *   before(a)      — string that sorts before a
+ *   after(a)       — string that sorts after a
+ *   initial(n)     — evenly-spaced positions for n items
+ *   needsRebalance(positions) — true when gaps are exhausted
+ */
+
+const PREFIX = "p";
+const DIGITS = 7;
+const MIN_VAL = 0;
+const MAX_VAL = 9999999;
+const REBALANCE_THRESHOLD = 1; // gap < 2 means we can't insert between
+
+function toInt(pos) {
+  if (!pos || !pos.startsWith(PREFIX)) return MIN_VAL;
+  return parseInt(pos.slice(PREFIX.length), 10) || MIN_VAL;
+}
+
+function fromInt(n) {
+  const clamped = Math.max(MIN_VAL, Math.min(MAX_VAL, Math.round(n)));
+  return PREFIX + String(clamped).padStart(DIGITS, "0");
+}
+
+/**
+ * Return a position string that sorts strictly between a and b.
+ * Returns null if the gap is exhausted (needsRebalance will catch this).
+ */
+export function between(a, b) {
+  const lo = a ? toInt(a) : MIN_VAL;
+  const hi = b ? toInt(b) : MAX_VAL;
+  if (hi - lo < 2) return null; // gap exhausted
+  return fromInt(Math.floor((lo + hi) / 2));
+}
+
+/** Return a position that sorts before a (halves the gap to MIN_VAL). */
+export function before(a) {
+  const n = a ? toInt(a) : MAX_VAL;
+  return fromInt(Math.floor(n / 2));
+}
+
+/** Return a position that sorts after a (halfway to MAX_VAL). */
+export function after(a) {
+  const n = a ? toInt(a) : MIN_VAL;
+  if (n >= MAX_VAL) return null; // no room after
+  return fromInt(Math.floor((n + MAX_VAL) / 2));
+}
+
+/** Generate n evenly-spaced initial positions. */
+export function initial(n) {
+  if (n <= 0) return [];
+  const step = Math.floor(MAX_VAL / (n + 1));
+  return Array.from({ length: n }, (_, i) => fromInt(step * (i + 1)));
+}
+
+/** True when any adjacent gap is too small to insert between. */
+export function needsRebalance(positions) {
+  if (!positions || positions.length < 2) return false;
+  const sorted = [...positions].sort();
+  for (let i = 0; i < sorted.length - 1; i++) {
+    if (toInt(sorted[i + 1]) - toInt(sorted[i]) < REBALANCE_THRESHOLD + 1) return true;
+  }
+  return false;
+}
+
+/** Rebalance: return evenly-spaced replacements for the same number of positions. */
+export function rebalance(count) {
+  return initial(count);
+}

--- a/src/pages/admin/hackathons/index.js
+++ b/src/pages/admin/hackathons/index.js
@@ -56,6 +56,7 @@ import {
   QuizOutlined as QuizIcon,
   ToggleOn as ToggleIcon,
   Groups as TeamSettingsIcon,
+  Dashboard as PlanningIcon,
 } from "@mui/icons-material";
 import { LocalizationProvider, DatePicker, DateTimePicker } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
@@ -68,6 +69,8 @@ import HackathonDuplicator from "../../../components/admin/HackathonDuplicator";
 import NonprofitManagement from "../../../components/admin/NonprofitManagement";
 import MealManagement from "../../../components/admin/MealManagement";
 import EventMediaManagement from "../../../components/admin/EventMediaManagement";
+import PlanningEditorsManager from "../../../components/Planning/PlanningEditorsManager";
+import PlanningSlackSettings from "../../../components/Planning/PlanningSlackSettings";
 import TimezoneSelect from "react-timezone-select";
 import { DEFAULT_EVENT_TIMEZONE } from "../../../lib/timezoneUtils";
 
@@ -1037,6 +1040,131 @@ const AdminHackathonPage = () => {
                     socialPosts={editingHackathon?.social_posts || []}
                     onSocialPostsChange={(s) => handleInputChange("social_posts", s)}
                   />
+                </AccordionDetails>
+              </Accordion>
+
+              <Accordion>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <PlanningIcon fontSize="small" />
+                    <Typography>Planning Board</Typography>
+                  </Box>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Stack spacing={2}>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={!!(editingHackathon?.planning?.enabled)}
+                          onChange={(e) => handleInputChange("planning", {
+                            ...(editingHackathon?.planning || {}),
+                            enabled: e.target.checked,
+                          })}
+                        />
+                      }
+                      label="Enable planning board (makes /hack/{event_id}/plan public)"
+                    />
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={!!(editingHackathon?.planning?.budget_widget_on_event_page)}
+                          onChange={(e) => handleInputChange("planning", {
+                            ...(editingHackathon?.planning || {}),
+                            budget_widget_on_event_page: e.target.checked,
+                          })}
+                        />
+                      }
+                      label="Show budget widget on the public event page"
+                    />
+                    {editingHackathon?.event_id && (
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        href={`/hack/${editingHackathon.event_id}/plan`}
+                        target="_blank"
+                        startIcon={<LaunchIcon />}
+                      >
+                        Open planning board ↗
+                      </Button>
+                    )}
+                    {editingHackathon?.planning?.enabled && !editingHackathon?.planning?.template_seeded && (
+                      <Alert
+                        severity="info"
+                        action={
+                          <Button
+                            size="small"
+                            onClick={async () => {
+                              await fetch(
+                                `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/planning/${editingHackathon.event_id}/seed-template`,
+                                {
+                                  method: "POST",
+                                  headers: {
+                                    authorization: `Bearer ${accessToken}`,
+                                    "X-Org-Id": orgId,
+                                  },
+                                }
+                              );
+                              handleInputChange("planning", {
+                                ...(editingHackathon?.planning || {}),
+                                template_seeded: true,
+                              });
+                            }}
+                          >
+                            Apply template
+                          </Button>
+                        }
+                      >
+                        Template not yet applied. Seed the OHack default lists and cards.
+                      </Alert>
+                    )}
+                    <Divider />
+                    <PlanningSlackSettings
+                      planning={editingHackathon?.planning || {}}
+                      onUpdateConfig={(config) => {
+                        const updated = { ...(editingHackathon?.planning || {}), ...config };
+                        handleInputChange("planning", updated);
+                      }}
+                      onSlackNotify={async () => {
+                        await fetch(
+                          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/planning/${editingHackathon?.event_id}/slack/notify`,
+                          {
+                            method: "POST",
+                            headers: {
+                              authorization: `Bearer ${accessToken}`,
+                              "X-Org-Id": orgId,
+                            },
+                          }
+                        );
+                      }}
+                    />
+                    <Divider />
+                    <PlanningEditorsManager
+                      editors={(editingHackathon?.planning?.editors) || []}
+                      onUpdateEditors={async (add, remove) => {
+                        const res = await fetch(
+                          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/planning/${editingHackathon?.event_id}/editors`,
+                          {
+                            method: "PATCH",
+                            headers: {
+                              authorization: `Bearer ${accessToken}`,
+                              "content-type": "application/json",
+                              "X-Org-Id": orgId,
+                            },
+                            body: JSON.stringify({ add, remove }),
+                          }
+                        );
+                        if (res.ok) {
+                          const data = await res.json();
+                          handleInputChange("planning", {
+                            ...(editingHackathon?.planning || {}),
+                            editors: data.editors,
+                          });
+                          return { ok: true };
+                        }
+                        return { ok: false, error: "Failed" };
+                      }}
+                    />
+                  </Stack>
                 </AccordionDetails>
               </Accordion>
 

--- a/src/pages/hack/[event_id]/plan.js
+++ b/src/pages/hack/[event_id]/plan.js
@@ -1,0 +1,268 @@
+import dynamic from "next/dynamic";
+import Head from "next/head";
+import NextLink from "next/link";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Breadcrumbs,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Link,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  ArrowBack,
+  EditNote,
+  LockOutlined,
+  OpenInNew,
+  Visibility,
+} from "@mui/icons-material";
+import { usePlanningBoard } from "../../../hooks/use-planning-board";
+import PlanningPublicNotice from "../../../components/Planning/PlanningPublicNotice";
+
+const PlanningBoard = dynamic(
+  () => import("../../../components/Planning/PlanningBoard"),
+  { ssr: false }
+);
+
+const PlanningCardDialog = dynamic(
+  () => import("../../../components/Planning/PlanningCardDialog"),
+  { ssr: false }
+);
+
+export default function PlanPage({ eventData, initialBoard }) {
+  const router = useRouter();
+  const eventId = router.query.event_id;
+
+  const {
+    board,
+    loading,
+    error,
+    canWrite,
+    canComment,
+    createList,
+    createCard,
+    updateCard,
+    archiveCard,
+    moveCard,
+    createComment,
+    deleteComment,
+    createLabel,
+    updateLabel,
+    updateEditors,
+    updateConfig,
+    seedTemplate,
+    slackNotify,
+    refetch,
+  } = usePlanningBoard(eventId);
+
+  const [selectedCard, setSelectedCard] = useState(null);
+  const [selectedCardComments, setSelectedCardComments] = useState([]);
+
+  const title = eventData?.title || eventId || "Hackathon";
+  const planning = board?.planning || {};
+  const enabled = planning.enabled;
+
+  // Board not enabled yet
+  if (!loading && board && !enabled) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Head>
+          <title>{`${title} Planning | Opportunity Hack`}</title>
+        </Head>
+        <Breadcrumbs sx={{ mb: 2 }}>
+          <Link component={NextLink} href="/hack" underline="hover">Events</Link>
+          <Link component={NextLink} href={`/hack/${eventId}`} underline="hover">{title}</Link>
+          <Typography color="text.primary">Planning</Typography>
+        </Breadcrumbs>
+        <Alert severity="info">
+          Planning hasn&apos;t been opened for this event yet.
+          {canWrite && (
+            <Button size="small" sx={{ ml: 2 }} onClick={() => updateConfig({ enabled: true })}>
+              Enable planning board
+            </Button>
+          )}
+        </Alert>
+      </Container>
+    );
+  }
+
+  async function handleCardClick(card) {
+    setSelectedCard(card);
+    // Fetch comments for the card
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/planning/${eventId}/cards/${card.id}/comments`
+      );
+      const data = await res.json();
+      setSelectedCardComments(data.comments || []);
+    } catch {
+      setSelectedCardComments([]);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{`${title} Planning Board | Opportunity Hack`}</title>
+        <meta
+          name="description"
+          content={`Planning board for ${title} — track progress, sponsors, volunteers, and the run of show.`}
+        />
+      </Head>
+
+      <Box
+        sx={{
+          bgcolor: "primary.dark",
+          color: "white",
+          py: 1.5,
+          px: 2,
+          position: "sticky",
+          top: 0,
+          zIndex: 10,
+        }}
+      >
+        <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap">
+          <Button
+            component={NextLink}
+            href={`/hack/${eventId}`}
+            startIcon={<ArrowBack />}
+            size="small"
+            sx={{ color: "white" }}
+          >
+            {title}
+          </Button>
+
+          <Typography variant="h6" sx={{ fontWeight: 600, flex: 1 }}>
+            Planning Board
+          </Typography>
+
+          <Tooltip title={canWrite ? "You can edit this board" : "Read-only view"}>
+            <Chip
+              icon={canWrite ? <EditNote /> : <Visibility />}
+              label={canWrite ? "Editor" : "Viewer"}
+              size="small"
+              sx={{ color: "white", borderColor: "rgba(255,255,255,0.5)", border: "1px solid" }}
+            />
+          </Tooltip>
+
+          {planning.slack?.channel && (
+            <Button
+              size="small"
+              variant="outlined"
+              sx={{ color: "white", borderColor: "rgba(255,255,255,0.5)" }}
+              href={`https://opportunityhack.slack.com/channels/${planning.slack.channel}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              endIcon={<OpenInNew />}
+            >
+              Join Slack
+            </Button>
+          )}
+        </Stack>
+      </Box>
+
+      <Box sx={{ p: 2, overflowX: "hidden" }}>
+        <PlanningPublicNotice />
+
+        {loading && (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {!loading && !error && board && (
+          <>
+            {canWrite && !planning.template_seeded && (
+              <Alert
+                severity="info"
+                sx={{ mb: 2 }}
+                action={
+                  <Button size="small" onClick={seedTemplate}>
+                    Apply template
+                  </Button>
+                }
+              >
+                Start with the OHack default template to get lists and cards pre-populated.
+              </Alert>
+            )}
+
+            <PlanningBoard
+              board={board}
+              canWrite={canWrite}
+              onCardClick={handleCardClick}
+              createCard={createCard}
+              updateCard={updateCard}
+              moveCard={moveCard}
+              createList={createList}
+            />
+          </>
+        )}
+      </Box>
+
+      {selectedCard && (
+        <PlanningCardDialog
+          card={selectedCard}
+          comments={selectedCardComments}
+          labels={board?.labels || []}
+          canWrite={canWrite}
+          canComment={canComment}
+          eventId={eventId}
+          onClose={() => setSelectedCard(null)}
+          onUpdate={(updates) => updateCard(selectedCard.id, updates, selectedCard.updated_at)}
+          onArchive={() => {
+            archiveCard(selectedCard.id);
+            setSelectedCard(null);
+          }}
+          onCreateComment={(body) => createComment(selectedCard.id, body)}
+          onDeleteComment={deleteComment}
+          onCreateLabel={createLabel}
+        />
+      )}
+    </>
+  );
+}
+
+export async function getStaticProps({ params }) {
+  const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+  try {
+    const [eventRes, boardRes] = await Promise.all([
+      fetch(`${API}/api/messages/hackathon/${params.event_id}`),
+      fetch(`${API}/api/planning/${params.event_id}`),
+    ]);
+    const eventData = eventRes.ok ? await eventRes.json() : null;
+    const initialBoard = boardRes.ok ? await boardRes.json() : null;
+    return {
+      props: { eventData, initialBoard },
+      revalidate: 60,
+    };
+  } catch {
+    return { props: { eventData: null, initialBoard: null }, revalidate: 60 };
+  }
+}
+
+export async function getStaticPaths() {
+  const API = process.env.NEXT_PUBLIC_API_SERVER_URL;
+  try {
+    const res = await fetch(`${API}/api/messages/hackathon/all`);
+    const hackathons = await res.json();
+    const paths = hackathons.map((event) => ({
+      params: { event_id: event.event_id || event.id || "unknown" },
+    }));
+    return { paths, fallback: "blocking" };
+  } catch {
+    return { paths: [], fallback: "blocking" };
+  }
+}


### PR DESCRIPTION
## Summary

- New public page `/hack/[event_id]/plan` with ISR (revalidate: 60) so crawlers get rendered HTML
- Full Trello-parity board: lists + cards + drag/drop (`@dnd-kit`), labels, due dates, checklists, attachments (image-only v1), threaded comments, activity tail, archive
- Budget transparency: card-level `budget` field (amount/bucket/state) rolls up to Goal/Raised/Earmarked/Spent stacked bars per bucket in `PlanningBudgetWidget`
- Card kinds: `judges / mentors / hackers / nonprofits / teams / sponsor_prospect` each render a live-stat strip pulled from existing endpoints (zero new backend reads per kind)
- Run of Show sync: board → `hackathons.countdowns[]`, preserves `source:manual` entries, diff preview dialog before commit
- Sponsor pipeline view: list ↔ pipeline column toggle, grouped by `outreach_status`
- 412 conflict dialog: mine / theirs / side-by-side with `localStorage` draft preservation
- Adaptive polling: 6 s hot (recent mutation), 30 s cold, paused when tab hidden; ETag/If-None-Match
- Admin integration: Planning Board accordion in Advanced Settings (enable toggle, seed template, editors manager, Slack settings, quick link)
- `HackathonDuplicator` reset: duplicated events get `planning.enabled=false / editors=[] / template_seeded=false`
- `PlanningPublicNotice` (persistent info alert) rendered at page top, in upload dialog, and collapsible in comment box
- `PlanningCardConflictDialog` + `PlanningRunOfShowSyncDialog` components (Opus-level correctness per plan)

## New components

`src/components/Planning/` — PlanningBoard, PlanningList, PlanningCard, PlanningCardDialog, PlanningPublicNotice, PlanningBudgetWidget, PlanningEditorsManager, PlanningSlackSettings, PlanningCardConflictDialog, PlanningRunOfShowSyncDialog, PlanningCardKindRenderer, JudgesStat, MentorsStat, HackersStat, NonprofitsStat, TeamsStat, PlanningSponsorPipelineView

`src/hooks/use-planning-board.js` — snapshot state, adaptive polling, optimistic mutations, 412 detection
`src/lib/lexorank.js` — LexoRank position helper with rebalance support

## Test plan

- [ ] Enable planning on a test event in admin → `/hack/{event_id}/plan` renders (not 404)
- [ ] Seed OHack template → 8 lists appear; second click no-ops (`template_seeded` guard)
- [ ] Drag card between lists → optimistic move, PATCH fires, position stable after reload
- [ ] Edit card description → markdown renders in read mode
- [ ] Attach image → CDN URL follows `hackathons/{event_id}/planning/cards/{card_id}/{epoch}_slug.ext` pattern
- [ ] Add comment as logged-in non-editor → succeeds; edit buttons absent
- [ ] Anonymous visit → read-only, no action buttons
- [ ] Duplicate event → new event has `planning.enabled=false`, no orphaned subcollections
- [ ] Run of Show sync → diff preview shows incoming+preserved; confirm updates `/hack/{event_id}` countdowns
- [ ] Budget widget → earmarked bar updates client-side when card state changes to paid
- [ ] Kind=judges card → stat strip shows applied/selected/goal from existing volunteer endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)