### PR TITLE
[Teams] Team demo videos + /admin/teams polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,21 @@ Backfill script: `backend-ohack.dev/scripts/backfill_devpost_funnel.py` — dry-
 
 Front-of-house: `HackathonResults` accepts a `fullResultsHref` prop. On `/hack/[event_id]` it points to `/hack/[event_id]/results` so users can jump to the deeper page. The /results page renders the same `HackathonResults` widget at top + `HackathonFunnel` below.
 
+## Team Demo Videos
+Per-team `demo_video_url` (string) + companion `demo_video_url_submitted` (ISO timestamp, set on first save). Stored on the Firestore `teams` doc, mirrors the `devpost_link` shape. Allowed providers: YouTube, Vimeo, Loom, Google Drive (same set the `VideoDisplay` component handles).
+- **Backend:** field in `edit_team()` allowlist (`api/teams/teams_service.py`). Hacker self-serve via `POST /api/team/<teamid>/demo-video` (mirrors `/devpost`). Admin uses the existing `PATCH /api/team/edit` (gated on `volunteer.admin`).
+- **Public display:** `TeamList.js` shows a `<LiteVideoThumbnail>` per team card (CWV-safe — single lazy `<img>` of the YouTube hqdefault.jpg, NOT an iframe per card). Click → one page-level `<Dialog>` with `<VideoDisplay>`. Per-card iframes were rejected because 30+ embeds = ~45MB and trashes LCP/CLS.
+- **Winners (`HackathonResults` on `/hack/[id]/results`):** inline `<VideoDisplay>` embed — only 3-5 cards so direct iframe is fine. Iframe has `loading="lazy"`.
+- **Hacker self-serve:** `TeamCreation/TeamStatusPanel.js` has its own "Demo Video" section beside the DevPost section with live preview via `LiteVideoThumbnail`. Validates URL is one of the 4 supported providers client-side.
+- **`LiteVideoThumbnail`** (`src/components/VideoDisplay/LiteVideoThumbnail.js`): the lite-embed component. Renders YouTube hqdefault thumb when the URL is YouTube; otherwise a generic dark "▶ Watch demo" tile (don't fetch Vimeo oEmbed per render — kills CWV). Always wraps a `<button>` with `loading="lazy" decoding="async"` + explicit `width`/`height` (CLAUDE.md CWV rule).
+
+## Admin Teams (`/admin/teams?event_id=...`)
+File: `src/components/admin/TeamManagement.js` (~2900 lines, hosted in `src/pages/admin/teams/index.js`). Three concerns added together (deliberately scoped — no full redesign):
+- **Demo Video column + inline-edit Popover** (`TeamFieldPopover`): table cell shows a 96×54 thumbnail if set, "+ Add" button if missing. Click → Popover with `TextField` + live `LiteVideoThumbnail` preview + Save/Cancel/Clear. Optimistic update: `handleQuickPatch` PATCHes the partial and merges into local `teams` state — no full refetch.
+- **`patchTeam(partial)` helper**: extracted from `handleSaveTeam`. Always include `id` in the partial. Both the full edit Dialog and `TeamFieldPopover` use it. If you add another quick-edit field, hang it off this same helper + the Popover (parameterize `field`/`label`/`placeholder`/`validate`/`previewKind`).
+- **Filter chips above the table** (state: `activeFilter`): `All` / `Winning` / `In review` / `Active` / `Missing DevPost` / `Missing Video`. Pure client-side — extends the existing `filteredTeams` useEffect. Filter resets `page` to 0 so the user lands on results.
+- The full edit Dialog's Team Details tab also has the Demo Video URL TextField (next to DevPost), with the same `validateDemoVideoUrl` helper and a `LiteVideoThumbnail` preview underneath.
+
 ## Local Landing Pages
 
 ### Arizona Hackathons (`/hackathons/arizona`)

--- a/src/components/Hackathon/HackathonResults.js
+++ b/src/components/Hackathon/HackathonResults.js
@@ -19,6 +19,7 @@ import PendingIcon from '@mui/icons-material/HourglassTop';
 import { useAuthInfo } from '@propelauth/react';
 import { WINNING_STATUSES, isWinningStatus, getWinningStatus } from '../../constants/teamStatus';
 import TeamMember from './TeamMember';
+import VideoDisplay from '../VideoDisplay/VideoDisplay';
 
 const RANK_STYLES = {
   1: { gradient: 'linear-gradient(135deg, #FFD700 0%, #FFA000 100%)', emoji: '\uD83E\uDD47', border: '#FFD700' },
@@ -313,6 +314,15 @@ const HackathonResults = ({ teams, nonprofitMap, eventId, eventTitle, githubOrg,
                             );
                           })}
                         </Grid>
+                      </Box>
+                    )}
+
+                    {team.demo_video_url && (
+                      <Box sx={{ mb: 2 }}>
+                        <VideoDisplay
+                          url={team.demo_video_url}
+                          title={`${team.name} demo`}
+                        />
                       </Box>
                     )}
 

--- a/src/components/Hackathon/TeamList.js
+++ b/src/components/Hackathon/TeamList.js
@@ -44,12 +44,15 @@ import {
   FaHandshake,
   FaUsers,
   FaShieldAlt,
+  FaTimes,
 } from 'react-icons/fa';
 import { useAuthInfo } from "@propelauth/react";
 import MuiAlert from "@mui/material/Alert";
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { TEAM_STATUS_OPTIONS, getStatusOption, isJoiningDisabled } from '../../constants/teamStatus';
 import { isHackathonExpired } from '../../lib/dateUtils';
