### PR TITLE
[Admin] Meals — vendor menu catalog + cost estimator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,20 @@ The old "Edit Hackathon" Dialog at `/admin/hackathons` is gone. Editing now live
 - The Schedule editor groups countdowns by day in a timeline view with "Quick add" presets (Kickoff, Workshop, Coffee break, Lunch, Judging starts, Awards, Wrap-up). Single timezone selector at the top of the section defaults to the hackathon's `timezone`. List view is a fallback that supports drag-reorder.
 - `ALLOWED_DIETARY_TAGS` lives in `MealsSection.js` (was previously in the deleted `MealManagement.js`). Keep in sync with backend `validators.py`.
 
+### Vendor menu catalog (Meals section)
+The Meals editor has a "Browse menu" button on each meal slot that opens a searchable catalog picker. Catalog files live in `src/components/admin/hackathon-edit/catalog/`:
+- `fatFreddysCatalog.js` — seeded items from Fat Freddy's Catering (Phoenix). Update freely as menus change. Items have `{ id, category, name, description, price_cents, unit, min_quantity, dietary_tags, bundled_with? }`. `unit` is `"per_person" | "each" | "fixed"`.
+- `catalogStorage.js` — combines the seeded catalog with user-added items persisted to `localStorage` under `ohack_admin_menu_catalog_v1`. New vendors / items added via the picker's "Add a custom item" form go here. (Promote to backend storage if you want cross-device sharing.)
+- `MenuCatalogPicker.js` — the dialog. Filters by vendor + category, search across name/description, multi-select to add to a meal.
+- `formatCurrency.js` — USD formatters and `computeItemCostCents` / `computeMealCostCents` / `computeAllMealsCostCents`.
+
+Cost extras stored on the hackathon doc (both pass through the permissive `validate_meals` validator without backend changes):
+- `constraints.meals_estimated_headcount` (int, default 50) — used as the default people-eating count for cost estimates.
+- `meal.headcount_override` (int, optional) — per-slot override when not all attendees eat that meal.
+- `meal.items[i]` gains optional `price_cents`, `unit`, `quantity` (for `each`), `vendor`, `catalog_item_id` fields.
+
+`MealsSection` shows a "Estimated cost" summary card at the top of the section using the Fat Freddy's quote defaults (8.6% AZ tax, ~10% gratuity, 2.9% card surcharge, $45 delivery) — toggleable. Per-meal subtotals display as a green chip on each meal card; per-item cost shows under each priced item.
+
 ## Hackathon Per-Event Config (admin → `constraints`)
 The `constraints` object on a hackathon doc carries per-event toggles. Keys consumed by the application forms:
 - `judge_venue_arrival_time` (HH:MM, 24-hour) — judge form's Availability step shows it when set; falls back to existing default copy when null.

--- a/src/components/admin/hackathon-edit/catalog/MenuCatalogPicker.js
+++ b/src/components/admin/hackathon-edit/catalog/MenuCatalogPicker.js
@@ -1,0 +1,419 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  IconButton,
+  InputAdornment,
+  InputLabel,
+  MenuItem,
+  OutlinedInput,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  Close as CloseIcon,
+  Delete as DeleteIcon,
+  RestaurantMenu as MenuIconSvg,
+  Search as SearchIcon,
+} from "@mui/icons-material";
+import {
+  addUserCatalogItem,
+  getCategoriesForVendor,
+  getCombinedCatalog,
+  getVendors,
+  isSeededItem,
+  removeUserCatalogItem,
+} from "./catalogStorage";
+import { formatUSD } from "./formatCurrency";
+
+const ALLOWED_DIETARY_TAGS = [
+  "vegetarian",
+  "vegan",
+  "halal",
+  "kosher",
+  "gluten-free",
+  "dairy-free",
+  "nut-free",
+  "pescatarian",
+];
+
+const newId = () => `user-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+const blankCustomItem = (vendor) => ({
+  id: newId(),
+  vendor: vendor || "",
+  category: "",
+  name: "",
+  description: "",
+  price_cents: 0,
+  unit: "per_person",
+  min_quantity: 15,
+  dietary_tags: [],
+});
+
+const AddCustomForm = ({ vendor, onAdd, onCancel }) => {
+  const [draft, setDraft] = useState(blankCustomItem(vendor));
+  const set = (field, value) => setDraft((d) => ({ ...d, [field]: value }));
+  const valid = draft.name.trim() && draft.vendor.trim() && draft.price_cents >= 0;
+
+  const handleSave = () => {
+    addUserCatalogItem({
+      ...draft,
+      name: draft.name.trim(),
+      vendor: draft.vendor.trim(),
+      category: draft.category.trim() || "Custom",
+      description: draft.description.trim() || undefined,
+    });
+    onAdd();
+  };
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2, bgcolor: "primary.50" }}>
+      <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 700 }}>
+        New catalog item (saves to your browser)
+      </Typography>
+      <Stack spacing={1.5}>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+          <TextField
+            label="Name"
+            size="small"
+            fullWidth
+            value={draft.name}
+            onChange={(e) => set("name", e.target.value)}
+            required
+          />
+          <TextField
+            label="Vendor"
+            size="small"
+            fullWidth
+            value={draft.vendor}
+            onChange={(e) => set("vendor", e.target.value)}
+            required
+            placeholder="e.g. Local Pizza Co"
+          />
+        </Stack>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+          <TextField
+            label="Category"
+            size="small"
+            fullWidth
+            value={draft.category}
+            onChange={(e) => set("category", e.target.value)}
+            placeholder="Lunch, Dinner, Snack…"
+          />
+          <TextField
+            label="Price (USD)"
+            type="number"
+            size="small"
+            value={(draft.price_cents / 100).toString()}
+            onChange={(e) => {
+              const dollars = parseFloat(e.target.value);
+              set("price_cents", Number.isFinite(dollars) ? Math.round(dollars * 100) : 0);
+            }}
+            inputProps={{ min: 0, step: 0.25 }}
+            sx={{ width: 140 }}
+          />
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <InputLabel>Unit</InputLabel>
+            <Select label="Unit" value={draft.unit} onChange={(e) => set("unit", e.target.value)}>
+              <MenuItem value="per_person">per person</MenuItem>
+              <MenuItem value="each">each (qty)</MenuItem>
+              <MenuItem value="fixed">fixed total</MenuItem>
+            </Select>
+          </FormControl>
+        </Stack>
+        <TextField
+          label="Description (optional)"
+          size="small"
+          fullWidth
+          multiline
+          rows={2}
+          value={draft.description}
+          onChange={(e) => set("description", e.target.value)}
+        />
+        <FormControl size="small" fullWidth>
+          <InputLabel>Dietary tags</InputLabel>
+          <Select
+            multiple
+            value={draft.dietary_tags}
+            onChange={(e) => set("dietary_tags", e.target.value)}
+            input={<OutlinedInput label="Dietary tags" />}
+            renderValue={(sel) => (
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                {sel.map((v) => <Chip key={v} label={v} size="small" />)}
+              </Box>
+            )}
+          >
+            {ALLOWED_DIETARY_TAGS.map((tag) => (
+              <MenuItem key={tag} value={tag}>{tag}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Stack direction="row" justifyContent="flex-end" spacing={1}>
+          <Button size="small" onClick={onCancel}>Cancel</Button>
+          <Button size="small" variant="contained" disabled={!valid} onClick={handleSave}>Save to catalog</Button>
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+};
+
+const MenuCatalogPicker = ({ open, onClose, onAddItems, headcount }) => {
+  const [catalog, setCatalog] = useState(() => getCombinedCatalog());
+  const [vendors, setVendors] = useState(() => getVendors());
+  const [vendorFilter, setVendorFilter] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("");
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState(new Set());
+  const [showAdd, setShowAdd] = useState(false);
+
+  // Refresh catalog whenever the dialog is opened so newly-added user items
+  // show up immediately.
+  useEffect(() => {
+    if (open) {
+      setCatalog(getCombinedCatalog());
+      setVendors(getVendors());
+      setSelected(new Set());
+      setShowAdd(false);
+    }
+  }, [open]);
+
+  const refresh = () => {
+    setCatalog(getCombinedCatalog());
+    setVendors(getVendors());
+    setShowAdd(false);
+  };
+
+  const categories = useMemo(() => {
+    if (!vendorFilter) {
+      const all = new Set();
+      catalog.forEach((it) => it.category && all.add(it.category));
+      return Array.from(all);
+    }
+    return getCategoriesForVendor(vendorFilter);
+  }, [vendorFilter, catalog]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return catalog.filter((it) => {
+      if (vendorFilter && it.vendor !== vendorFilter) return false;
+      if (categoryFilter && it.category !== categoryFilter) return false;
+      if (q && !`${it.name} ${it.description || ""}`.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [catalog, vendorFilter, categoryFilter, search]);
+
+  const toggleOne = (id) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleAdd = () => {
+    const items = catalog
+      .filter((it) => selected.has(it.id))
+      .map((it) => ({
+        id: `m-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+        name: it.name,
+        description: it.description || "",
+        dietary_tags: it.dietary_tags || [],
+        price_cents: it.price_cents,
+        unit: it.unit || "per_person",
+        vendor: it.vendor,
+        catalog_item_id: it.id,
+        ...(it.unit === "each" ? { quantity: 1 } : {}),
+      }));
+    onAddItems(items);
+    onClose();
+  };
+
+  const handleDeleteUserItem = (id) => {
+    if (!window.confirm("Remove this catalog item from your saved list?")) return;
+    removeUserCatalogItem(id);
+    refresh();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1, pr: 6 }}>
+        <MenuIconSvg color="primary" />
+        Browse menu catalog
+        <Box sx={{ flex: 1 }} />
+        <IconButton size="small" onClick={onClose} aria-label="Close" sx={{ position: "absolute", right: 8, top: 8 }}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+            <TextField
+              size="small"
+              fullWidth
+              placeholder="Search items…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel>Vendor</InputLabel>
+              <Select
+                label="Vendor"
+                value={vendorFilter}
+                onChange={(e) => {
+                  setVendorFilter(e.target.value);
+                  setCategoryFilter("");
+                }}
+              >
+                <MenuItem value=""><em>All vendors</em></MenuItem>
+                {vendors.map((v) => <MenuItem key={v} value={v}>{v}</MenuItem>)}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel>Category</InputLabel>
+              <Select
+                label="Category"
+                value={categoryFilter}
+                onChange={(e) => setCategoryFilter(e.target.value)}
+              >
+                <MenuItem value=""><em>All categories</em></MenuItem>
+                {categories.map((c) => <MenuItem key={c} value={c}>{c}</MenuItem>)}
+              </Select>
+            </FormControl>
+          </Stack>
+
+          {headcount > 0 && (
+            <Alert severity="info" sx={{ py: 0.5 }}>
+              Headcount: <strong>{headcount}</strong> — per-person prices are multiplied by this when added to a meal.
+            </Alert>
+          )}
+
+          <Box>
+            <Button size="small" startIcon={<AddIcon />} onClick={() => setShowAdd((v) => !v)}>
+              {showAdd ? "Hide add form" : "Add a custom item"}
+            </Button>
+            <Collapse in={showAdd}>
+              <Box sx={{ mt: 1 }}>
+                <AddCustomForm vendor={vendorFilter} onAdd={refresh} onCancel={() => setShowAdd(false)} />
+              </Box>
+            </Collapse>
+          </Box>
+
+          <Divider />
+
+          {filtered.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
+              No items match. Adjust filters or add a custom item.
+            </Typography>
+          ) : (
+            <Stack spacing={1}>
+              {filtered.map((it) => {
+                const checked = selected.has(it.id);
+                const userOwned = !isSeededItem(it.id);
+                return (
+                  <Paper
+                    key={it.id}
+                    variant="outlined"
+                    onClick={() => toggleOne(it.id)}
+                    sx={{
+                      p: 1.5,
+                      cursor: "pointer",
+                      borderColor: checked ? "primary.main" : "divider",
+                      bgcolor: checked ? "primary.50" : "background.paper",
+                      transition: "border-color 80ms",
+                    }}
+                  >
+                    <Stack direction="row" spacing={1} alignItems="flex-start">
+                      <Checkbox checked={checked} sx={{ p: 0.5 }} onClick={(e) => e.stopPropagation()} onChange={() => toggleOne(it.id)} />
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Stack direction="row" alignItems="center" spacing={1} sx={{ flexWrap: "wrap" }}>
+                          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{it.name}</Typography>
+                          <Chip label={it.category} size="small" variant="outlined" />
+                          {(it.dietary_tags || []).map((t) => (
+                            <Chip key={t} label={t} size="small" sx={{ fontSize: "0.7rem" }} />
+                          ))}
+                          {userOwned && <Chip label="custom" size="small" color="warning" variant="outlined" />}
+                        </Stack>
+                        {it.description && (
+                          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+                            {it.description}
+                          </Typography>
+                        )}
+                        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+                          {it.vendor}
+                          {it.min_quantity ? ` · ${it.min_quantity}-person min` : ""}
+                        </Typography>
+                      </Box>
+                      <Box sx={{ textAlign: "right", whiteSpace: "nowrap" }}>
+                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                          {formatUSD(it.price_cents)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {it.unit === "per_person" ? "/ person" : it.unit === "each" ? "each" : "fixed"}
+                        </Typography>
+                        {it.unit === "per_person" && headcount > 0 && (
+                          <Typography variant="caption" color="primary.main" sx={{ display: "block", fontWeight: 600 }}>
+                            = {formatUSD((it.price_cents || 0) * headcount)}
+                          </Typography>
+                        )}
+                        {userOwned && (
+                          <Tooltip title="Remove from catalog">
+                            <IconButton
+                              size="small"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteUserItem(it.id);
+                              }}
+                            >
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                      </Box>
+                    </Stack>
+                  </Paper>
+                );
+              })}
+            </Stack>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          disabled={selected.size === 0}
+          onClick={handleAdd}
+          startIcon={<AddIcon />}
+        >
+          Add {selected.size || ""} item{selected.size === 1 ? "" : "s"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default MenuCatalogPicker;

--- a/src/components/admin/hackathon-edit/catalog/catalogStorage.js
+++ b/src/components/admin/hackathon-edit/catalog/catalogStorage.js
@@ -1,0 +1,69 @@
+// localStorage-backed user catalog. Lives client-side until we decide to
+// promote it to the backend. Keyed per-vendor so admins can keep different
+// vendors' menus separate.
+//
+// Shape per stored item (matches FAT_FREDDYS_CATALOG entries):
+//   { id, vendor, category, name, description?, price_cents, unit, min_quantity?, dietary_tags[] }
+
+import { FAT_FREDDYS_CATALOG, FAT_FREDDYS_VENDOR, FAT_FREDDYS_CATEGORIES } from "./fatFreddysCatalog";
+
+const STORAGE_KEY = "ohack_admin_menu_catalog_v1";
+
+const seededFatFreddysItems = FAT_FREDDYS_CATALOG.map((it) => ({ ...it, vendor: FAT_FREDDYS_VENDOR }));
+
+const readStorage = () => {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    console.warn("Failed to read catalog from localStorage:", err);
+    return [];
+  }
+};
+
+const writeStorage = (items) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch (err) {
+    console.warn("Failed to write catalog to localStorage:", err);
+  }
+};
+
+export const getCombinedCatalog = () => {
+  const userItems = readStorage();
+  return [...seededFatFreddysItems, ...userItems];
+};
+
+export const getVendors = () => {
+  const vendors = new Set([FAT_FREDDYS_VENDOR]);
+  readStorage().forEach((it) => it.vendor && vendors.add(it.vendor));
+  return Array.from(vendors);
+};
+
+export const getCategoriesForVendor = (vendor) => {
+  if (vendor === FAT_FREDDYS_VENDOR) return FAT_FREDDYS_CATEGORIES;
+  const categories = new Set();
+  readStorage().forEach((it) => {
+    if (it.vendor === vendor && it.category) categories.add(it.category);
+  });
+  return Array.from(categories);
+};
+
+export const addUserCatalogItem = (item) => {
+  const userItems = readStorage();
+  const next = [...userItems, item];
+  writeStorage(next);
+  return next;
+};
+
+export const removeUserCatalogItem = (id) => {
+  const next = readStorage().filter((it) => it.id !== id);
+  writeStorage(next);
+  return next;
+};
+
+export const isSeededItem = (id) => seededFatFreddysItems.some((it) => it.id === id);

--- a/src/components/admin/hackathon-edit/catalog/fatFreddysCatalog.js
+++ b/src/components/admin/hackathon-edit/catalog/fatFreddysCatalog.js
@@ -1,0 +1,609 @@
+// Catalog seeded from Fat Freddy's Catering menu (October 2025 v2).
+//
+// Source: vendor PDFs at https://www.fatfreddyscatering.com
+// Prices are per-person unless `unit` says otherwise. Per-person items have a
+// 15-person minimum unless specified. Many entrees come bundled with mixed
+// greens salad, fresh baked bread, and chef's daily desserts — those bundled
+// sides are noted in `bundled_with` for the cost-summary view.
+//
+// Update freely as menus change. Items are matched/identified by `id` only;
+// the rest of the fields are display data and can be edited safely.
+
+export const FAT_FREDDYS_VENDOR = "Fat Freddy's Catering";
+
+const ENTREE_BUNDLE_SALAD_BREAD_DESSERT = [
+  "Mixed greens salad with dressing",
+  "Fresh baked bread",
+  "Chef's daily dessert selection",
+];
+
+const ENTREE_BUNDLE_BBQ = ["Two sides", "Sandwich buns or rolls", "Dessert"];
+
+export const FAT_FREDDYS_CATALOG = [
+  // ---- Breakfast ----
+  {
+    id: "ff-bf-sandwiches",
+    category: "Breakfast",
+    name: "Breakfast Sandwiches",
+    description:
+      "Choose one: English Muffin with Fried Egg, Shaved Black Forest Ham & Swiss; Croissant with Fried Egg, Spicy Sausage & Swiss; or Burrito with Scrambled Egg, Chorizo, Potatoes & Cheddar.",
+    price_cents: 1250,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-bf-continental",
+    category: "Breakfast",
+    name: "Continental Breakfast",
+    description:
+      "Assortment of sweet breads, mini muffins, danish, fresh cut fruit, and regular and/or decaf coffee.",
+    price_cents: 1050,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["vegetarian"],
+  },
+  {
+    id: "ff-bf-deluxe-continental",
+    category: "Breakfast",
+    name: "Deluxe Continental Breakfast",
+    description:
+      "Sweet breads, mini muffins, danish, bagels with cream cheese, butter & jellies, fresh cut fruit, yogurt & granola, and coffee.",
+    price_cents: 1600,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["vegetarian"],
+  },
+  {
+    id: "ff-bf-cowboy",
+    category: "Breakfast",
+    name: "Cowboy Breakfast",
+    description:
+      "Buttermilk biscuits, country sausage gravy, scrambled eggs, bacon, and fresh cut fruit.",
+    price_cents: 1600,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-bf-pancake",
+    category: "Breakfast",
+    name: "Pancake Breakfast",
+    description:
+      "Buttermilk pancakes with butter & warm maple syrup, scrambled eggs, breakfast sausage, and fresh cut fruit.",
+    price_cents: 1600,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-bf-brunch-starter",
+    category: "Breakfast",
+    name: "Brunch Starter",
+    description:
+      "Breakfast egg strata, caramelized french toast with butter & warm maple syrup, fresh cut fruit.",
+    price_cents: 1850,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["vegetarian"],
+  },
+  {
+    id: "ff-bf-french-toast",
+    category: "Breakfast",
+    name: "Fat Freddy's French Toast",
+    description:
+      "Thick cut caramelized french toast with butter and warm maple syrup, scrambled eggs, breakfast sausage, and fresh cut fruit.",
+    price_cents: 1600,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-bf-ultimate",
+    category: "Breakfast",
+    name: "Ultimate Breakfast",
+    description:
+      "Scrambled eggs, apple wood smoked bacon, potatoes O'Brien, sweet breads, mini muffins, danish, bagels with cream cheese, butter & jellies, individual yogurt parfaits with granola & fresh cut fruit.",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-bf-tacos",
+    category: "Breakfast",
+    name: "Breakfast Tacos (GF)",
+    description:
+      "Scrambled eggs, shredded cheddar, salsa, breakfast potatoes, fresh cut fruit and sausage crumble. Served with warm corn tortillas.",
+    price_cents: 1500,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["gluten-free"],
+  },
+  {
+    id: "ff-bf-omelets",
+    category: "Breakfast",
+    name: "Omelets Made to Order",
+    description:
+      "Chef-prepared personalized omelets, plus a buffet with potatoes O'Brien, apple wood smoked bacon, fresh cut fruit, and assorted sweet breads. (*) Full-Service Events only — additional labor fees apply.",
+    price_cents: 2500,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+  },
+
+  // ---- All American & BBQ entrees (bundled with salad, bread, dessert) ----
+  {
+    id: "ff-am-herb-roasted-chicken",
+    category: "All American & BBQ",
+    name: "Herb Roasted Chicken (GF)",
+    description:
+      "Fresh roasted bone-in chicken with our special blend of spices, served with red skin garlic mashed potatoes.",
+    price_cents: 1750,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["gluten-free"],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-am-yankee-pot-roast",
+    category: "All American & BBQ",
+    name: "Yankee Pot Roast",
+    description:
+      "Slow roasted eye of round with pearl onions, peas and carrots. Served with homestyle mashed potatoes and brown gravy.",
+    price_cents: 1975,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-am-meatloaf",
+    category: "All American & BBQ",
+    name: "Pan Fried Meatloaf",
+    description:
+      "75-year-old family recipe with beef and pork. Served with homestyle mashed potatoes and brown gravy.",
+    price_cents: 1875,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-am-southern-fried-chicken",
+    category: "All American & BBQ",
+    name: "Southern Style Fried Chicken",
+    description:
+      "Crispy bone-in chicken fried in our family's secret spices. Served with homestyle mashed potatoes and creamy pepper gravy.",
+    price_cents: 1675,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-am-burgers",
+    category: "All American & BBQ",
+    name: "1/3 Pound Angus All Beef Hamburgers",
+    description:
+      "Build-your-own condiment station: ketchup, mustard, mayo, American cheese slices, lettuce, tomato, pickle & onion. Gluten free buns at additional charge.",
+    price_cents: 1600,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-bone-in-chicken",
+    category: "All American & BBQ",
+    name: "Bone-in Chicken Quarters (GF)",
+    description: "Traditional sweet & smoky BBQ sauce.",
+    price_cents: 1695,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["gluten-free"],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-hot-dogs",
+    category: "All American & BBQ",
+    name: "1/4 Pound All Beef Hot Dogs",
+    description:
+      "Build-your-own condiment station: ketchup, mustard, chopped onions, relish. Gluten free buns at additional charge.",
+    price_cents: 1275,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-sloppy-joes",
+    category: "All American & BBQ",
+    name: "Old Fashioned Sloppy Joes",
+    description: "Hearty classic with beef or turkey simmered in tangy house-made tomato sauce.",
+    price_cents: 1275,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-pulled-pork",
+    category: "All American & BBQ",
+    name: "BBQ Pulled Pork",
+    description: "Traditional sweet & smoky BBQ sauce. Gluten free buns at additional charge.",
+    price_cents: 1775,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-pulled-chicken",
+    category: "All American & BBQ",
+    name: "BBQ Pulled Chicken",
+    description: "Traditional sweet & smoky BBQ sauce. Gluten free buns at additional charge.",
+    price_cents: 1775,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-brisket",
+    category: "All American & BBQ",
+    name: "BBQ Beef Brisket (GF)",
+    description: "Cider glazed onions & BBQ au jus.",
+    price_cents: 2175,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["gluten-free"],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-spare-ribs",
+    category: "All American & BBQ",
+    name: "BBQ Pork Spare Ribs (GF)",
+    description: "Dry rubbed with our special blend of spices.",
+    price_cents: 1900,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["gluten-free"],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-baby-back-ribs",
+    category: "All American & BBQ",
+    name: "BBQ Baby Back Ribs (GF)",
+    description: "Dry rubbed with our special blend of spices.",
+    price_cents: 2450,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["gluten-free"],
+    bundled_with: ENTREE_BUNDLE_BBQ,
+  },
+  {
+    id: "ff-am-baked-potato-bar",
+    category: "All American & BBQ",
+    name: "Baked Potato Bar",
+    description:
+      "Idaho baked potatoes with butter, sour cream, shredded cheddar, apple wood bacon, broccoli cheese sauce, sautéed mushrooms & green onions; mixed greens salad with fresh vegetables and dressing; fresh baked rolls & butter; cookies & brownies.",
+    price_cents: 1450,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["vegetarian"],
+  },
+
+  // ---- International ----
+  {
+    id: "ff-int-garlic-chicken-dijon",
+    category: "International",
+    name: "Garlic Chicken Dijon",
+    description:
+      "Dijon-marinated and pan-fried chicken breast with pesto butter sauce, served with wild rice pilaf.",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-int-teriyaki-chicken",
+    category: "International",
+    name: "Teriyaki Chicken",
+    description:
+      "Wok tossed chicken slices with five spices and teriyaki sauce, served with basmati rice.",
+    price_cents: 1900,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-int-apricot-mango-chicken",
+    category: "International",
+    name: "Apricot Mango Chicken",
+    description:
+      "Freddy's award-winning jerk-rub marinated grilled chicken breast with apricot coulis, served with wild rice pilaf.",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-int-beef-stroganoff",
+    category: "International",
+    name: "Beef Stroganoff",
+    description:
+      "Tender beef in garlic-onion-sour cream-mushroom sauce, served with buttered egg noodles or homestyle mashed potatoes.",
+    price_cents: 1975,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-int-lemon-margarita-chicken",
+    category: "International",
+    name: "Lemon Margarita Chicken",
+    description:
+      "Charred lemon chicken breast with balsamic glazed tomatoes and fresh basil, served with rice pilaf.",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+  {
+    id: "ff-int-white-burgundy-chicken",
+    category: "International",
+    name: "White Burgundy Chicken",
+    description:
+      "Chicken breast in white cream sauce with mushrooms, garlic, and shallots, served with red skin garlic mashed potatoes.",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ENTREE_BUNDLE_SALAD_BREAD_DESSERT,
+  },
+
+  // ---- Italian ----
+  {
+    id: "ff-it-white-cheddar-broccoli",
+    category: "Italian",
+    name: "White Cheddar Broccoli Bake",
+    description:
+      "Penne pasta with fresh broccoli, grilled pesto chicken, apple wood bacon and white cheddar cheese.",
+    price_cents: 1575,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-chicken-penne-romano",
+    category: "Italian",
+    name: "Chicken Penne Romano",
+    description:
+      "Grilled sliced chicken breast, baby spinach and mushrooms tossed with penne, sun-dried tomatoes and a homemade white wine cream sauce.",
+    price_cents: 1575,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-baked-ziti",
+    category: "Italian",
+    name: "Baked Ziti with Italian Sausage",
+    description:
+      "Classic ziti pasta with marinara, sweet Italian sausage, herbed ricotta and three cheese blend.",
+    price_cents: 1575,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-baked-manicotti",
+    category: "Italian",
+    name: "Baked Manicotti",
+    description:
+      "Large pasta tubes stuffed with bolognese sauce, ricotta and mozzarella cheese.",
+    price_cents: 1575,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-rosetta-parmesan",
+    category: "Italian",
+    name: "Chicken Rosetta Parmesan",
+    description:
+      "Hand breaded chicken breast with alfredo and marinara sauces, mozzarella and parmesan, served with pasta marinara.",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-marsala",
+    category: "Italian",
+    name: "Chicken Marsala",
+    description:
+      "Sautéed chicken breast with pancetta bacon, mushrooms and marsala. Served with red skin garlic mashed potatoes.",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-piccata",
+    category: "Italian",
+    name: "Chicken Piccata",
+    description:
+      "Pecorino and egg battered chicken breast with fresh thyme, lemon and caper butter, served with a side of pasta.",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-spaghetti-bolognese",
+    category: "Italian",
+    name: "Spaghetti Bolognese",
+    description: "Marinara sauce made with roasted pork and beef.",
+    price_cents: 1575,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-rigatoni-pesto-primavera",
+    category: "Italian",
+    name: "Rigatoni Pesto Primavera (V)",
+    description:
+      "Sweet bell peppers, cauliflower, zucchini and mushrooms in a creamy pesto alfredo sauce.",
+    price_cents: 1675,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["vegetarian"],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+  {
+    id: "ff-it-grilled-pesto-chicken",
+    category: "Italian",
+    name: "Grilled Pesto Chicken (GF)",
+    description:
+      "Grilled chicken breast smothered in homemade pesto sauce, topped with tomato slices and mozzarella, served with pasta. (Chicken is GF.)",
+    price_cents: 1950,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: ["gluten-free"],
+    bundled_with: ["Mixed greens salad", "Garlic breadsticks", "Chef's dessert"],
+  },
+
+  // ---- Hors d'Oeuvre Packages ----
+  {
+    id: "ff-ho-italian-package",
+    category: "Hors d'Oeuvre Packages",
+    name: "Italian Hors d'Oeuvre Package",
+    description:
+      "Antipasto display, fruit skewers, goat cheese bruschetta, flatbread with sausage, spinach & artichoke dip, portabella empanada, sicilian arancini bolognese, italian dessert assortment.",
+    price_cents: 4450,
+    unit: "per_person",
+    min_quantity: 25,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-ho-southwest-package",
+    category: "Hors d'Oeuvre Packages",
+    name: "Southwest Hors d'Oeuvre Package",
+    description:
+      "Tortilla chips & salsa, fruit tray, vegetable & bean empanadas, spinach & artichoke crisps, beef taquitos, smoked turkey carving station, southwest dessert display.",
+    price_cents: 3150,
+    unit: "per_person",
+    min_quantity: 25,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-ho-traditional-package",
+    category: "Hors d'Oeuvre Packages",
+    name: "Traditional Hors d'Oeuvre Package",
+    description:
+      "Cheese tray, fruit tray, vegetable crudites, raspberry chipotle meatballs, mini hot dogs in puff pastry, mini beef wellington, teriyaki chicken skewers, brownies & bar cookies.",
+    price_cents: 3250,
+    unit: "per_person",
+    min_quantity: 25,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-ho-continental-package",
+    category: "Hors d'Oeuvre Packages",
+    name: "Continental Hors d'Oeuvre Package",
+    description:
+      "Beef tenderloin carving station, smoked salmon, imported cheese, fruit skewers, vegetable crudites, lobster & brie phyllo, portabella empanada, arancini, miniature dessert assortment.",
+    price_cents: 5550,
+    unit: "per_person",
+    min_quantity: 25,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-ho-passed-2",
+    category: "Hors d'Oeuvre Packages",
+    name: "Passed Appetizers — Choose 2",
+    description: "Pick any 2 passed appetizers (full-service events only).",
+    price_cents: 850,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+  },
+  {
+    id: "ff-ho-passed-3",
+    category: "Hors d'Oeuvre Packages",
+    name: "Passed Appetizers — Choose 3",
+    description: "Pick any 3 passed appetizers (full-service events only).",
+    price_cents: 1100,
+    unit: "per_person",
+    min_quantity: 15,
+    dietary_tags: [],
+  },
+
+  // ---- A la carte hors d'oeuvres (per-person, common $4.50) ----
+  { id: "ff-ala-nashville-hot-chicken-waffle", category: "A la carte appetizers", name: "Nashville Hot Chicken & Waffle Skewer", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-sesame-chicken-tenders", category: "A la carte appetizers", name: "Sesame Chicken Tenders", description: "with sweet thai chili sauce", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-chicken-skewers", category: "A la carte appetizers", name: "Chicken Skewers", description: "Thai peanut, teriyaki, or BBQ", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-chicken-taquitos", category: "A la carte appetizers", name: "Chicken Taquitos", description: "with southwest ranch dipping sauce", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-buffalo-chicken-tortilla-crisp", category: "A la carte appetizers", name: "Buffalo Chicken Tortilla Crisp", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-italian-sausage-stuffed-mushrooms", category: "A la carte appetizers", name: "Italian Sausage Stuffed Mushrooms", description: "with asiago cheese", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-mini-cuban-sandwiches", category: "A la carte appetizers", name: "Mini Cuban Sandwiches", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-pulled-pork-mango-flauta", category: "A la carte appetizers", name: "Pulled Pork & Mango Flauta", description: "with southwest ranch dipping sauce", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-mini-crab-cake", category: "A la carte appetizers", name: "Mini Crab Cake", description: "with remoulade sauce", price_cents: 500, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-crab-cheese-rangoons", category: "A la carte appetizers", name: "Crab & Cheese Rangoons", price_cents: 500, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-ala-iced-jumbo-shrimp", category: "A la carte appetizers", name: "Iced Jumbo Shrimp Cocktail", description: "13/15 count", price_cents: 500, unit: "each", dietary_tags: ["pescatarian"] },
+  { id: "ff-ala-vegetable-spring-roll", category: "A la carte appetizers", name: "Vegetable Spring Roll", description: "with sweet thai chili sauce", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-ala-spinach-pesto-puffs", category: "A la carte appetizers", name: "Spinach Pesto Puffs", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-ala-deviled-eggs", category: "A la carte appetizers", name: "Gourmet Deviled Eggs", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-ala-mac-cheese-bites", category: "A la carte appetizers", name: "Macaroni & Cheese Bites", description: "with chipotle ranch dipping sauce", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-ala-antipasto-skewers", category: "A la carte appetizers", name: "Antipasto Skewers", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+
+  // ---- Gourmet displays ----
+  { id: "ff-disp-domestic-cheese", category: "Gourmet Displays", name: "Domestic Cheese Display", description: "with assorted crackers", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-disp-imported-cheese", category: "Gourmet Displays", name: "Imported Cheese Display", price_cents: 550, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-disp-fruit-cheese", category: "Gourmet Displays", name: "Fresh Fruit & Cheese Display", price_cents: 550, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-disp-fruit", category: "Gourmet Displays", name: "Fresh Cut Fruit Display", description: "with poppy seed drizzle", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: ["vegan"] },
+  { id: "ff-disp-veg-crudite", category: "Gourmet Displays", name: "Traditional Vegetable Crudite Display", description: "with pesto ranch dipping sauce", price_cents: 450, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-disp-baked-brie", category: "Gourmet Displays", name: "Baked Brie with Apricot Preserves", price_cents: 625, unit: "per_person", min_quantity: 15, dietary_tags: ["vegetarian"] },
+  { id: "ff-disp-italian-meat-cheese", category: "Gourmet Displays", name: "Italian Meat & Cheese Display", description: "Imported Italian meats and cheeses with focaccia, breadsticks, olives, peppers, artichokes and mushrooms.", price_cents: 1650, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+  { id: "ff-disp-smoked-salmon", category: "Gourmet Displays", name: "Whole Smoked Salmon", description: "Hickory smoked Pacific salmon on pickled onion, fennel and cucumber slaw with sliced baguette and crostini.", price_cents: 1550, unit: "per_person", min_quantity: 15, dietary_tags: ["pescatarian"] },
+  { id: "ff-disp-grazing-board", category: "Gourmet Displays", name: "Grazing Board", description: "Assorted nuts, fruit spreads, berries, dried fruits, hard cheeses, salami, mortadella & pates with grissini sticks and crackers.", price_cents: 1950, unit: "per_person", min_quantity: 15, dietary_tags: [] },
+
+  // ---- Equipment / extras ----
+  {
+    id: "ff-equip-chafing-dish",
+    category: "Equipment & extras",
+    name: "Chafing Dish Kit",
+    description: "Per-pan chafing setup for keeping food warm.",
+    price_cents: 1750,
+    unit: "each",
+    dietary_tags: [],
+  },
+];
+
+// Export categories in display order for filter UIs.
+export const FAT_FREDDYS_CATEGORIES = [
+  "Breakfast",
+  "All American & BBQ",
+  "International",
+  "Italian",
+  "Hors d'Oeuvre Packages",
+  "A la carte appetizers",
+  "Gourmet Displays",
+  "Equipment & extras",
+];

--- a/src/components/admin/hackathon-edit/catalog/formatCurrency.js
+++ b/src/components/admin/hackathon-edit/catalog/formatCurrency.js
@@ -1,0 +1,39 @@
+export const dollars = (cents) => (cents == null ? 0 : cents / 100);
+
+export const formatUSD = (cents) => {
+  if (cents == null || isNaN(cents)) return "—";
+  return `$${(cents / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+export const formatUSDCompact = (cents) => {
+  if (cents == null || isNaN(cents)) return "—";
+  const d = cents / 100;
+  if (d >= 1000) return `$${d.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+  return `$${d.toFixed(2)}`;
+};
+
+// Compute the per-item cost given a headcount. `each` items use a fixed qty
+// stored on the item; `per_person` items use the meal's headcount.
+export const computeItemCostCents = (item, headcount) => {
+  if (!item || !item.price_cents) return 0;
+  const unit = item.unit || "per_person";
+  if (unit === "per_person") return Math.round(item.price_cents * Math.max(0, headcount || 0));
+  if (unit === "each") return Math.round(item.price_cents * Math.max(0, item.quantity || 1));
+  if (unit === "fixed") return item.price_cents;
+  return 0;
+};
+
+export const computeMealCostCents = (meal, headcount) => {
+  if (!meal || !Array.isArray(meal.items)) return 0;
+  const overriden = meal.headcount_override;
+  const effective = overriden != null && overriden !== "" ? Number(overriden) : headcount;
+  return meal.items.reduce((sum, it) => sum + computeItemCostCents(it, effective), 0);
+};
+
+export const computeAllMealsCostCents = (meals, headcount) => {
+  if (!Array.isArray(meals)) return 0;
+  return meals.reduce((sum, m) => sum + computeMealCostCents(m, headcount), 0);
+};

--- a/src/components/admin/hackathon-edit/sections/MealsSection.js
+++ b/src/components/admin/hackathon-edit/sections/MealsSection.js
@@ -11,6 +11,7 @@ import {
   FormControlLabel,
   Grid,
   IconButton,
+  InputAdornment,
   InputLabel,
   MenuItem,
   OutlinedInput,
@@ -29,6 +30,7 @@ import {
   ContentCopy as CloneIcon,
   Delete as DeleteIcon,
   DragIndicator as DragIcon,
+  MenuBook as CatalogIcon,
   Restaurant as MealIcon,
   Visibility as PreviewIcon,
   VisibilityOff as PreviewOffIcon,
@@ -43,6 +45,13 @@ import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { format, parseISO } from "date-fns";
 import SectionContainer from "../SectionContainer";
+import MenuCatalogPicker from "../catalog/MenuCatalogPicker";
+import {
+  computeAllMealsCostCents,
+  computeItemCostCents,
+  computeMealCostCents,
+  formatUSD,
+} from "../catalog/formatCurrency";
 
 // Kept in sync with backend `ALLOWED_DIETARY_TAGS` in validators.py.
 export const ALLOWED_DIETARY_TAGS = [
@@ -55,6 +64,16 @@ export const ALLOWED_DIETARY_TAGS = [
   "nut-free",
   "pescatarian",
 ];
+
+// Default surcharge assumptions sourced from the Fat Freddy's quote
+// (8.6% AZ tax, ~10% gratuity, $45 flat delivery, 2.9% credit-card
+// surcharge). Used only for the "with fees" toggle.
+const DEFAULT_SURCHARGES = {
+  tax_pct: 8.6,
+  gratuity_pct: 10,
+  delivery_cents: 4500,
+  card_surcharge_pct: 2.9,
+};
 
 const newId = () => `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -90,7 +109,7 @@ const formatMealTime = (value) => {
 };
 
 const QUICK_ADD = [
-  { label: "Friday Dinner", icon: DinnerIcon, hint: "Friday at 7:00 PM" },
+  { label: "Friday Dinner", icon: DinnerIcon },
   { label: "Saturday Breakfast", icon: MorningIcon },
   { label: "Saturday Lunch", icon: LunchIcon },
   { label: "Saturday Dinner", icon: DinnerIcon },
@@ -99,7 +118,31 @@ const QUICK_ADD = [
   { label: "Snacks", icon: SnackIcon },
 ];
 
-const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandleProps, eventStart, eventEnd }) => {
+const ItemCostRow = ({ item, headcount }) => {
+  if (!item.price_cents) return null;
+  const unit = item.unit || "per_person";
+  const cost = computeItemCostCents(item, headcount);
+  return (
+    <Box sx={{ mt: 0.75, display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+      <Chip
+        label={`${formatUSD(item.price_cents)} ${unit === "per_person" ? "/ person" : unit === "each" ? "each" : "fixed"}`}
+        size="small"
+        variant="outlined"
+        color="primary"
+      />
+      {cost > 0 && (
+        <Typography variant="caption" color="text.secondary">
+          ≈ <strong>{formatUSD(cost)}</strong> at {unit === "each" ? `qty ${item.quantity || 1}` : `${headcount} people`}
+        </Typography>
+      )}
+      {item.vendor && (
+        <Typography variant="caption" color="text.secondary">· {item.vendor}</Typography>
+      )}
+    </Box>
+  );
+};
+
+const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, onOpenCatalog, dragHandleProps, eventStart, eventEnd, headcount }) => {
   const updateField = (field, value) => onUpdate({ ...meal, [field]: value });
   const updateItem = (itemIndex, field, value) => {
     const items = (meal.items || []).map((it, i) => (i === itemIndex ? { ...it, [field]: value } : it));
@@ -110,6 +153,10 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
     onUpdate({ ...meal, items: (meal.items || []).filter((_, i) => i !== itemIndex) });
 
   const parsedTime = parseMealTime(meal.time);
+  const overriddenHeadcount = meal.headcount_override != null && meal.headcount_override !== ""
+    ? Number(meal.headcount_override)
+    : headcount;
+  const mealCost = computeMealCostCents(meal, headcount);
 
   return (
     <Card variant="outlined" sx={{ mb: 2 }}>
@@ -122,6 +169,15 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
           <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: 1 }}>
             {meal.name || `Meal ${mealIndex + 1}`}
           </Typography>
+          {mealCost > 0 && (
+            <Chip
+              label={formatUSD(mealCost)}
+              size="small"
+              color="success"
+              variant="outlined"
+              sx={{ fontWeight: 700 }}
+            />
+          )}
           <Tooltip title="Duplicate this meal">
             <IconButton size="small" onClick={onClone} aria-label="Duplicate meal">
               <CloneIcon fontSize="small" />
@@ -135,7 +191,7 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
         </Stack>
 
         <Grid container spacing={2}>
-          <Grid size={{ xs: 12, sm: 6 }}>
+          <Grid size={{ xs: 12, sm: 5 }}>
             <TextField
               label="Name"
               fullWidth
@@ -145,7 +201,7 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
               placeholder="Saturday Lunch"
             />
           </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
+          <Grid size={{ xs: 12, sm: 5 }}>
             <LocalizationProvider dateAdapter={AdapterDateFns}>
               <DateTimePicker
                 label="Time"
@@ -156,13 +212,27 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
                 slotProps={{ textField: { size: "small", fullWidth: true } }}
               />
             </LocalizationProvider>
-            {meal.time && !parsedTime && (
-              <Typography variant="caption" color="warning.main">
-                Legacy free-text time — pick a real datetime to upgrade.
-              </Typography>
-            )}
+          </Grid>
+          <Grid size={{ xs: 12, sm: 2 }}>
+            <TextField
+              label="People eating"
+              type="number"
+              size="small"
+              fullWidth
+              value={meal.headcount_override ?? ""}
+              onChange={(e) => updateField("headcount_override", e.target.value === "" ? null : Number(e.target.value))}
+              placeholder={String(headcount || 0)}
+              inputProps={{ min: 0 }}
+              helperText={meal.headcount_override == null ? `default ${headcount}` : "override"}
+            />
           </Grid>
         </Grid>
+
+        {meal.time && !parsedTime && (
+          <Typography variant="caption" color="warning.main" sx={{ display: "block", mt: 1 }}>
+            Legacy free-text time — pick a real datetime above to upgrade.
+          </Typography>
+        )}
 
         <Stack direction="row" alignItems="center" spacing={2} sx={{ mt: 2 }}>
           <FormControlLabel
@@ -198,21 +268,28 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
 
         {meal.catering_provided !== false && (
           <Box sx={{ mt: 2, pl: 2, borderLeft: "3px solid", borderColor: "primary.light" }}>
-            <Typography variant="subtitle2" sx={{ mb: 1 }}>
-              Menu options
-            </Typography>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
+              <Typography variant="subtitle2">Menu options</Typography>
+              <Stack direction="row" spacing={1}>
+                <Button size="small" startIcon={<CatalogIcon />} variant="contained" color="primary" onClick={onOpenCatalog}>
+                  Browse menu
+                </Button>
+                <Button size="small" startIcon={<AddIcon />} onClick={addItem} variant="outlined">
+                  Blank item
+                </Button>
+              </Stack>
+            </Stack>
             <Stack spacing={2}>
               {(meal.items || []).map((item, i) => (
                 <Box key={item.id || i} sx={{ pb: 2, borderBottom: i < (meal.items.length - 1) ? "1px solid" : "none", borderColor: "divider" }}>
                   <Stack direction="row" spacing={1} alignItems="flex-start">
-                    <Box sx={{ flex: 1 }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
                       <TextField
                         label={`Item ${i + 1} name`}
                         size="small"
                         fullWidth
                         value={item.name || ""}
                         onChange={(e) => updateItem(i, "name", e.target.value)}
-                        placeholder="Margherita Pizza"
                       />
                       <TextField
                         label="Description"
@@ -222,29 +299,68 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
                         rows={2}
                         value={item.description || ""}
                         onChange={(e) => updateItem(i, "description", e.target.value)}
-                        placeholder="Tomato, fresh mozzarella, basil"
                         sx={{ mt: 1 }}
                       />
-                      <FormControl size="small" fullWidth sx={{ mt: 1 }}>
-                        <InputLabel>Dietary tags</InputLabel>
-                        <Select
-                          multiple
-                          value={item.dietary_tags || []}
-                          onChange={(e) => updateItem(i, "dietary_tags", e.target.value)}
-                          input={<OutlinedInput label="Dietary tags" />}
-                          renderValue={(selected) => (
-                            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                              {selected.map((v) => (
-                                <Chip key={v} label={v} size="small" />
-                              ))}
-                            </Box>
-                          )}
-                        >
-                          {ALLOWED_DIETARY_TAGS.map((tag) => (
-                            <MenuItem key={tag} value={tag}>{tag}</MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
+                      <Stack direction={{ xs: "column", sm: "row" }} spacing={1} sx={{ mt: 1 }}>
+                        <TextField
+                          label="Price"
+                          type="number"
+                          size="small"
+                          value={item.price_cents != null ? (item.price_cents / 100).toString() : ""}
+                          onChange={(e) => {
+                            const dollars = parseFloat(e.target.value);
+                            const cents = Number.isFinite(dollars) ? Math.round(dollars * 100) : null;
+                            updateItem(i, "price_cents", cents);
+                          }}
+                          InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                          inputProps={{ min: 0, step: 0.25 }}
+                          sx={{ width: 130 }}
+                        />
+                        <FormControl size="small" sx={{ minWidth: 130 }}>
+                          <InputLabel>Unit</InputLabel>
+                          <Select
+                            label="Unit"
+                            value={item.unit || "per_person"}
+                            onChange={(e) => updateItem(i, "unit", e.target.value)}
+                          >
+                            <MenuItem value="per_person">per person</MenuItem>
+                            <MenuItem value="each">each (qty)</MenuItem>
+                            <MenuItem value="fixed">fixed total</MenuItem>
+                          </Select>
+                        </FormControl>
+                        {item.unit === "each" && (
+                          <TextField
+                            label="Qty"
+                            type="number"
+                            size="small"
+                            value={item.quantity ?? 1}
+                            onChange={(e) => updateItem(i, "quantity", Math.max(0, parseInt(e.target.value, 10) || 0))}
+                            inputProps={{ min: 0, step: 1 }}
+                            sx={{ width: 90 }}
+                          />
+                        )}
+                        <FormControl size="small" sx={{ flex: 1, minWidth: 200 }}>
+                          <InputLabel>Dietary tags</InputLabel>
+                          <Select
+                            multiple
+                            value={item.dietary_tags || []}
+                            onChange={(e) => updateItem(i, "dietary_tags", e.target.value)}
+                            input={<OutlinedInput label="Dietary tags" />}
+                            renderValue={(selected) => (
+                              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                                {selected.map((v) => (
+                                  <Chip key={v} label={v} size="small" />
+                                ))}
+                              </Box>
+                            )}
+                          >
+                            {ALLOWED_DIETARY_TAGS.map((tag) => (
+                              <MenuItem key={tag} value={tag}>{tag}</MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      </Stack>
+                      <ItemCostRow item={item} headcount={overriddenHeadcount} />
                     </Box>
                     <IconButton size="small" color="error" onClick={() => removeItem(i)} aria-label="Remove item">
                       <DeleteIcon fontSize="small" />
@@ -252,11 +368,11 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
                   </Stack>
                 </Box>
               ))}
-              <Box>
-                <Button size="small" startIcon={<AddIcon />} onClick={addItem} variant="outlined">
-                  Add menu item
-                </Button>
-              </Box>
+              {(meal.items || []).length === 0 && (
+                <Typography variant="caption" color="text.secondary">
+                  No items yet. Click "Browse menu" to pick from Fat Freddy's, or add a blank item.
+                </Typography>
+              )}
             </Stack>
           </Box>
         )}
@@ -265,9 +381,6 @@ const MealEditor = ({ meal, mealIndex, onUpdate, onRemove, onClone, dragHandlePr
   );
 };
 
-// What hackers see at the bottom of the application form. Keep this rendering
-// loose enough to remind the admin of the experience without depending on
-// any of the live components.
 const HackerPreview = ({ meals }) => {
   if (!meals || meals.length === 0) {
     return (
@@ -324,12 +437,70 @@ const HackerPreview = ({ meals }) => {
   );
 };
 
+const CostSummary = ({ meals, headcount }) => {
+  const [showFees, setShowFees] = useState(true);
+  const subtotal = computeAllMealsCostCents(meals, headcount);
+  if (subtotal === 0) return null;
+
+  const tax = Math.round((subtotal * DEFAULT_SURCHARGES.tax_pct) / 100);
+  const gratuity = Math.round((subtotal * DEFAULT_SURCHARGES.gratuity_pct) / 100);
+  const cardSurcharge = Math.round((subtotal * DEFAULT_SURCHARGES.card_surcharge_pct) / 100);
+  const delivery = DEFAULT_SURCHARGES.delivery_cents;
+  const grand = subtotal + tax + gratuity + cardSurcharge + delivery;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, bgcolor: "success.50", borderColor: "success.light" }}>
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2} justifyContent="space-between" alignItems={{ sm: "center" }}>
+        <Box>
+          <Typography variant="overline" color="text.secondary">Estimated cost</Typography>
+          <Typography variant="h5" sx={{ fontWeight: 700, color: "success.dark" }}>
+            {formatUSD(showFees ? grand : subtotal)}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {meals.length} meal slot{meals.length === 1 ? "" : "s"} · {headcount} people · {showFees ? "with" : "without"} typical fees
+          </Typography>
+        </Box>
+        <FormControlLabel
+          control={<Switch checked={showFees} onChange={(e) => setShowFees(e.target.checked)} />}
+          label="Include taxes & fees"
+        />
+      </Stack>
+      {showFees && (
+        <Box sx={{ mt: 1.5, fontSize: "0.85rem" }}>
+          <Stack spacing={0.25}>
+            <CostLine label="Subtotal" value={subtotal} />
+            <CostLine label={`Tax (${DEFAULT_SURCHARGES.tax_pct}%)`} value={tax} />
+            <CostLine label={`Gratuity (~${DEFAULT_SURCHARGES.gratuity_pct}%)`} value={gratuity} />
+            <CostLine label={`Card surcharge (${DEFAULT_SURCHARGES.card_surcharge_pct}%)`} value={cardSurcharge} />
+            <CostLine label="Delivery (flat)" value={delivery} />
+            <Divider sx={{ my: 0.5 }} />
+            <CostLine label="Estimated total" value={grand} bold />
+          </Stack>
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1, fontStyle: "italic" }}>
+            Surcharges based on Fat Freddy's quote (Phoenix, AZ). Adjust with the vendor.
+          </Typography>
+        </Box>
+      )}
+    </Paper>
+  );
+};
+
+const CostLine = ({ label, value, bold }) => (
+  <Stack direction="row" justifyContent="space-between" sx={{ fontWeight: bold ? 700 : 400 }}>
+    <Box>{label}</Box>
+    <Box>{formatUSD(value)}</Box>
+  </Stack>
+);
+
 const MealsSection = ({ admin }) => {
   const { hackathon, setConstraint, markSectionDirty, dirtySections, commitSection, discardSection, saveState } = admin;
   const meals = hackathon.constraints?.meals || [];
+  const headcount = hackathon.constraints?.meals_estimated_headcount ?? 50;
   const dirty = dirtySections.has("meals");
   const saving = saveState.status === "saving";
   const [showPreview, setShowPreview] = useState(true);
+  const [catalogOpen, setCatalogOpen] = useState(false);
+  const [catalogTargetMeal, setCatalogTargetMeal] = useState(null);
 
   const eventStart = useMemo(
     () => (hackathon.start_date ? new Date(`${hackathon.start_date}T00:00:00`) : null),
@@ -363,6 +534,11 @@ const MealsSection = ({ admin }) => {
     updateMeals(next);
   };
 
+  const setHeadcount = (value) => {
+    setConstraint("meals_estimated_headcount", value);
+    // headcount is purely an estimation aid — no need to mark dirty
+  };
+
   const onDragEnd = (result) => {
     if (!result.destination) return;
     if (result.destination.index === result.source.index) return;
@@ -372,10 +548,24 @@ const MealsSection = ({ admin }) => {
     updateMeals(next);
   };
 
+  const openCatalogFor = (mealIndex) => {
+    setCatalogTargetMeal(mealIndex);
+    setCatalogOpen(true);
+  };
+
+  const handleCatalogAdd = (newItems) => {
+    if (catalogTargetMeal == null) return;
+    const target = meals[catalogTargetMeal];
+    if (!target) return;
+    const updated = { ...target, items: [...(target.items || []), ...newItems] };
+    updateOne(catalogTargetMeal, updated);
+    setCatalogTargetMeal(null);
+  };
+
   return (
     <SectionContainer
       title="Meals & Catering"
-      description="Configure meals served at the in-person event. Hackers pick one option per slot, so the catering team has exact orders. Drag to reorder."
+      description="Configure meals, pick items from a vendor catalog (Fat Freddy's seeded), and see live cost estimates. Drag to reorder. Hackers pick one option per slot."
       actions={
         <ToggleButtonGroup
           value={showPreview ? "preview" : "edit"}
@@ -392,6 +582,32 @@ const MealsSection = ({ admin }) => {
       onSave={() => commitSection("meals")}
       onDiscard={() => discardSection("meals")}
     >
+      <Stack spacing={2.5} sx={{ mb: 3 }}>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems={{ sm: "center" }}>
+          <TextField
+            label="Estimated headcount"
+            type="number"
+            size="small"
+            value={headcount}
+            onChange={(e) => setHeadcount(Math.max(0, parseInt(e.target.value, 10) || 0))}
+            inputProps={{ min: 0, step: 1 }}
+            helperText="Used for cost estimates and per-meal defaults"
+            sx={{ maxWidth: 220 }}
+          />
+          <Button
+            size="medium"
+            variant="outlined"
+            startIcon={<CatalogIcon />}
+            onClick={() => openCatalogFor(null)}
+            disabled
+            sx={{ visibility: "hidden" }}
+          >
+            Browse menu
+          </Button>
+        </Stack>
+        <CostSummary meals={meals} headcount={headcount} />
+      </Stack>
+
       <Grid container spacing={3}>
         <Grid size={{ xs: 12, md: showPreview ? 7 : 12 }}>
           {meals.length === 0 ? (
@@ -415,9 +631,11 @@ const MealsSection = ({ admin }) => {
                               onUpdate={(v) => updateOne(index, v)}
                               onRemove={() => removeOne(index)}
                               onClone={() => cloneOne(index)}
+                              onOpenCatalog={() => openCatalogFor(index)}
                               dragHandleProps={p.dragHandleProps}
                               eventStart={eventStart}
                               eventEnd={eventEnd}
+                              headcount={headcount}
                             />
                           </Box>
                         )}
@@ -463,6 +681,20 @@ const MealsSection = ({ admin }) => {
           </Grid>
         )}
       </Grid>
+
+      <MenuCatalogPicker
+        open={catalogOpen}
+        onClose={() => {
+          setCatalogOpen(false);
+          setCatalogTargetMeal(null);
+        }}
+        onAddItems={handleCatalogAdd}
+        headcount={
+          catalogTargetMeal != null && meals[catalogTargetMeal]?.headcount_override != null && meals[catalogTargetMeal].headcount_override !== ""
+            ? Number(meals[catalogTargetMeal].headcount_override)
+            : headcount
+        }
+      />
     </SectionContainer>
   );
 };


### PR DESCRIPTION
## Summary

Follow-up to #289. Adds a searchable vendor menu catalog and live cost estimator to the rebuilt Meals editor at `/admin/hackathons/[event_id]?section=meals`.

The pain it solves: typing menu items by hand is slow, and there was no way to see the rough cost before talking to the caterer. Now an admin can pick from a seeded Fat Freddy's menu in two clicks and see "≈ $X with taxes & fees" update live.

### What's new

- **"Browse menu" button** on each meal slot opens a searchable catalog dialog seeded with ~70 items from Fat Freddy's Catering (Breakfast, BBQ, International, Italian, Hors d'Oeuvres, Displays). Filter by vendor + category, search across name/description, multi-select to add.
- **Per-item pricing inline**: each item card has Price, Unit (per person / each / fixed), and Qty (when "each") — auto-filled from the catalog when picked, but always editable.
- **"Estimated headcount"** field at the top (persisted as `constraints.meals_estimated_headcount`); per-meal "People eating" override for slots where attendance dips.
- **Per-meal subtotal chip** (green) on each meal card; **"Estimated cost" summary card** at the top with subtotal and a toggle to include AZ-typical fees (8.6% tax, ~10% gratuity, 2.9% card surcharge, $45 delivery — defaults sourced from a real Fat Freddy's quote).
- **"Add a custom item"** form inside the picker saves to `localStorage` (`ohack_admin_menu_catalog_v1`) so you can grow the catalog with new vendors without a backend change. Custom items show a yellow "custom" chip and have a delete button.

### Files added

`src/components/admin/hackathon-edit/catalog/`:
- `fatFreddysCatalog.js` — seeded menu items
- `catalogStorage.js` — localStorage-backed user catalog merged with seeded
- `MenuCatalogPicker.js` — the dialog
- `formatCurrency.js` — USD formatters + `computeItemCostCents` / `computeMealCostCents`

### Backend impact

None. `validate_meals` in `common/utils/validators.py` is permissive on extra item fields (`price_cents`, `unit`, `quantity`, `vendor`, `catalog_item_id`) and on top-level `constraints.meals_estimated_headcount`, so all the new fields pass through and persist on the existing PATCH `/api/messages/hackathon` endpoint.

### Promote-to-backend later (out of scope)

Custom catalog items live in localStorage — fine for one admin's machine, doesn't sync across devices/users. If we want shared vendor catalogs we can add `/api/catalog/vendors` and persist there. CLAUDE.md notes the upgrade path.

## Test plan

- [ ] `/admin/hackathons/fall-2026?section=meals` → "Estimated headcount" defaults to 50; cost summary card is empty until items are added
- [ ] On any meal slot click "Browse menu" → dialog opens with seeded Fat Freddy's items, filterable by vendor/category, searchable
- [ ] Multi-select 3 items → "Add 3 items" → meal card updates with the items, prices, and a green subtotal chip; main cost summary updates
- [ ] Toggle "Include taxes & fees" on the summary card → estimated total swaps between subtotal and grand total with line breakdown
- [ ] Per-item: change Price / Unit inline → cost recomputes; switch Unit to "each" → Qty field appears
- [ ] "People eating" override on a slot → that slot recomputes using the override (helper text shows)
- [ ] In the picker, "Add a custom item" → fill name/vendor/price → Save → item appears with "custom" chip and persists across refreshes
- [ ] Save the meal section → reload page → all prices, headcount, and overrides survive (verify via the `constraints.meals[*].price_cents` and `constraints.meals_estimated_headcount` shapes in DevTools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)