+import LiteVideoThumbnail from '../VideoDisplay/LiteVideoThumbnail';
+import VideoDisplay from '../VideoDisplay/VideoDisplay';
 
 // Helper function to check if team status prevents joining
 const isJoiningDisabledByStatus = (status) => {
@@ -777,7 +780,7 @@ const GitHubStats = ({ githubUrl, teamMembers, accessToken, onStatsLoaded }) => 
 };
 
 // Team Card component - extracted for better organization
-const TeamCard = ({ team, userProfile, isLoggedIn, onJoin, onLeave, loadingTeamId, isHackathonExpired, teamJoinEnabled, nonprofitMap, accessToken, onCopyGithubUsername }) => {
+const TeamCard = ({ team, userProfile, isLoggedIn, onJoin, onLeave, loadingTeamId, isHackathonExpired, teamJoinEnabled, nonprofitMap, accessToken, onCopyGithubUsername, onPlayVideo }) => {
   const hasGithubLinks = team?.github_links && team?.github_links.length > 0;
   const [githubData, setGithubData] = useState(null);
   const [showJoinModal, setShowJoinModal] = useState(false);
@@ -938,6 +941,17 @@ const TeamCard = ({ team, userProfile, isLoggedIn, onJoin, onLeave, loadingTeamI
           )}
         </Box>
 
+        {/* Demo Video */}
+        {team?.demo_video_url && (
+          <Box sx={{ mb: 1.5 }}>
+            <LiteVideoThumbnail
+              url={team.demo_video_url}
+              label={`Watch ${team?.name || 'team'} demo`}
+              onClick={() => onPlayVideo?.(team.demo_video_url, team?.name)}
+            />
+          </Box>
+        )}
+
         {/* DevPost Project */}
         <Box sx={{ mb: 1 }}>
           {team?.devpost_link ? (
@@ -1083,7 +1097,20 @@ const TeamList = ({ teams, event_id, id, endDate, eventTimezone, constraints = {
   const [userProfile, setUserProfile] = useState(null);
   const [nonprofitMap, setNonprofitMap] = useState({});
   const [nonprofitsLoading, setNonprofitsLoading] = useState(false);
+  const [videoDialog, setVideoDialog] = useState({
+    open: false,
+    url: null,
+    teamName: null,
+  });
   const { isLoggedIn, accessToken } = useAuthInfo();
+
+  const handlePlayVideo = useCallback((url, teamName) => {
+    setVideoDialog({ open: true, url, teamName: teamName || null });
+  }, []);
+
+  const handleCloseVideoDialog = useCallback(() => {
+    setVideoDialog((prev) => ({ ...prev, open: false }));
+  }, []);
 
   // Check if team joining is enabled from constraints
   const teamJoinEnabled = constraints.team_join_enabled !== false; // Default to true if not specified
@@ -1409,10 +1436,38 @@ const TeamList = ({ teams, event_id, id, endDate, eventTimezone, constraints = {
               nonprofitMap={nonprofitMap}
               accessToken={accessToken}
               onCopyGithubUsername={handleCopyGithubUsername}
+              onPlayVideo={handlePlayVideo}
             />
           </Grid>        
         ))}
       </Grid>
+
+      <Dialog
+        open={videoDialog.open}
+        onClose={handleCloseVideoDialog}
+        maxWidth="md"
+        fullWidth
+        aria-labelledby="team-demo-video-title"
+      >
+        <DialogTitle id="team-demo-video-title" sx={{ pr: 6 }}>
+          {videoDialog.teamName ? `${videoDialog.teamName} demo` : "Team demo"}
+          <IconButton
+            aria-label="Close demo video"
+            onClick={handleCloseVideoDialog}
+            sx={{ position: "absolute", right: 8, top: 8 }}
+          >
+            <FaTimes />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          {videoDialog.url && (
+            <VideoDisplay
+              url={videoDialog.url}
+              title={videoDialog.teamName || "Team demo"}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
 
       <Snackbar
         open={snackbar.open}

--- a/src/components/TeamCreation/TeamStatusPanel.js
+++ b/src/components/TeamCreation/TeamStatusPanel.js
@@ -48,6 +48,7 @@ import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
 import StarIcon from '@mui/icons-material/Star';
 import Link from 'next/link';
+import LiteVideoThumbnail from '../VideoDisplay/LiteVideoThumbnail';
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(3),
@@ -244,6 +245,8 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
   const [selectedVideo, setSelectedVideo] = useState('');
   const [devpostSubmissions, setDevpostSubmissions] = useState({});
   const [devpostLoading, setDevpostLoading] = useState({});
+  const [demoVideoSubmissions, setDemoVideoSubmissions] = useState({});
+  const [demoVideoLoading, setDemoVideoLoading] = useState({});
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
 
   // Select a random waiting video on component mount
@@ -337,6 +340,74 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
   // Handle input change for DevPost URL
   const handleDevPostInputChange = (teamId, value) => {
     setDevpostSubmissions(prev => ({ ...prev, [teamId]: value }));
+  };
+
+  // Demo video URL: accept YouTube, Vimeo, Loom, or Google Drive (matches VideoDisplay providers)
+  const isValidDemoVideoUrl = (url) => {
+    if (!url) return false;
+    const trimmed = url.trim();
+    return (
+      /youtube\.com\/.+v=[\w-]{11}/i.test(trimmed) ||
+      /youtu\.be\/[\w-]{11}/i.test(trimmed) ||
+      /vimeo\.com\/\d+/i.test(trimmed) ||
+      /loom\.com\/(share|embed)\/[a-zA-Z0-9]+/i.test(trimmed) ||
+      /drive\.google\.com\/file\/d\//i.test(trimmed)
+    );
+  };
+
+  const handleDemoVideoInputChange = (teamId, value) => {
+    setDemoVideoSubmissions(prev => ({ ...prev, [teamId]: value }));
+  };
+
+  const handleDemoVideoSubmit = async (teamId) => {
+    const url = (demoVideoSubmissions[teamId] || '').trim();
+    if (!url) {
+      setSnackbar({ open: true, message: 'Please enter a video URL', severity: 'error' });
+      return;
+    }
+    if (!isValidDemoVideoUrl(url)) {
+      setSnackbar({
+        open: true,
+        message: 'Please enter a YouTube, Vimeo, Loom, or Google Drive video URL.',
+        severity: 'error',
+      });
+      return;
+    }
+
+    setDemoVideoLoading(prev => ({ ...prev, [teamId]: true }));
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/team/${teamId}/demo-video`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({ demo_video_url: url }),
+        }
+      );
+      if (!response.ok) throw new Error('Failed to update demo video');
+
+      // Mirror DevPost handler: snackbar success; team prop is owned by parent.
+      // Locally update the input value to the saved URL so the preview reflects truth.
+      setDemoVideoSubmissions(prev => ({ ...prev, [teamId]: url }));
+
+      setSnackbar({
+        open: true,
+        message: 'Demo video saved! Judges and visitors will see it on the event page.',
+        severity: 'success',
+      });
+    } catch (error) {
+      console.error('Error updating demo video URL:', error);
+      setSnackbar({
+        open: true,
+        message: 'Failed to update demo video. Please try again.',
+        severity: 'error',
+      });
+    } finally {
+      setDemoVideoLoading(prev => ({ ...prev, [teamId]: false }));
+    }
   };
 
   // Handle loading state with better UX
@@ -1340,7 +1411,101 @@ const TeamStatusPanel = ({ teams, loading, error, nonprofits, event, eventId, ac
                           Judging Criteria
                         </Button>
                       </Box>
-                    </Box>                    
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Box>
+
+              {/* Demo Video Section */}
+              <Box sx={{ mb: 3 }}>
+                <Typography
+                  variant="subtitle1"
+                  fontWeight="bold"
+                  gutterBottom
+                  sx={{ display: "flex", alignItems: "center" }}
+                >
+                  <YouTubeIcon fontSize="small" sx={{ mr: 1 }} /> Demo Video
+                </Typography>
+                <Card
+                  variant="outlined"
+                  sx={{ borderLeft: "4px solid #c4302b", borderRadius: 1 }}
+                >
+                  <CardContent>
+                    {team.demo_video_url ? (
+                      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                        <CheckIcon sx={{ color: 'success.main', mr: 1 }} />
+                        <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+                          Demo Video Linked
+                        </Typography>
+                      </Box>
+                    ) : (
+                      <Typography
+                        variant="body1"
+                        paragraph
+                        sx={{ color: "text.secondary", fontSize: "1.05rem" }}
+                      >
+                        🎬 <strong>Share Your Demo Video:</strong> Paste a public YouTube (or Vimeo / Loom / Google Drive) link so judges and visitors can watch your demo right from the event page.
+                      </Typography>
+                    )}
+
+                    <TextField
+                      fullWidth
+                      label="Demo Video URL"
+                      placeholder="https://youtu.be/..."
+                      value={demoVideoSubmissions[team.id] ?? team.demo_video_url ?? ''}
+                      onChange={(e) => handleDemoVideoInputChange(team.id, e.target.value)}
+                      error={
+                        !!demoVideoSubmissions[team.id] &&
+                        !isValidDemoVideoUrl(demoVideoSubmissions[team.id])
+                      }
+                      helperText={
+                        demoVideoSubmissions[team.id] && !isValidDemoVideoUrl(demoVideoSubmissions[team.id])
+                          ? "Enter a YouTube, Vimeo, Loom, or Google Drive URL."
+                          : team.demo_video_url && !demoVideoSubmissions[team.id]
+                          ? "Your current demo video is shown above."
+                          : "Public link only — viewers will not need to sign in."
+                      }
+                      InputProps={{
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <YouTubeIcon color="action" />
+                          </InputAdornment>
+                        ),
+                      }}
+                      sx={{ mb: 2 }}
+                    />
+
+                    {(() => {
+                      const previewUrl =
+                        (demoVideoSubmissions[team.id] && isValidDemoVideoUrl(demoVideoSubmissions[team.id])
+                          ? demoVideoSubmissions[team.id]
+                          : team.demo_video_url) || null;
+                      return previewUrl ? (
+                        <Box sx={{ mb: 2, maxWidth: 360 }}>
+                          <LiteVideoThumbnail
+                            url={previewUrl}
+                            label="Preview"
+                            onClick={() => window.open(previewUrl, '_blank', 'noopener,noreferrer')}
+                          />
+                        </Box>
+                      ) : null;
+                    })()}
+
+                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleDemoVideoSubmit(team.id)}
+                        disabled={
+                          demoVideoLoading[team.id] ||
+                          !demoVideoSubmissions[team.id] ||
+                          !isValidDemoVideoUrl(demoVideoSubmissions[team.id])
+                        }
+                        startIcon={demoVideoLoading[team.id] ? <CircularProgress size={16} /> : <SendIcon />}
+                      >
+                        {demoVideoLoading[team.id] ? 'Saving...' : (team.demo_video_url ? 'Update Video' : 'Save Video')}
+                      </Button>
+                    </Box>
                   </CardContent>
                 </Card>
               </Box>

--- a/src/components/VideoDisplay/LiteVideoThumbnail.js
+++ b/src/components/VideoDisplay/LiteVideoThumbnail.js
@@ -1,0 +1,139 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import PlayCircleFilledIcon from "@mui/icons-material/PlayCircleFilled";
+
+// Match VideoDisplay.js regex so we extract the same YouTube ID
+const YOUTUBE_REGEX =
+  /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/;
+const VIMEO_REGEX = /vimeo\.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^\/]*)\/videos\/|album\/(?:\d+)\/video\/|video\/|)(\d+)/;
+const LOOM_REGEX = /loom\.com\/(?:share|embed)\//;
+const DRIVE_REGEX = /drive\.google\.com\/file\/d\//;
+
+const providerLabel = (url) => {
+  if (!url) return null;
+  if (YOUTUBE_REGEX.test(url)) return "YouTube";
+  if (VIMEO_REGEX.test(url)) return "Vimeo";
+  if (LOOM_REGEX.test(url)) return "Loom";
+  if (DRIVE_REGEX.test(url)) return "Google Drive";
+  return null;
+};
+
+const LiteVideoThumbnail = ({
+  url,
+  onClick,
+  width = 320,
+  height = 180,
+  label = "Watch demo",
+}) => {
+  if (!url) return null;
+
+  const youtubeMatch = url.match(YOUTUBE_REGEX);
+  const youtubeId = youtubeMatch ? youtubeMatch[1] : null;
+  const provider = providerLabel(url);
+
+  const buttonStyles = {
+    position: "relative",
+    display: "block",
+    width: "100%",
+    maxWidth: width,
+    padding: 0,
+    margin: 0,
+    border: 0,
+    borderRadius: 1.5,
+    overflow: "hidden",
+    cursor: "pointer",
+    background: "#000",
+    "&:hover .lite-video-overlay-icon": {
+      transform: "translate(-50%, -50%) scale(1.1)",
+      opacity: 1,
+    },
+    "&:focus-visible": {
+      outline: "2px solid",
+      outlineColor: "primary.main",
+      outlineOffset: 2,
+    },
+  };
+
+  return (
+    <Box
+      component="button"
+      type="button"
+      onClick={onClick}
+      sx={buttonStyles}
+      aria-label={label}
+    >
+      <Box
+        sx={{
+          position: "relative",
+          width: "100%",
+          paddingBottom: "56.25%",
+          height: 0,
+          bgcolor: youtubeId ? "transparent" : "grey.900",
+        }}
+      >
+        {youtubeId ? (
+          <Box
+            component="img"
+            src={`https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            width={width}
+            height={height}
+            sx={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+              display: "block",
+            }}
+          />
+        ) : (
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "common.white",
+              gap: 0.5,
+            }}
+          >
+            <Typography variant="body2" sx={{ opacity: 0.85 }}>
+              {label}
+            </Typography>
+            {provider && (
+              <Typography variant="caption" sx={{ opacity: 0.6 }}>
+                {provider}
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        <Box
+          className="lite-video-overlay-icon"
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            color: "common.white",
+            filter: "drop-shadow(0 2px 6px rgba(0,0,0,0.5))",
+            opacity: 0.92,
+            transition: "transform 120ms ease, opacity 120ms ease",
+            pointerEvents: "none",
+          }}
+        >
+          <PlayCircleFilledIcon sx={{ fontSize: Math.min(64, height * 0.45) }} />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default LiteVideoThumbnail;

--- a/src/components/VideoDisplay/VideoDisplay.js
+++ b/src/components/VideoDisplay/VideoDisplay.js
@@ -93,6 +93,7 @@ const VideoDisplay = ({ url, title }) => {
           frameBorder="0"
           allow={videoConfig.allow}
           allowFullScreen
+          loading="lazy"
         />
       </VideoWrapper>
     </Box>

--- a/src/components/admin/TeamFieldPopover.js
+++ b/src/components/admin/TeamFieldPopover.js
@@ -1,0 +1,149 @@
+import React, { useState, useEffect } from "react";
+import {
+  Popover,
+  Box,
+  TextField,
+  Button,
+  Stack,
+  Typography,
+  CircularProgress,
+} from "@mui/material";
+import LiteVideoThumbnail from "../VideoDisplay/LiteVideoThumbnail";
+
+/**
+ * Inline quick-edit Popover for a single team field.
+ * Designed to anchor to a table cell (DOM element passed as anchorEl).
+ *
+ * Props:
+ *   open, anchorEl, onClose
+ *   team               — current team object (used for id + current value)
+ *   field              — db field key, e.g. "demo_video_url" or "devpost_link"
+ *   label              — TextField label
+ *   placeholder        — TextField placeholder
+ *   helperText         — TextField helperText
+ *   validate(value)    — optional (value) => string|null  (returns error msg or null)
+ *   previewKind        — "video" | "none"
+ *   onSave(team, partial)  — async; should perform the patch and resolve on success
+ */
+const TeamFieldPopover = ({
+  open,
+  anchorEl,
+  onClose,
+  team,
+  field,
+  label,
+  placeholder,
+  helperText,
+  validate,
+  previewKind = "none",
+  onSave,
+}) => {
+  const initial = team?.[field] || "";
+  const [value, setValue] = useState(initial);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setValue(team?.[field] || "");
+    }
+  }, [open, team, field]);
+
+  const validationError = validate ? validate(value) : null;
+  const trimmed = (value || "").trim();
+  const isDirty = trimmed !== (team?.[field] || "").trim();
+  const canSave = !saving && !validationError && isDirty;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      await onSave(team, { [field]: trimmed });
+      onClose();
+    } catch (err) {
+      // onSave is expected to surface its own error UI (snackbar); leave popover open.
+      console.error(`Failed to save ${field}:`, err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await onSave(team, { [field]: "" });
+      onClose();
+    } catch (err) {
+      console.error(`Failed to clear ${field}:`, err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      transformOrigin={{ vertical: "top", horizontal: "left" }}
+    >
+      <Box sx={{ p: 2, width: 360 }}>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          {team?.name ? `${team.name} — ${label}` : label}
+        </Typography>
+        <TextField
+          fullWidth
+          size="small"
+          autoFocus
+          label={label}
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          error={!!validationError}
+          helperText={validationError || helperText}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && canSave) {
+              e.preventDefault();
+              handleSave();
+            }
+          }}
+          sx={{ mb: 1.5 }}
+        />
+
+        {previewKind === "video" && trimmed && !validationError && (
+          <Box sx={{ mb: 1.5 }}>
+            <LiteVideoThumbnail url={trimmed} label="Preview" />
+          </Box>
+        )}
+
+        <Stack direction="row" spacing={1} justifyContent="flex-end">
+          {team?.[field] && (
+            <Button
+              size="small"
+              color="error"
+              onClick={handleClear}
+              disabled={saving}
+            >
+              Clear
+            </Button>
+          )}
+          <Button size="small" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            onClick={handleSave}
+            disabled={!canSave}
+            startIcon={saving ? <CircularProgress size={14} /> : null}
+          >
+            {saving ? "Saving" : "Save"}
+          </Button>
+        </Stack>
+      </Box>
+    </Popover>
+  );
+};
+
+export default TeamFieldPopover;

--- a/src/components/admin/TeamManagement.js
+++ b/src/components/admin/TeamManagement.js
@@ -66,7 +66,9 @@ import {
   FaExternalLinkAlt,
   FaCheckCircle,
   FaBug,
-  FaLink
+  FaLink,
+  FaVideo,
+  FaPlus
 } from 'react-icons/fa';
 import axios from 'axios';
 import { useAuthInfo } from '@propelauth/react';
@@ -74,7 +76,9 @@ import { useSnackbar } from 'notistack';
 import { useRouter } from 'next/router';
 import useHackathonEvents from '../../hooks/use-hackathon-events';
 import UserSearchDialog from './UserSearchDialog';
-import { TEAM_STATUS_OPTIONS, getStatusOption } from '../../constants/teamStatus';
+import TeamFieldPopover from './TeamFieldPopover';
+import LiteVideoThumbnail from '../VideoDisplay/LiteVideoThumbnail';
+import { TEAM_STATUS_OPTIONS, getStatusOption, WINNING_STATUSES, isWinningStatus } from '../../constants/teamStatus';
 
 // GitHub Issue Templates for different hackathon phases
 // Returns templates with event-specific URLs based on the provided eventId
@@ -293,6 +297,17 @@ const TeamManagement = ({ orgId }) => {
   const [expandedRepo, setExpandedRepo] = useState(null);
   const [githubIssueSummaries, setGithubIssueSummaries] = useState({}); // Add state for table issue summaries
 
+  // Status / completeness filter applied above the team table
+  const [activeFilter, setActiveFilter] = useState('all');
+
+  // Inline quick-edit popover (for video and devpost columns)
+  const [popoverState, setPopoverState] = useState({
+    open: false,
+    anchorEl: null,
+    team: null,
+    field: null,
+  });
+
   // Handle URL parameters and set initial state
   useEffect(() => {
     if (!router?.query) return;
@@ -353,31 +368,42 @@ const TeamManagement = ({ orgId }) => {
   }, [selectedHackathon]);
 
   console.log("Team Data:", teamData);
-  // Filter teams based on search term
+  // Filter teams based on search term + active filter chip
   useEffect(() => {
     if (!teams) return;
 
-    const filtered = teams.filter(
-      (team) => {
-        const searchLower = searchTerm.toLowerCase();
-        
-        // Check team name
-        const nameMatch = team.name?.toLowerCase().includes(searchLower);
-        
-        // Check slack channel
-        const slackMatch = team.slack_channel?.toLowerCase().includes(searchLower);
-        
-        // Check team members - with null-safe checks
-        const memberMatch = team.team_members?.some(
-          (member) => member?.name?.toLowerCase().includes(searchLower)
-        );
-        
-        return nameMatch || slackMatch || memberMatch;
+    const searchLower = searchTerm.toLowerCase();
+    const filtered = teams.filter((team) => {
+      // Search filter
+      const nameMatch = team.name?.toLowerCase().includes(searchLower);
+      const slackMatch = team.slack_channel?.toLowerCase().includes(searchLower);
+      const memberMatch = team.team_members?.some(
+        (member) => member?.name?.toLowerCase().includes(searchLower)
+      );
+      const matchesSearch = !searchLower || nameMatch || slackMatch || memberMatch;
+      if (!matchesSearch) return false;
+
+      // Chip filter
+      switch (activeFilter) {
+        case 'winning':
+          return isWinningStatus(team.status);
+        case 'in_review':
+          return (team.status || 'IN_REVIEW') === 'IN_REVIEW';
+        case 'active':
+          return team.active === 'True' || team.active === true;
+        case 'missing_devpost':
+          return !team.devpost_link;
+        case 'missing_video':
+          return !team.demo_video_url;
+        case 'all':
+        default:
+          return true;
       }
-    );
+    });
 
     setFilteredTeams(filtered);
-  }, [searchTerm, teams]);
+    setPage(0);
+  }, [searchTerm, teams, activeFilter]);
 
   // Sort teams when sortConfig changes
   useEffect(() => {
@@ -583,35 +609,87 @@ const TeamManagement = ({ orgId }) => {
     }));
   };
 
-  // Save team updates
+  // Low-level PATCH helper used by both the full edit Dialog save and inline Popover quick-edits.
+  // `partial` should include `id` and whatever fields to update. Caller is responsible for
+  // showing snackbars and refreshing list state if it cares about them.
+  const patchTeam = useCallback(async (partial) => {
+    const response = await axios.patch(
+      `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/team/edit`,
+      partial,
+      {
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "content-type": "application/json",
+          "X-Org-Id": orgId,
+        },
+      }
+    );
+    if (!response.data?.success) {
+      throw new Error(response.data?.message || "Update failed");
+    }
+    return response.data;
+  }, [accessToken, orgId]);
+
+  // Save team updates from the full edit Dialog
   const handleSaveTeam = async () => {
     setLoading(true);
     try {
-      const response = await axios.patch(
-        `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/team/edit`,        
-        {
-            ...teamData,
-            active: teamData.active ? "True" : "False",          
-        },
-        {
-          headers: {
-            authorization: `Bearer ${accessToken}`,
-            "content-type": "application/json",
-            "X-Org-Id": orgId,
-          },                
-        });
-
-      if (response.data && response.data.success) {
-        enqueueSnackbar("Team updated successfully", { variant: "success" });
-        setEditDialogOpen(false);
-        fetchTeams(selectedHackathon);
-      }
+      await patchTeam({
+        ...teamData,
+        active: teamData.active ? "True" : "False",
+      });
+      enqueueSnackbar("Team updated successfully", { variant: "success" });
+      setEditDialogOpen(false);
+      fetchTeams(selectedHackathon);
     } catch (error) {
       console.error("Error updating team:", error);
       enqueueSnackbar("Failed to update team", { variant: "error" });
     } finally {
       setLoading(false);
     }
+  };
+
+  // Optimistic inline-edit save used by TeamFieldPopover.
+  // Updates the local teams list immediately so the table reflects the change without a full refetch.
+  const handleQuickPatch = useCallback(async (team, partial) => {
+    try {
+      await patchTeam({ id: team.id, ...partial });
+      setTeams((prev) =>
+        prev.map((t) => (t.id === team.id ? { ...t, ...partial } : t))
+      );
+      enqueueSnackbar("Team updated", { variant: "success" });
+    } catch (error) {
+      console.error("Quick-edit failed:", error);
+      enqueueSnackbar("Failed to update team", { variant: "error" });
+      throw error;
+    }
+  }, [patchTeam, enqueueSnackbar]);
+
+  // Demo-video URL validator shared by the Popover and the full edit Dialog
+  const validateDemoVideoUrl = (value) => {
+    if (!value) return null; // empty = clear (allowed)
+    const trimmed = value.trim();
+    if (trimmed.length > 500) return "URL too long (500 char max).";
+    const valid =
+      /youtube\.com\/.+v=[\w-]{11}/i.test(trimmed) ||
+      /youtu\.be\/[\w-]{11}/i.test(trimmed) ||
+      /vimeo\.com\/\d+/i.test(trimmed) ||
+      /loom\.com\/(share|embed)\/[a-zA-Z0-9]+/i.test(trimmed) ||
+      /drive\.google\.com\/file\/d\//i.test(trimmed);
+    return valid ? null : "Enter a YouTube, Vimeo, Loom, or Google Drive URL.";
+  };
+
+  const openVideoPopover = (event, team) => {
+    setPopoverState({
+      open: true,
+      anchorEl: event.currentTarget,
+      team,
+      field: "demo_video_url",
+    });
+  };
+
+  const closePopover = () => {
+    setPopoverState((prev) => ({ ...prev, open: false }));
   };
 
   // Send message to team's slack channel
@@ -1417,6 +1495,53 @@ const TeamManagement = ({ orgId }) => {
 
                 <TextField
                   fullWidth
+                  label="Demo Video URL"
+                  value={teamData.demo_video_url || ""}
+                  onChange={(e) =>
+                    handleTeamDataChange("demo_video_url", e.target.value)
+                  }
+                  placeholder="https://youtu.be/..."
+                  error={!!validateDemoVideoUrl(teamData.demo_video_url)}
+                  helperText={
+                    validateDemoVideoUrl(teamData.demo_video_url) ||
+                    "YouTube, Vimeo, Loom, or Google Drive"
+                  }
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <FaVideo />
+                      </InputAdornment>
+                    ),
+                    endAdornment: teamData.demo_video_url && (
+                      <InputAdornment position="end">
+                        <IconButton
+                          size="small"
+                          component="a"
+                          href={teamData.demo_video_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          color="primary"
+                        >
+                          <FaExternalLinkAlt size={14} />
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                {teamData.demo_video_url && !validateDemoVideoUrl(teamData.demo_video_url) && (
+                  <Box sx={{ maxWidth: 320 }}>
+                    <LiteVideoThumbnail
+                      url={teamData.demo_video_url}
+                      label="Preview"
+                      onClick={() =>
+                        window.open(teamData.demo_video_url, '_blank', 'noopener,noreferrer')
+                      }
+                    />
+                  </Box>
+                )}
+
+                <TextField
+                  fullWidth
                   label="Admin Notes (Private)"
                   value={teamData.admin_notes || ""}
                   onChange={(e) =>
@@ -2022,6 +2147,36 @@ const TeamManagement = ({ orgId }) => {
             />
           </Grid>
         </Grid>
+
+        {/* Filter chips — quick scoping for demo/judging-day workflows */}
+        {selectedHackathon && (
+          <Box sx={{ mt: 2, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+            <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+              Show:
+            </Typography>
+            {[
+              { key: 'all',             label: 'All' },
+              { key: 'winning',         label: 'Winning' },
+              { key: 'in_review',       label: 'In review' },
+              { key: 'active',          label: 'Active' },
+              { key: 'missing_devpost', label: 'Missing DevPost' },
+              { key: 'missing_video',   label: 'Missing Video' },
+            ].map((f) => {
+              const selected = activeFilter === f.key;
+              return (
+                <Chip
+                  key={f.key}
+                  label={f.label}
+                  size="small"
+                  clickable
+                  color={selected ? 'primary' : 'default'}
+                  variant={selected ? 'filled' : 'outlined'}
+                  onClick={() => setActiveFilter(f.key)}
+                />
+              );
+            })}
+          </Box>
+        )}
       </Paper>
 
       {loading && !editDialogOpen ? (
@@ -2118,6 +2273,7 @@ const TeamManagement = ({ orgId }) => {
                     <TableCell>Members</TableCell>
                     <TableCell>GitHub</TableCell>
                     <TableCell>DevPost</TableCell>
+                    <TableCell>Demo Video</TableCell>
                     <TableCell>Nonprofit</TableCell>
                     <TableCell>Actions</TableCell>
                   </TableRow>
@@ -2215,6 +2371,28 @@ const TeamManagement = ({ orgId }) => {
                             </Link>
                           ) : (
                             <Typography variant="body2" color="text.secondary">—</Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {team.demo_video_url ? (
+                            <Box sx={{ width: 96 }}>
+                              <LiteVideoThumbnail
+                                url={team.demo_video_url}
+                                width={96}
+                                height={54}
+                                label="Edit demo video"
+                                onClick={(e) => openVideoPopover(e, team)}
+                              />
+                            </Box>
+                          ) : (
+                            <Button
+                              size="small"
+                              variant="outlined"
+                              startIcon={<FaPlus size={10} />}
+                              onClick={(e) => openVideoPopover(e, team)}
+                            >
+                              Add
+                            </Button>
                           )}
                         </TableCell>
                         <TableCell>
@@ -2722,6 +2900,37 @@ const TeamManagement = ({ orgId }) => {
           }}
         />
       )}
+
+      {/* Inline quick-edit popover (video / devpost) */}
+      <TeamFieldPopover
+        open={popoverState.open}
+        anchorEl={popoverState.anchorEl}
+        onClose={closePopover}
+        team={popoverState.team}
+        field={popoverState.field}
+        label={
+          popoverState.field === 'demo_video_url'
+            ? 'Demo Video URL'
+            : popoverState.field === 'devpost_link'
+            ? 'DevPost Link'
+            : 'Value'
+        }
+        placeholder={
+          popoverState.field === 'demo_video_url'
+            ? 'https://youtu.be/...'
+            : popoverState.field === 'devpost_link'
+            ? 'https://devpost.com/software/...'
+            : ''
+        }
+        helperText={
+          popoverState.field === 'demo_video_url'
+            ? 'YouTube, Vimeo, Loom, or Google Drive'
+            : ''
+        }
+        validate={popoverState.field === 'demo_video_url' ? validateDemoVideoUrl : undefined}
+        previewKind={popoverState.field === 'demo_video_url' ? 'video' : 'none'}
+        onSave={handleQuickPatch}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Adds a per-team **demo video** (YouTube / Vimeo / Loom / Google Drive) across the public event pages, the results page, the hacker-facing \`/manageteam\` form, and the \`/admin/teams\` console — paired with a focused round of admin UX polish that materially helps during demo/judging day.

Pairs with backend PR [opportunity-hack/backend-ohack.dev#217](https://github.com/opportunity-hack/backend-ohack.dev/pull/217), which adds \`demo_video_url\` to \`edit_team()\` and the \`POST /api/team/<teamid>/demo-video\` self-serve endpoint.

## What changed

**Public surfaces (CWV-safe — no eager iframes)**
- \`TeamList\` on \`/hack/[event_id]\` renders a new \`LiteVideoThumbnail\` per card (single lazy \`<img>\` of the YouTube hqdefault.jpg, NOT an iframe). Click opens a single page-level \`<Dialog>\` with the existing \`VideoDisplay\`. Per-card iframes were rejected — 30+ embeds would push ~45 MB and trash LCP/CLS.
- \`HackathonResults\` on \`/hack/[id]/results\` embeds the demo inline (3-5 winner cards only; \`VideoDisplay\` iframe now has \`loading=\"lazy\"\`).

**Hacker self-serve (\`/hack/[event_id]/manageteam\`)**
- New Demo Video section in \`TeamStatusPanel\` beside the existing DevPost section.
- Validates URL is one of the 4 supported providers client-side, posts to the new backend endpoint, and shows a live \`LiteVideoThumbnail\` preview.

**Admin (\`/admin/teams\`)** — scoped polish, not a redesign
- New **Demo Video column** in the team table — thumbnail when set, \"+ Add\" CTA when missing.
- New **inline-edit Popover** (\`TeamFieldPopover\`) for the column: paste a URL, see a live preview, save without opening the full 5-tab Dialog. Component is parameterized so it can be reused for the DevPost column later.
- New **filter chip row** above the table: \`All\` / \`Winning\` / \`In review\` / \`Active\` / \`Missing DevPost\` / \`Missing Video\`. Pure client-side over the existing \`filteredTeams\` array.
- New **Demo Video URL TextField** in the full edit Dialog with live preview underneath.
- Extracted a \`patchTeam(partial)\` helper so the full Dialog save and the inline Popover share one PATCH path; quick-edits update local state optimistically.

**Shared component**
- \`LiteVideoThumbnail\` (\`src/components/VideoDisplay/LiteVideoThumbnail.js\`) — extracts YouTube IDs with the same regex \`VideoDisplay\` uses; renders the YouTube hqdefault.jpg with \`loading=\"lazy\" decoding=\"async\"\` + explicit width/height. Vimeo/Loom/Drive/unknown providers fall back to a generic dark \"Watch demo\" tile (no per-render network hop).

## Why

- \"Show me the team's demo\" is the single most common ask during and after a hackathon — judges, sponsors, social media. Threading it through the existing event/results pages removes the \"hunt for the DevPost\" step.
- Admins needed a way to fix up missing videos quickly without re-opening the multi-tab edit Dialog every time; the inline Popover + Missing Video chip is the high-leverage flow.

## Reviewer notes

- **No new collection / no migration.** Additive \`demo_video_url\` string + companion \`demo_video_url_submitted\` ISO timestamp on first set. Mirrors the \`devpost_link\` shape exactly.
- **CWV.** Network inspection on \`/hack/[event_id]\` should show NO \`youtube.com/embed\` requests on first load even when many teams have videos — only the lazy thumbnail images.
- **Admin UX is intentionally scoped polish.** No drawer redesign, no kanban view, no virtualization — the existing table + Dialog still work; the additions are a column + chips + Popover. Easy to extend the Popover to more fields later.
- The hacker self-serve endpoint mirrors \`/api/team/<id>/devpost\` exactly (auth-required, no admin permission). Existing \`PATCH /api/team/edit\` continues to gate on \`volunteer.admin\`.

## Test plan

- [ ] **Admin column + Popover** — \`/admin/teams?event_id=467ceb62c95611f09ff7dead62e9ece0\` shows the Demo Video column; click \"+ Add\" → Popover → paste a YouTube URL → preview appears → Save → row's thumbnail updates without opening the full Dialog.
- [ ] **Admin filter chips** — toggle \"Missing Video\" → only teams without a URL show; toggle \"Winning\" → only winning-status teams show; chip toggle resets pagination.
- [ ] **Admin full Dialog** — open edit Dialog on a team; confirm new Demo Video URL TextField in Team Details, live preview, open-in-new-tab adornment, validation when given a non-supported URL.
- [ ] **Hacker self-serve** — as a logged-in team member, \`/hack/2026_spring_wics_asu/manageteam\` → paste a YouTube URL → Save → confirm preview renders and admin column reflects it.
- [ ] **Public event page** — \`/hack/2026_spring_wics_asu\` — find a team with a video. Confirm thumbnail tile renders, and in DevTools Network there are **no** \`youtube.com/embed\` requests on first load. Click thumbnail → Dialog opens, iframe loads, video plays.
- [ ] **Results page** — \`/hack/2026_spring_wics_asu/results\` — WinnerCard shows inline embed; inspect element confirms iframe has \`loading=\"lazy\"\`.
- [ ] **Graceful fallback** — set a team's \`demo_video_url\` to a malformed string → generic \"Watch demo\" tile renders without crashing; clicking opens Dialog with \`VideoDisplay\`'s \"Unsupported video URL\" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)