### PR TITLE
[Blog] /admin/blog — full CMS with markdown, SEO, drafts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,37 @@ Static pages targeting organic search impressions. Each uses `getStaticProps` wi
 ## Pillar Pages
 SEO landing pages at `/coding-for-nonprofits` (service: free software model) and `/hackathon-for-social-good` (event: the hackathon experience). Cross-linked from homepage (`index.js` pillar link buttons), about page, and each other. Both follow the same pattern: `getStaticProps` with full OG/Twitter meta + structured data (`WebPage`, `BreadcrumbList`, `FAQPage`). The hackathon page also includes an `Event` schema node for Fall 2026. Do not duplicate content between the two — keep the service/event distinction.
 
+## Blog Admin (`/admin/blog`)
+Full CMS for the `news` Firestore collection. Mirrors the `/admin/hackathons/[event_id]` pattern (sidebar + hybrid autosave/explicit save).
+
+- **List page**: `src/pages/admin/blog/index.js`. Search across title/description/author/tags, status filter chips (All / Published / Drafts / Archived), table with status chips and inline actions (edit, view-public, delete). "+ New post" creates a draft via `POST /api/messages/admin/news` and redirects to the editor. Delete is hard delete via `DELETE /api/messages/admin/news/<id>` (Firestore doc removed).
+- **Editor**: `src/pages/admin/blog/[id].js` + `src/components/admin/blog-edit/` (mirrors `hackathon-edit/`):
+  - `useBlogAdmin` — hybrid save: `content` (title/body/featured_image) and `seo` (all seo.* fields) sections require **explicit Save**; `metadata` (author, tags, status, slug, published_at) autosaves on change (debounced 1.5s). Status change uses a dedicated `setStatus()` that bypasses the debounce so the publish/unpublish chip updates immediately. `beforeunload` warns when any explicit section is dirty.
+  - Reuses `SectionContainer` from `hackathon-edit/` for the sticky save bar.
+  - URL state: `?section=content|seo|metadata` (shallow router replace).
+- **Body format**: posts have `content_format` ("html" | "markdown"). Markdown is authored with `@uiw/react-md-editor` (dynamic, ssr:false) and rendered with `react-markdown` in `SingleNews.js`. Switching from markdown to plain in the editor does NOT delete the markdown — both fields persist. Legacy posts default to "html" so they render unchanged.
+- **Backend routes** (in `backend-ohack.dev/api/messages/messages_views.py`):
+  - `GET /api/messages/admin/news?limit=&status=` — admin list (includes drafts/archived). Service: `admin_list_news`.
+  - `POST /api/messages/admin/news` — create. Service: `admin_create_news`. Skips OpenAI image generation when `featured_image` is supplied. Stamps `slack_ts=time.time()` if missing so existing ordering keeps working.
+  - `PATCH /api/messages/admin/news/<id>` — partial update. Service: `admin_update_news`. Only keys in `_ADMIN_ALLOWED_KEYS` get through; clears `get_news` cache.
+  - `DELETE /api/messages/admin/news/<id>` — hard delete. Service: `admin_delete_news`.
+  - All four are auth-gated with `volunteer.admin`. The original public `POST /api/messages/news` (X-Api-Key) is **untouched** — the Slack integration depends on it.
+- **Public `get_news` filtering**: `services/news_service.py::_is_publicly_visible` filters out `status in ("draft", "archived")` for both the list and single-item routes. Over-fetches by 3x so the limit-after-filter still returns enough.
+- **New optional fields on a news doc** (all optional; legacy docs without them stay valid):
+  - `content_markdown`, `content_format` ("html"|"markdown")
+  - `featured_image` (overrides the auto-generated `image`)
+  - `author: { name, email, propel_user_id, db_id }`
+  - `tags: string[]`, `slug`, `status` ("draft"|"published"|"archived"), `published_at` (ISO)
+  - `seo: { title, description, keywords[], canonical, og_image }`
+  - `last_updated_by`, `created_by`
+- **Public-side honoring** (`src/pages/blog/[blog_id].js` + `src/components/News/SingleNews.js`):
+  - When `seo.title|description|canonical|og_image` are set, they win; otherwise current auto-derivation is the fallback.
+  - When `content_format === "markdown"`, the body renders via `<ReactMarkdown>`; when not, the legacy `description` plain-text path renders.
+  - `tags[]` render as clickable chips; falls back to hashtag regex extraction when absent.
+  - `published_at` → `article:published_time` (falls back to `slack_ts_human_readable`).
+  - Markdown `<img>`s render with `loading="lazy"` and `max-width: 100%; height: auto` to preserve CWV.
+- **GA tracking**: admin actions emit events under `EventCategory.ADMIN` — `admin_blog_view_list`, `admin_blog_create`, `admin_blog_edit_save` (per section), `admin_blog_publish`, `admin_blog_unpublish`, `admin_blog_archive`, `admin_blog_delete`, `admin_blog_open_ga`. Public-side tracking is unchanged (lives in `SingleNews.js` `gaButton` helper + `ScrollTracker`).
+
 ## Social Media Integration
 
 ### Overview

--- a/src/components/News/SingleNews.js
+++ b/src/components/News/SingleNews.js
@@ -1,13 +1,14 @@
 import Grid from '@mui/material/Grid';
-import {  
+import dynamic from 'next/dynamic';
+import {
   NewsLinkButton,
-  SlackButton,  
+  SlackButton,
   TitleStyled,
   TitleContainer,
   CaptionContainer,
   MoreNewsStyle,
   ButtonContainersSmall,
-  TextMuted,  
+  TextMuted,
   EventCards,
   BlankContainer,
 } from './styles';
@@ -15,7 +16,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import { useState, useEffect } from 'react';
-import { Snackbar } from '@mui/material';
+import { Snackbar, Box, Chip } from '@mui/material';
 import { Alert } from '@mui/material';
 import { Typography } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
@@ -27,9 +28,25 @@ import { normalizeImageUrl } from '../../lib/imageUtils'
 
 import Link from 'next/link';
 
-function SingleNews( {newsItem} ) {
-  console.log("NEWS ITEM:", newsItem)
+// Lazy-load the markdown renderer so the legacy HTML path stays light.
+const ReactMarkdown = dynamic(() => import('react-markdown'), { ssr: true });
 
+const markdownImageRenderer = ({ src, alt }) => (
+  // eslint-disable-next-line @next/next/no-img-element
+  <img
+    src={src}
+    alt={alt || ''}
+    loading="lazy"
+    decoding="async"
+    style={{ maxWidth: '100%', height: 'auto', display: 'block', margin: '1em 0' }}
+  />
+);
+
+const markdownLinkRenderer = ({ href, children }) => (
+  <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>
+);
+
+function SingleNews( {newsItem} ) {
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
   
@@ -70,74 +87,155 @@ function SingleNews( {newsItem} ) {
     });    
   };
 
+  const heroImage = newsItem.featured_image || newsItem.image;
+  const isMarkdown = newsItem.content_format === 'markdown' && newsItem.content_markdown;
+  const publishedDate = newsItem.published_at || newsItem.slack_ts_human_readable;
+  const author = newsItem.author?.name;
+  const tags = Array.isArray(newsItem.tags) ? newsItem.tags : [];
+  const hasSlackPermalink = !!newsItem.slack_permalink;
+
   return (
-    <EventCards container direction='row' style={{ margin: '2px', padding: '8px' }}>      
-        
-        <Link prefetch={false} href="/blog">        
-        <MoreNewsStyle>        
+    <EventCards container direction='row' style={{ margin: '2px', padding: '8px' }}>
+
+        <Link prefetch={false} href="/blog">
+        <MoreNewsStyle>
           <ArrowBackIcon/>
           Back to news
-        </MoreNewsStyle>   
+        </MoreNewsStyle>
         </Link>
 
-        <Link prefetch={false} href="/about">        
-        <MoreNewsStyle style={{marginLeft:'5px'}}>        
+        <Link prefetch={false} href="/about">
+        <MoreNewsStyle style={{marginLeft:'5px'}}>
           <InfoIcon/>&nbsp;
           Read more about us
-        </MoreNewsStyle>   
+        </MoreNewsStyle>
         </Link>
 
         <BlankContainer xs={12} md={12} lg={12}  key={newsItem.id}>
-          <TitleContainer container>          
-            <Grid size={{ xs: 12, md: 12, lg: 12 }}>                          
-              {newsItem?.image && (
+          <TitleContainer container>
+            <Grid size={{ xs: 12, md: 12, lg: 12 }}>
+              {heroImage && (
               <Image
-                src={normalizeImageUrl(newsItem.image)}
+                src={normalizeImageUrl(heroImage)}
                 alt={newsItem.title}
 
-                height={150}
-                width={150}
-                                
+                height={isMarkdown ? 320 : 150}
+                width={isMarkdown ? 640 : 150}
+
                 style={{
                   marginBottom: '0.5em',
-                  maxWidth: '100%',                  
+                  maxWidth: '100%',
+                  height: 'auto',
+                  borderRadius: isMarkdown ? 8 : 0,
                 }}
-              />                              
+              />
               )}
-                  
+
                 <Typography variant="h2">
                     {newsItem.title}
-                </Typography>                
-            
-                <Typography>This was summarized by AI, see the Slack post for specific details.</Typography>
+                </Typography>
+
+                {!isMarkdown && hasSlackPermalink && (
+                  <Typography>This was summarized by AI, see the Slack post for specific details.</Typography>
+                )}
                 <TitleStyled variant="h1">
 
-                <SlackButton onClick={() => gaButton("button_slack_post", newsItem.slack_permalink)} target="_blank" variant="outlined" >
-                  <Link href={newsItem.slack_permalink} target='_blank'>
-                    Original Slack Post
-                  </Link>
-                </SlackButton>
-              
-                <FileCopyIcon // Add the FileCopy icon button
-                  onClick={() => handleCopy(`${newsItem.title} ${newsItem.description}`)} // Call handleCopy function on click
+                {hasSlackPermalink && (
+                  <SlackButton onClick={() => gaButton("button_slack_post", newsItem.slack_permalink)} target="_blank" variant="outlined" >
+                    <Link href={newsItem.slack_permalink} target='_blank'>
+                      Original Slack Post
+                    </Link>
+                  </SlackButton>
+                )}
+
+                <FileCopyIcon
+                  onClick={() => handleCopy(`${newsItem.title} ${newsItem.description}`)}
                   style={{ cursor: 'pointer', marginLeft: '5px' }}
+                  aria-label="Copy blog excerpt"
                 />
-                
-                
+
+
 
               </TitleStyled>
-              
+
             </Grid>
             <Grid size={{ xs: 12, md: 12, lg: 12 }}>
               <TextMuted>
                 <CalendarTodayIcon style={{ marginRight: '5px' }} />
-                {newsItem.slack_ts_human_readable}
+                {publishedDate}
+                {author && <span style={{ marginLeft: 12 }}>· by {author}</span>}
               </TextMuted>
             </Grid>
           </TitleContainer>
-          <CaptionContainer style={{ fontSize: '15px'}}>
-            {newsItem.description}
-          </CaptionContainer>
+
+          {isMarkdown ? (
+            <Box
+              sx={{
+                fontSize: '17px',
+                lineHeight: 1.7,
+                color: 'text.primary',
+                '& h1, & h2, & h3': { mt: 3, mb: 1.5, fontWeight: 600 },
+                '& h1': { fontSize: '2rem' },
+                '& h2': { fontSize: '1.5rem' },
+                '& h3': { fontSize: '1.2rem' },
+                '& p': { my: 1.5 },
+                '& ul, & ol': { pl: 3, my: 1.5 },
+                '& li': { mb: 0.5 },
+                '& a': { color: 'primary.main', textDecoration: 'underline' },
+                '& blockquote': {
+                  borderLeft: '4px solid',
+                  borderColor: 'primary.main',
+                  pl: 2,
+                  ml: 0,
+                  fontStyle: 'italic',
+                  color: 'text.secondary',
+                },
+                '& code': {
+                  bgcolor: 'grey.100',
+                  px: 0.5,
+                  borderRadius: 0.5,
+                  fontFamily: 'monospace',
+                  fontSize: '0.95em',
+                },
+                '& pre': {
+                  bgcolor: 'grey.900',
+                  color: 'common.white',
+                  p: 2,
+                  borderRadius: 1,
+                  overflow: 'auto',
+                  '& code': { bgcolor: 'transparent', color: 'inherit', p: 0 },
+                },
+                '& hr': { my: 3, borderColor: 'divider' },
+              }}
+            >
+              <ReactMarkdown
+                components={{ img: markdownImageRenderer, a: markdownLinkRenderer }}
+              >
+                {newsItem.content_markdown}
+              </ReactMarkdown>
+            </Box>
+          ) : (
+            <CaptionContainer style={{ fontSize: '15px'}}>
+              {newsItem.description}
+            </CaptionContainer>
+          )}
+
+          {tags.length > 0 && (
+            <Box mt={2} display="flex" flexWrap="wrap" gap={1}>
+              {tags.map((tag) => (
+                <Link key={tag} href={`/blog?tag=${encodeURIComponent(tag)}`} passHref>
+                  <Chip
+                    label={`#${tag}`}
+                    clickable
+                    color="primary"
+                    variant="outlined"
+                    size="small"
+                    onClick={() => gaButton("tag_click", tag)}
+                  />
+                </Link>
+              ))}
+            </Box>
+          )}
           {
             // If there are newsItem.links, render them as a button where name is the title, and url is the <Link> href attribute
             // Filter for links where name starts with #

--- a/src/components/admin/AdminNavigation.js
+++ b/src/components/admin/AdminNavigation.js
@@ -41,6 +41,7 @@ import {
   PostAdd as RequestIcon,
   ContactMail as ContactMailIcon,
   Storefront as StorefrontIcon,
+  Article as ArticleIcon,
 } from "@mui/icons-material";
 import HandshakeIcon from '@mui/icons-material/Handshake';
 
@@ -153,6 +154,11 @@ const adminPages = [
     path: "/admin/social-media",
     label: "Social Media",
     icon: <ShareIcon style={{ color: "#1DA1F2" }} />
+  },
+  {
+    path: "/admin/blog",
+    label: "Blog",
+    icon: <ArticleIcon style={{ color: "#093170" }} />
   },
   // {
   //   path: "/admin/store",

--- a/src/components/admin/blog-edit/BlogAdminLayout.js
+++ b/src/components/admin/blog-edit/BlogAdminLayout.js
@@ -1,0 +1,202 @@
+import React from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Stack,
+  Tooltip,
+  Typography,
+  Drawer,
+  useMediaQuery,
+} from "@mui/material";
+import {
+  ArrowBack as BackIcon,
+  Launch as LaunchIcon,
+  Menu as MenuIcon,
+  FiberManualRecord as DotIcon,
+} from "@mui/icons-material";
+import { useTheme } from "@mui/material/styles";
+import { SECTIONS } from "./sectionsManifest";
+import SaveIndicator from "./SaveIndicator";
+
+const SIDEBAR_WIDTH = 220;
+
+const statusChipColor = (status) => {
+  if (status === "draft") return "warning";
+  if (status === "archived") return "default";
+  return "success";
+};
+
+const SidebarContent = ({ activeSection, onPick, dirtySections }) => (
+  <Box sx={{ width: SIDEBAR_WIDTH, py: 2 }}>
+    <Typography variant="overline" sx={{ px: 2, color: "text.secondary", display: "block" }}>
+      Sections
+    </Typography>
+    <List dense>
+      {SECTIONS.map(({ slug, label, icon: Icon }) => {
+        const active = activeSection === slug;
+        const dirty = dirtySections?.has(slug);
+        return (
+          <ListItemButton
+            key={slug}
+            selected={active}
+            onClick={() => onPick(slug)}
+            sx={{
+              mx: 1,
+              borderRadius: 1,
+              my: 0.25,
+              "&.Mui-selected": {
+                bgcolor: "primary.50",
+                color: "primary.main",
+                "& .MuiListItemIcon-root": { color: "primary.main" },
+              },
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 36 }}>
+              <Icon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText
+              primary={label}
+              primaryTypographyProps={{ fontSize: "0.92rem", fontWeight: active ? 600 : 500 }}
+            />
+            {dirty && (
+              <Tooltip title="Unsaved changes">
+                <DotIcon sx={{ fontSize: 10, color: "warning.main" }} />
+              </Tooltip>
+            )}
+          </ListItemButton>
+        );
+      })}
+    </List>
+  </Box>
+);
+
+const BlogAdminLayout = ({
+  post,
+  activeSection,
+  onSelectSection,
+  saveState,
+  dirtySections,
+  onBack,
+  children,
+}) => {
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.down("md"));
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
+
+  const postId = post?.id;
+  const title = post?.title || "Untitled post";
+  const status = post?.status || "published";
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        minHeight: "calc(100vh - 100px)",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 2,
+        overflow: "hidden",
+        bgcolor: "background.paper",
+      }}
+    >
+      {isSmall ? (
+        <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)}>
+          <SidebarContent
+            activeSection={activeSection}
+            onPick={(s) => {
+              onSelectSection(s);
+              setDrawerOpen(false);
+            }}
+            dirtySections={dirtySections}
+          />
+        </Drawer>
+      ) : (
+        <Box
+          sx={{
+            width: SIDEBAR_WIDTH,
+            flexShrink: 0,
+            borderRight: "1px solid",
+            borderColor: "divider",
+            bgcolor: "grey.50",
+          }}
+        >
+          <SidebarContent
+            activeSection={activeSection}
+            onPick={onSelectSection}
+            dirtySections={dirtySections}
+          />
+        </Box>
+      )}
+
+      <Box sx={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <Box
+          sx={{
+            position: "sticky",
+            top: 0,
+            zIndex: 2,
+            px: { xs: 2, md: 3 },
+            py: 2.25,
+            minHeight: 64,
+            display: "flex",
+            alignItems: "center",
+            gap: 2,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            bgcolor: "background.paper",
+            flexShrink: 0,
+          }}
+        >
+          {isSmall && (
+            <IconButton size="small" onClick={() => setDrawerOpen(true)} aria-label="Open sections">
+              <MenuIcon />
+            </IconButton>
+          )}
+          <Tooltip title="Back to blog list">
+            <IconButton size="small" onClick={onBack} aria-label="Back">
+              <BackIcon />
+            </IconButton>
+          </Tooltip>
+          <Stack direction="row" alignItems="center" spacing={1.5} sx={{ flex: 1, minWidth: 0 }}>
+            <Typography
+              variant="h6"
+              component="h1"
+              sx={{ fontWeight: 700, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}
+            >
+              {title}
+            </Typography>
+            <Chip
+              label={status === "published" ? "Published" : status === "draft" ? "Draft" : "Archived"}
+              size="small"
+              color={statusChipColor(status)}
+              variant={status === "draft" ? "filled" : "outlined"}
+            />
+          </Stack>
+          <Stack direction="row" alignItems="center" spacing={1.5}>
+            <SaveIndicator saveState={saveState} dirtySections={dirtySections} />
+            {postId && (
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<LaunchIcon />}
+                href={`/blog/${postId}`}
+                target="_blank"
+              >
+                View public page
+              </Button>
+            )}
+          </Stack>
+        </Box>
+
+        <Box sx={{ p: { xs: 2, md: 3 }, flex: 1, overflowY: "auto" }}>{children}</Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default BlogAdminLayout;

--- a/src/components/admin/blog-edit/SaveIndicator.js
+++ b/src/components/admin/blog-edit/SaveIndicator.js
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+import { Box, Chip, Tooltip } from "@mui/material";
+import {
+  CloudDone as SavedIcon,
+  CloudSync as SavingIcon,
+  CloudOff as ErrorIcon,
+  PauseCircleOutline as PausedIcon,
+} from "@mui/icons-material";
+import { SECTION_LABELS } from "./useBlogAdmin";
+
+const formatRelative = (ts) => {
+  if (!ts) return "";
+  const secs = Math.max(1, Math.round((Date.now() - ts) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  return new Date(ts).toLocaleTimeString();
+};
+
+const SaveIndicator = ({ saveState, dirtySections }) => {
+  const [, force] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => force((n) => n + 1), 15000);
+    return () => clearInterval(t);
+  }, []);
+
+  if (dirtySections && dirtySections.size > 0) {
+    const labels = Array.from(dirtySections).map((s) => SECTION_LABELS[s] || s).join(", ");
+    return (
+      <Tooltip title="Autosave is paused while you have unsaved manual changes. Save or discard them to resume.">
+        <Chip
+          icon={<PausedIcon />}
+          label={`Unsaved · ${labels}`}
+          color="warning"
+          size="small"
+          variant="outlined"
+        />
+      </Tooltip>
+    );
+  }
+
+  if (saveState.status === "saving") {
+    return <Chip icon={<SavingIcon />} label="Saving…" size="small" color="info" variant="outlined" />;
+  }
+  if (saveState.status === "error") {
+    return (
+      <Tooltip title={saveState.error || "Autosave failed. Edits will retry on the next change."}>
+        <Chip icon={<ErrorIcon />} label="Save failed" size="small" color="error" />
+      </Tooltip>
+    );
+  }
+  if (saveState.status === "saved" && saveState.lastSavedAt) {
+    return <Chip icon={<SavedIcon />} label={`Saved · ${formatRelative(saveState.lastSavedAt)}`} size="small" color="success" variant="outlined" />;
+  }
+  return <Box sx={{ width: 1 }} />;
+};
+
+export default SaveIndicator;

--- a/src/components/admin/blog-edit/sections/ContentSection.js
+++ b/src/components/admin/blog-edit/sections/ContentSection.js
@@ -1,0 +1,148 @@
+import React from "react";
+import dynamic from "next/dynamic";
+import {
+  Alert,
+  Box,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import SectionContainer from "../../hackathon-edit/SectionContainer";
+import ImageUpload from "../../ImageUpload";
+import * as ga from "../../../../lib/ga";
+
+// MDEditor pulls in a chunky bundle; load on the client and avoid SSR.
+const MDEditor = dynamic(
+  () => import("@uiw/react-md-editor").then((mod) => mod.default),
+  { ssr: false, loading: () => <Box sx={{ minHeight: 400, bgcolor: "grey.50", borderRadius: 1 }} /> }
+);
+
+const ContentSection = ({ admin, accessToken, orgId, onSnack }) => {
+  const { post, setField, markSectionDirty, dirtySections, commitSection, discardSection, saveState } = admin;
+  if (!post) return null;
+
+  const dirty = dirtySections.has("content");
+  const isMarkdown = post.content_format === "markdown";
+
+  const onFieldChange = (field) => (e) => {
+    setField(field, e.target.value);
+    markSectionDirty("content", true);
+  };
+
+  const onMarkdownChange = (value) => {
+    setField("content_markdown", value || "");
+    markSectionDirty("content", true);
+  };
+
+  const onFormatToggle = (e) => {
+    setField("content_format", e.target.checked ? "markdown" : "html");
+    markSectionDirty("content", true);
+  };
+
+  const onImageChange = (url) => {
+    setField("featured_image", url);
+    setField("image", url);
+    markSectionDirty("content", true);
+  };
+
+  const handleSave = async () => {
+    const res = await commitSection("content");
+    if (res?.ok) {
+      onSnack?.("Content saved", "success");
+      ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_edit_save", "content", null, {
+        post_id: post.id,
+      });
+    } else if (res?.error) {
+      onSnack?.(`Save failed: ${res.error}`, "error");
+    }
+  };
+
+  const handleDiscard = () => {
+    discardSection("content");
+    onSnack?.("Reverted content changes", "info");
+  };
+
+  return (
+    <SectionContainer
+      title="Content"
+      description="Headline, body, and featured image. Click Save to publish your changes."
+      dirty={dirty}
+      saving={saveState.status === "saving"}
+      onSave={handleSave}
+      onDiscard={handleDiscard}
+    >
+      <Stack spacing={3}>
+        <TextField
+          label="Title"
+          value={post.title || ""}
+          onChange={onFieldChange("title")}
+          fullWidth
+          required
+          inputProps={{ maxLength: 200 }}
+          helperText="Used in the page title and the SEO title (unless you override it)"
+        />
+
+        <ImageUpload
+          label="Featured image"
+          value={post.featured_image || ""}
+          onChange={onImageChange}
+          directory={`news/${post.id || "drafts"}`}
+          accessToken={accessToken}
+          orgId={orgId}
+          helperText="Used as the hero image and the social-share image (unless overridden in SEO)"
+        />
+
+        <Box>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+            <Typography variant="subtitle1">Body</Typography>
+            <FormControlLabel
+              control={<Switch checked={isMarkdown} onChange={onFormatToggle} />}
+              label={isMarkdown ? "Markdown" : "Plain text (legacy)"}
+            />
+          </Stack>
+
+          {isMarkdown ? (
+            <Box data-color-mode="light">
+              <MDEditor
+                value={post.content_markdown || ""}
+                onChange={onMarkdownChange}
+                height={520}
+                preview="live"
+              />
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: "block" }}>
+                {(post.content_markdown || "").length.toLocaleString()} characters · GFM markdown supported
+              </Typography>
+            </Box>
+          ) : (
+            <>
+              <TextField
+                label="Description (plain text / HTML)"
+                value={post.description || ""}
+                onChange={onFieldChange("description")}
+                fullWidth
+                multiline
+                minRows={10}
+              />
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: "block" }}>
+                {(post.description || "").length.toLocaleString()} characters
+              </Typography>
+              <Alert severity="info" sx={{ mt: 2 }}>
+                Tip: switch to Markdown for a better authoring experience — headers, lists, links, and images render nicely on the public page.
+              </Alert>
+            </>
+          )}
+        </Box>
+
+        {isMarkdown && (post.description || "").length > 0 && (
+          <Alert severity="info">
+            The legacy <code>description</code> field still has content. It will continue to be used as a short excerpt and in the SEO description fallback. Edit it by toggling back to Plain text.
+          </Alert>
+        )}
+      </Stack>
+    </SectionContainer>
+  );
+};
+
+export default ContentSection;

--- a/src/components/admin/blog-edit/sections/MetadataSection.js
+++ b/src/components/admin/blog-edit/sections/MetadataSection.js
@@ -1,0 +1,215 @@
+import React, { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  Close as CloseIcon,
+  Launch as LaunchIcon,
+  Publish as PublishIcon,
+  Drafts as DraftsIcon,
+  Archive as ArchiveIcon,
+} from "@mui/icons-material";
+import SectionContainer from "../../hackathon-edit/SectionContainer";
+import * as ga from "../../../../lib/ga";
+
+const slugify = (raw) =>
+  (raw || "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+
+const MetadataSection = ({ admin, onSnack }) => {
+  const { post, setField, setStatus } = admin;
+  const [tagDraft, setTagDraft] = useState("");
+
+  if (!post) return null;
+
+  const tags = Array.isArray(post.tags) ? post.tags : [];
+
+  const onAuthorChange = (field) => (e) => {
+    setField("author", { ...(post.author || {}), [field]: e.target.value });
+  };
+
+  const addTag = () => {
+    const trimmed = tagDraft.trim().replace(/^#/, "");
+    if (!trimmed) return;
+    if (tags.includes(trimmed)) {
+      setTagDraft("");
+      return;
+    }
+    setField("tags", [...tags, trimmed]);
+    setTagDraft("");
+  };
+
+  const removeTag = (t) => setField("tags", tags.filter((x) => x !== t));
+
+  const handleStatusChange = async (_e, newStatus) => {
+    if (!newStatus || newStatus === post.status) return;
+    await setStatus(newStatus);
+    onSnack?.(`Status: ${newStatus}`, "success");
+    if (newStatus === "published") {
+      ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_publish", post.id);
+    } else if (newStatus === "draft") {
+      ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_unpublish", post.id);
+    } else if (newStatus === "archived") {
+      ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_archive", post.id);
+    }
+  };
+
+  const fillSlugFromTitle = () => {
+    setField("slug", slugify(post.title));
+  };
+
+  const gaUrl = `https://analytics.google.com/analytics/web/#/p${process.env.NEXT_PUBLIC_GA_PROPERTY_ID || ""}/reports/explorer?params=_u..nav%3Dmaui&collectionId=user&reportId=lifecycle-engagement-pages-and-screens&_r.explorerCard..fieldRefs=%5B%7B%22fieldType%22%3A%22dimension%22%2C%22fieldName%22%3A%22pagePath%22%7D%5D&_r.explorerCard..segment_keep=true&_r.explorerCard..filters=%5B%7B%22type%22%3A2%2C%22fieldName%22%3A%22pagePath%22%2C%22evaluationType%22%3A1%2C%22expressionList%22%3A%5B%22%2Fblog%2F${post.id}%22%5D%2C%22complement%22%3Afalse%7D%5D`;
+
+  return (
+    <SectionContainer
+      title="Metadata"
+      description="Author, tags, status, and publish date. Saves automatically as you edit."
+    >
+      <Stack spacing={3}>
+        <Box>
+          <Typography variant="subtitle1" sx={{ mb: 1 }}>Status</Typography>
+          <ToggleButtonGroup
+            value={post.status || "published"}
+            exclusive
+            onChange={handleStatusChange}
+            size="small"
+          >
+            <ToggleButton value="draft" sx={{ gap: 0.5 }}>
+              <DraftsIcon fontSize="small" /> Draft
+            </ToggleButton>
+            <ToggleButton value="published" sx={{ gap: 0.5 }}>
+              <PublishIcon fontSize="small" /> Published
+            </ToggleButton>
+            <ToggleButton value="archived" sx={{ gap: 0.5 }}>
+              <ArchiveIcon fontSize="small" /> Archived
+            </ToggleButton>
+          </ToggleButtonGroup>
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1 }}>
+            Draft and Archived posts are hidden from the public blog. Status change saves immediately.
+          </Typography>
+        </Box>
+
+        <Box>
+          <Typography variant="subtitle1" sx={{ mb: 1 }}>Tags</Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+            {tags.map((t) => (
+              <Chip key={t} label={`#${t}`} onDelete={() => removeTag(t)} deleteIcon={<CloseIcon />} />
+            ))}
+            {tags.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                No tags yet. Tags drive the related-posts widget and appear as chips on the public page.
+              </Typography>
+            )}
+          </Stack>
+          <Stack direction="row" spacing={1}>
+            <TextField
+              size="small"
+              value={tagDraft}
+              onChange={(e) => setTagDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addTag();
+                }
+              }}
+              placeholder="Add a tag and press Enter"
+              fullWidth
+            />
+            <IconButton onClick={addTag} disabled={!tagDraft.trim()} aria-label="Add tag">
+              <AddIcon />
+            </IconButton>
+          </Stack>
+        </Box>
+
+        <Box>
+          <Typography variant="subtitle1" sx={{ mb: 1 }}>Author</Typography>
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField
+              label="Name"
+              value={post.author?.name || ""}
+              onChange={onAuthorChange("name")}
+              fullWidth
+            />
+            <TextField
+              label="Email"
+              value={post.author?.email || ""}
+              onChange={onAuthorChange("email")}
+              fullWidth
+            />
+          </Stack>
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1 }}>
+            Appears on the public page as "by Name" and in the article:author meta tag.
+          </Typography>
+        </Box>
+
+        <Box>
+          <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+            <Typography variant="subtitle1">Slug</Typography>
+            <Button size="small" onClick={fillSlugFromTitle} disabled={!post.title}>
+              Fill from title
+            </Button>
+          </Stack>
+          <TextField
+            value={post.slug || ""}
+            onChange={(e) => setField("slug", e.target.value)}
+            fullWidth
+            placeholder={slugify(post.title) || "my-blog-post"}
+            helperText="Stored for future use. URLs currently still use the post ID."
+          />
+        </Box>
+
+        <TextField
+          label="Published date / time"
+          type="datetime-local"
+          value={post.published_at ? toDatetimeLocal(post.published_at) : ""}
+          onChange={(e) => setField("published_at", e.target.value ? new Date(e.target.value).toISOString() : "")}
+          InputLabelProps={{ shrink: true }}
+          helperText="Shown on the public page and used in article:published_time. Leave blank to use the Slack timestamp."
+        />
+
+        <Alert severity="info" icon={<LaunchIcon />} action={
+          <Button
+            size="small"
+            color="inherit"
+            href={`https://analytics.google.com/analytics/web/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_open_ga", post.id)}
+          >
+            Open GA4
+          </Button>
+        }>
+          Per-post engagement metrics live in Google Analytics. Filter by <strong>pagePath = /blog/{post.id}</strong> to see views, scroll depth, share clicks, and external-link clicks for this post.
+        </Alert>
+      </Stack>
+    </SectionContainer>
+  );
+};
+
+// Convert ISO string to the value expected by <input type="datetime-local">
+function toDatetimeLocal(iso) {
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return "";
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  } catch {
+    return "";
+  }
+}
+
+export default MetadataSection;

--- a/src/components/admin/blog-edit/sections/SeoSection.js
+++ b/src/components/admin/blog-edit/sections/SeoSection.js
@@ -1,0 +1,255 @@
+import React, { useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Chip,
+  IconButton,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Add as AddIcon, Close as CloseIcon } from "@mui/icons-material";
+import SectionContainer from "../../hackathon-edit/SectionContainer";
+import * as ga from "../../../../lib/ga";
+
+const CharCount = ({ value, max, idealMin = 0 }) => {
+  const len = (value || "").length;
+  let color = "text.secondary";
+  if (len > max) color = "error.main";
+  else if (len > max * 0.95) color = "warning.main";
+  else if (len >= idealMin) color = "success.main";
+  return (
+    <Typography variant="caption" sx={{ color, ml: 1 }}>
+      {len} / {max}
+    </Typography>
+  );
+};
+
+const SerpPreview = ({ title, description, url }) => (
+  <Paper variant="outlined" sx={{ p: 2, bgcolor: "grey.50" }}>
+    <Typography variant="overline" color="text.secondary">Google search result preview</Typography>
+    <Box sx={{ mt: 1 }}>
+      <Typography sx={{ color: "#202124", fontSize: "0.8rem" }}>{url}</Typography>
+      <Typography sx={{ color: "#1a0dab", fontSize: "1.25rem", fontFamily: "arial, sans-serif", mb: 0.5, mt: 0.25 }}>
+        {title || "(missing title)"}
+      </Typography>
+      <Typography sx={{ color: "#4d5156", fontSize: "0.9rem", fontFamily: "arial, sans-serif" }}>
+        {description || "(missing description)"}
+      </Typography>
+    </Box>
+  </Paper>
+);
+
+const SocialPreview = ({ title, description, image, url }) => (
+  <Paper variant="outlined" sx={{ overflow: "hidden" }}>
+    <Typography variant="overline" color="text.secondary" sx={{ display: "block", px: 2, pt: 1.5 }}>
+      Social share preview (Twitter / LinkedIn)
+    </Typography>
+    <Box sx={{ display: "flex", flexDirection: { xs: "column", sm: "row" }, mt: 1 }}>
+      {image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={image}
+          alt=""
+          style={{
+            width: 200,
+            height: 120,
+            objectFit: "cover",
+            display: "block",
+            flexShrink: 0,
+          }}
+          loading="lazy"
+          decoding="async"
+        />
+      ) : (
+        <Box sx={{ width: 200, height: 120, bgcolor: "grey.200", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+          <Typography variant="caption" color="text.secondary">No image</Typography>
+        </Box>
+      )}
+      <Box sx={{ p: 2, minWidth: 0 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ textTransform: "uppercase" }}>{(() => {
+          try { return new URL(url).hostname; } catch { return "ohack.dev"; }
+        })()}</Typography>
+        <Typography sx={{ fontWeight: 600, mb: 0.5 }}>{title || "(missing title)"}</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+        }}>{description || ""}</Typography>
+      </Box>
+    </Box>
+  </Paper>
+);
+
+const SeoSection = ({ admin, onSnack }) => {
+  const { post, setSeo, markSectionDirty, dirtySections, commitSection, discardSection, saveState } = admin;
+  const [keywordDraft, setKeywordDraft] = useState("");
+
+  if (!post) return null;
+
+  const dirty = dirtySections.has("seo");
+  const seo = post.seo || {};
+
+  const onSeoChange = (field) => (e) => {
+    setSeo(field, e.target.value);
+    markSectionDirty("seo", true);
+  };
+
+  const addKeyword = () => {
+    const trimmed = keywordDraft.trim();
+    if (!trimmed) return;
+    const current = Array.isArray(seo.keywords) ? seo.keywords : [];
+    if (current.includes(trimmed)) {
+      setKeywordDraft("");
+      return;
+    }
+    setSeo("keywords", [...current, trimmed]);
+    markSectionDirty("seo", true);
+    setKeywordDraft("");
+  };
+
+  const removeKeyword = (kw) => {
+    const next = (seo.keywords || []).filter((k) => k !== kw);
+    setSeo("keywords", next);
+    markSectionDirty("seo", true);
+  };
+
+  // Effective values shown on the public page when fields are blank.
+  const effectiveTitle = seo.title || (post.title ? `OHack Blog: ${post.title}` : "");
+  const effectiveDescription = seo.description || post.description || "";
+  const effectiveImage = seo.og_image || post.featured_image || post.image || "";
+  const effectiveUrl = seo.canonical || (post.id ? `https://ohack.dev/blog/${post.id}` : "https://ohack.dev/blog");
+
+  const handleSave = async () => {
+    const res = await commitSection("seo");
+    if (res?.ok) {
+      onSnack?.("SEO saved", "success");
+      ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_edit_save", "seo", null, {
+        post_id: post.id,
+      });
+    } else if (res?.error) {
+      onSnack?.(`Save failed: ${res.error}`, "error");
+    }
+  };
+
+  const handleDiscard = () => {
+    discardSection("seo");
+    onSnack?.("Reverted SEO changes", "info");
+  };
+
+  return (
+    <SectionContainer
+      title="Search engine optimization"
+      description="Override the page's <title>, meta description, canonical URL, and social-share image. Blank fields fall back to derived values."
+      dirty={dirty}
+      saving={saveState.status === "saving"}
+      onSave={handleSave}
+      onDiscard={handleDiscard}
+    >
+      <Stack spacing={3}>
+        <Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="baseline">
+            <Typography variant="subtitle1">SEO title <Typography component="span" variant="caption" color="text.secondary">— shown in search results</Typography></Typography>
+            <CharCount value={seo.title} max={60} idealMin={30} />
+          </Stack>
+          <TextField
+            value={seo.title || ""}
+            onChange={onSeoChange("title")}
+            fullWidth
+            placeholder={`OHack Blog: ${post.title || ""}`}
+            helperText="Aim for 50–60 characters. Leave blank to use the post title with the OHack prefix."
+          />
+        </Box>
+
+        <Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="baseline">
+            <Typography variant="subtitle1">Meta description</Typography>
+            <CharCount value={seo.description} max={160} idealMin={120} />
+          </Stack>
+          <TextField
+            value={seo.description || ""}
+            onChange={onSeoChange("description")}
+            fullWidth
+            multiline
+            minRows={2}
+            placeholder={post.description?.slice(0, 160) || ""}
+            helperText="Aim for 120–160 characters. Search engines may rewrite this if it's too short."
+          />
+        </Box>
+
+        <Box>
+          <Typography variant="subtitle1" sx={{ mb: 1 }}>Keywords</Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+            {(seo.keywords || []).map((kw) => (
+              <Chip
+                key={kw}
+                label={kw}
+                onDelete={() => removeKeyword(kw)}
+                deleteIcon={<CloseIcon />}
+              />
+            ))}
+            {(seo.keywords || []).length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                No custom keywords — tags and extracted hashtags will be used as a fallback.
+              </Typography>
+            )}
+          </Stack>
+          <Stack direction="row" spacing={1}>
+            <TextField
+              size="small"
+              value={keywordDraft}
+              onChange={(e) => setKeywordDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addKeyword();
+                }
+              }}
+              placeholder="Add a keyword and press Enter"
+              fullWidth
+            />
+            <IconButton onClick={addKeyword} disabled={!keywordDraft.trim()} aria-label="Add keyword">
+              <AddIcon />
+            </IconButton>
+          </Stack>
+        </Box>
+
+        <TextField
+          label="Canonical URL"
+          value={seo.canonical || ""}
+          onChange={onSeoChange("canonical")}
+          fullWidth
+          placeholder={`https://ohack.dev/blog/${post.id || ""}`}
+          helperText="Override only if this post is published elsewhere first and should point to the original."
+        />
+
+        <TextField
+          label="Social-share image URL (OG image)"
+          value={seo.og_image || ""}
+          onChange={onSeoChange("og_image")}
+          fullWidth
+          placeholder={post.featured_image || ""}
+          helperText="Recommended 1200x630px. Leave blank to use the featured image."
+        />
+
+        {!post.title && (
+          <Alert severity="warning">Add a post title in the Content section first — the SEO preview needs it.</Alert>
+        )}
+
+        <Stack spacing={2}>
+          <SerpPreview title={effectiveTitle} description={effectiveDescription} url={effectiveUrl} />
+          <SocialPreview
+            title={effectiveTitle}
+            description={effectiveDescription}
+            image={effectiveImage}
+            url={effectiveUrl}
+          />
+        </Stack>
+      </Stack>
+    </SectionContainer>
+  );
+};
+
+export default SeoSection;

--- a/src/components/admin/blog-edit/sectionsManifest.js
+++ b/src/components/admin/blog-edit/sectionsManifest.js
@@ -1,0 +1,18 @@
+// Sidebar manifest for the per-post blog editor.
+// Add a new section: append here, then implement `./sections/<Slug>Section.js`.
+
+import {
+  Article as ContentIcon,
+  Search as SeoIcon,
+  Tag as MetadataIcon,
+} from "@mui/icons-material";
+
+export const SECTIONS = [
+  { slug: "content", label: "Content", icon: ContentIcon, hint: "Title, body, featured image" },
+  { slug: "seo", label: "SEO", icon: SeoIcon, hint: "Title tag, meta description, canonical, OG" },
+  { slug: "metadata", label: "Metadata", icon: MetadataIcon, hint: "Author, tags, status, publish date" },
+];
+
+export const DEFAULT_SECTION = "content";
+
+export const isValidSection = (slug) => SECTIONS.some((s) => s.slug === slug);

--- a/src/components/admin/blog-edit/useBlogAdmin.js
+++ b/src/components/admin/blog-edit/useBlogAdmin.js
@@ -1,0 +1,311 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const SAVE_DEBOUNCE_MS = 1500;
+
+const cloneDeep = (v) =>
+  typeof structuredClone === "function" ? structuredClone(v) : JSON.parse(JSON.stringify(v));
+
+// Sections that require an explicit Save action (never autosave).
+// Body content shouldn't silently save mid-keystroke; SEO changes should be deliberate.
+export const EXPLICIT_SAVE_SECTIONS = new Set(["content", "seo"]);
+
+export const SECTION_LABELS = {
+  content: "Content",
+  seo: "SEO",
+  metadata: "Metadata",
+};
+
+const buildHeaders = (accessToken, orgId) => ({
+  authorization: `Bearer ${accessToken}`,
+  "content-type": "application/json",
+  ...(orgId ? { "X-Org-Id": orgId } : {}),
+});
+
+// Top-level keys owned by each explicit-save section. Used to pause autosave
+// for those keys while the section has unsaved changes.
+function collectKeysForSections(sectionSet) {
+  const keys = new Set();
+  sectionSet.forEach((s) => {
+    if (s === "content") {
+      keys.add("title");
+      keys.add("description");
+      keys.add("content_markdown");
+      keys.add("content_format");
+      keys.add("featured_image");
+      keys.add("image");
+    } else if (s === "seo") {
+      keys.add("seo");
+    }
+  });
+  return keys;
+}
+
+const normalizePost = (raw) => ({
+  ...raw,
+  title: raw.title || "",
+  description: raw.description || "",
+  content_markdown: raw.content_markdown || "",
+  content_format: raw.content_format || (raw.content_markdown ? "markdown" : "html"),
+  featured_image: raw.featured_image || raw.image || "",
+  image: raw.image || raw.featured_image || "",
+  tags: Array.isArray(raw.tags) ? raw.tags : [],
+  status: raw.status || "published",
+  slug: raw.slug || "",
+  published_at: raw.published_at || raw.slack_ts_human_readable || "",
+  author: raw.author || null,
+  seo: {
+    title: raw.seo?.title || "",
+    description: raw.seo?.description || "",
+    keywords: Array.isArray(raw.seo?.keywords) ? raw.seo.keywords : [],
+    canonical: raw.seo?.canonical || "",
+    og_image: raw.seo?.og_image || "",
+  },
+  links: Array.isArray(raw.links) ? raw.links : [],
+});
+
+/**
+ * Per-post blog admin state machine. Mirrors useHackathonAdmin.
+ *
+ *   draft     — in-memory edit, what the form renders
+ *   committed — last server-confirmed snapshot (autosave diffs against this)
+ *
+ * Hybrid save model: autosave runs for keys NOT owned by any dirty
+ * explicit-save section. Explicit sections call commitSection(name) to flush.
+ */
+export function useBlogAdmin({ postId, accessToken, orgId, isAdmin }) {
+  const [draft, setDraft] = useState(null);
+  const [committed, setCommitted] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+  const [saveState, setSaveState] = useState({ status: "idle", lastSavedAt: null, error: null });
+  const [dirtySections, setDirtySections] = useState(new Set());
+  const saveTimerRef = useRef(null);
+  const inflightRef = useRef(null);
+
+  const apiBase = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+  const fetchPost = useCallback(async () => {
+    if (!isAdmin || !postId || !accessToken) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      // Public single-news route works for admins reading a post by id.
+      const res = await fetch(`${apiBase}/api/messages/news/${postId}`, {
+        headers: buildHeaders(accessToken, orgId),
+      });
+      if (!res.ok) throw new Error(`Failed to load post (${res.status})`);
+      const data = await res.json();
+      const post = data?.text;
+      if (!post || !post.title) {
+        // Fall back to the admin list so drafts (filtered out of /news) are reachable.
+        const adminRes = await fetch(`${apiBase}/api/messages/admin/news?limit=2000`, {
+          headers: buildHeaders(accessToken, orgId),
+        });
+        if (adminRes.ok) {
+          const adminData = await adminRes.json();
+          const found = (adminData.text || []).find((p) => p.id === postId);
+          if (found) {
+            const normalized = normalizePost({ ...found, id: postId });
+            setDraft(normalized);
+            setCommitted(cloneDeep(normalized));
+            return;
+          }
+        }
+        setLoadError(`No blog post with id "${postId}"`);
+        setDraft(null);
+        setCommitted(null);
+        return;
+      }
+      const normalized = normalizePost({ ...post, id: postId });
+      setDraft(normalized);
+      setCommitted(cloneDeep(normalized));
+    } catch (err) {
+      console.error("Blog post load failed:", err);
+      setLoadError(err.message || "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBase, postId, accessToken, orgId, isAdmin]);
+
+  useEffect(() => {
+    fetchPost();
+  }, [fetchPost]);
+
+  const pushPatch = useCallback(
+    async (payload) => {
+      const myToken = Symbol("save");
+      inflightRef.current = myToken;
+      const { id, ...patch } = payload;
+      const res = await fetch(`${apiBase}/api/messages/admin/news/${postId}`, {
+        method: "PATCH",
+        headers: buildHeaders(accessToken, orgId),
+        body: JSON.stringify(patch),
+      });
+      if (inflightRef.current !== myToken) return null;
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `Save failed (${res.status})`);
+      }
+      return payload;
+    },
+    [apiBase, accessToken, orgId, postId]
+  );
+
+  // Autosave payload = committed + draft-for-non-dirty-explicit-section-keys
+  const buildAutosavePayload = useCallback(() => {
+    if (!draft || !committed) return null;
+    const dirtyKeys = collectKeysForSections(dirtySections);
+    const merged = { ...committed };
+    Object.keys(draft).forEach((k) => {
+      if (!dirtyKeys.has(k)) merged[k] = draft[k];
+    });
+    return merged;
+  }, [draft, committed, dirtySections]);
+
+  useEffect(() => {
+    if (!draft || !committed) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    const payload = buildAutosavePayload();
+    if (!payload) return;
+    if (JSON.stringify(payload) === JSON.stringify(committed)) return;
+
+    saveTimerRef.current = setTimeout(async () => {
+      setSaveState({ status: "saving", lastSavedAt: null, error: null });
+      try {
+        const saved = await pushPatch(payload);
+        if (saved) {
+          setCommitted(cloneDeep(saved));
+          setSaveState({ status: "saved", lastSavedAt: Date.now(), error: null });
+        }
+      } catch (err) {
+        console.error("Autosave failed:", err);
+        setSaveState({ status: "error", lastSavedAt: null, error: err.message });
+      }
+    }, SAVE_DEBOUNCE_MS);
+    return () => clearTimeout(saveTimerRef.current);
+  }, [draft, committed, buildAutosavePayload, pushPatch]);
+
+  const setField = useCallback((field, value) => {
+    setDraft((prev) => (prev ? { ...prev, [field]: value } : prev));
+  }, []);
+
+  const setSeo = useCallback((field, value) => {
+    setDraft((prev) =>
+      prev ? { ...prev, seo: { ...(prev.seo || {}), [field]: value } } : prev
+    );
+  }, []);
+
+  const markSectionDirty = useCallback((section, dirty) => {
+    setDirtySections((prev) => {
+      const next = new Set(prev);
+      if (dirty) next.add(section);
+      else next.delete(section);
+      return next;
+    });
+  }, []);
+
+  const commitSection = useCallback(
+    async (section) => {
+      if (!draft) return { ok: false, error: "No draft" };
+      setSaveState({ status: "saving", lastSavedAt: null, error: null });
+      try {
+        const saved = await pushPatch(draft);
+        if (saved) {
+          setCommitted(cloneDeep(saved));
+          setSaveState({ status: "saved", lastSavedAt: Date.now(), error: null });
+          markSectionDirty(section, false);
+          return { ok: true };
+        }
+        return { ok: false, error: "Concurrent save" };
+      } catch (err) {
+        setSaveState({ status: "error", lastSavedAt: null, error: err.message });
+        return { ok: false, error: err.message };
+      }
+    },
+    [draft, pushPatch, markSectionDirty]
+  );
+
+  const discardSection = useCallback(
+    (section) => {
+      if (!committed) return;
+      const keys = collectKeysForSections(new Set([section]));
+      setDraft((prev) => {
+        if (!prev) return prev;
+        const next = { ...prev };
+        keys.forEach((k) => {
+          next[k] = cloneDeep(committed[k]);
+        });
+        return next;
+      });
+      markSectionDirty(section, false);
+    },
+    [committed, markSectionDirty]
+  );
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (dirtySections.size === 0) return;
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [dirtySections]);
+
+  // Convenience: publish / unpublish flips status and immediately saves (autosave path).
+  const setStatus = useCallback(
+    async (newStatus) => {
+      setDraft((prev) => (prev ? { ...prev, status: newStatus } : prev));
+      // Force-flush via direct PATCH so the user sees the chip change immediately,
+      // bypassing the debounce. Don't await dirty-section conflicts — status is in
+      // MetadataSection which is autosaved.
+      try {
+        await fetch(`${apiBase}/api/messages/admin/news/${postId}`, {
+          method: "PATCH",
+          headers: buildHeaders(accessToken, orgId),
+          body: JSON.stringify({ status: newStatus }),
+        });
+        setCommitted((prev) => (prev ? { ...prev, status: newStatus } : prev));
+        setSaveState({ status: "saved", lastSavedAt: Date.now(), error: null });
+      } catch (err) {
+        setSaveState({ status: "error", lastSavedAt: null, error: err.message });
+      }
+    },
+    [apiBase, accessToken, orgId, postId]
+  );
+
+  const value = useMemo(
+    () => ({
+      post: draft,
+      committed,
+      loading,
+      loadError,
+      saveState,
+      dirtySections,
+      setField,
+      setSeo,
+      setStatus,
+      markSectionDirty,
+      commitSection,
+      discardSection,
+      refetch: fetchPost,
+    }),
+    [
+      draft,
+      committed,
+      loading,
+      loadError,
+      saveState,
+      dirtySections,
+      setField,
+      setSeo,
+      setStatus,
+      markSectionDirty,
+      commitSection,
+      discardSection,
+      fetchPost,
+    ]
+  );
+
+  return value;
+}

--- a/src/lib/ga/index.js
+++ b/src/lib/ga/index.js
@@ -27,7 +27,8 @@ export const EventCategory = {
   DONATION: 'donation',
   ERROR: 'error',
   USER: 'user',
-  SOCIAL: 'social'
+  SOCIAL: 'social',
+  ADMIN: 'admin'
 };
 
 // Standard event actions for consistent naming

--- a/src/pages/admin/blog/[id].js
+++ b/src/pages/admin/blog/[id].js
@@ -1,0 +1,113 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { useAuthInfo, RequiredAuthProvider, RedirectToLogin } from "@propelauth/react";
+import { Alert, Box, CircularProgress, Typography } from "@mui/material";
+import dynamic from "next/dynamic";
+import AdminPage from "../../../components/admin/AdminPage";
+import BlogAdminLayout from "../../../components/admin/blog-edit/BlogAdminLayout";
+import {
+  SECTIONS,
+  DEFAULT_SECTION,
+  isValidSection,
+} from "../../../components/admin/blog-edit/sectionsManifest";
+import { useBlogAdmin } from "../../../components/admin/blog-edit/useBlogAdmin";
+
+// Lazy-load section bodies so we don't pull MDEditor on metadata/SEO views.
+const sectionLoaders = {
+  content: dynamic(() => import("../../../components/admin/blog-edit/sections/ContentSection"), { ssr: false }),
+  seo: dynamic(() => import("../../../components/admin/blog-edit/sections/SeoSection"), { ssr: false }),
+  metadata: dynamic(() => import("../../../components/admin/blog-edit/sections/MetadataSection"), { ssr: false }),
+};
+
+const AdminBlogEditPage = () => {
+  const router = useRouter();
+  const { accessToken, userClass } = useAuthInfo();
+  const org = userClass?.getOrgByName("Opportunity Hack Org");
+  const isAdmin = !!org?.hasPermission("volunteer.admin");
+  const orgId = org?.orgId;
+
+  const { id: idRaw, section: sectionRaw } = router.query;
+  const postId = Array.isArray(idRaw) ? idRaw[0] : idRaw;
+  const sectionFromUrl = Array.isArray(sectionRaw) ? sectionRaw[0] : sectionRaw;
+  const activeSection = isValidSection(sectionFromUrl) ? sectionFromUrl : DEFAULT_SECTION;
+
+  const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "success" });
+  const showSnack = useCallback((message, severity = "success") => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
+
+  const admin = useBlogAdmin({ postId, accessToken, orgId, isAdmin });
+
+  useEffect(() => {
+    if (admin.saveState.status === "error" && admin.saveState.error) {
+      showSnack(`Autosave failed: ${admin.saveState.error}`, "error");
+    }
+  }, [admin.saveState.status, admin.saveState.error, showSnack]);
+
+  const navigateToSection = (slug) => {
+    router.replace(
+      { pathname: router.pathname, query: { ...router.query, section: slug } },
+      undefined,
+      { shallow: true, scroll: false }
+    );
+  };
+
+  if (!isAdmin) {
+    return (
+      <RequiredAuthProvider
+        authUrl={process.env.NEXT_PUBLIC_REACT_APP_AUTH_URL}
+        displayIfLoggedOut={<RedirectToLogin postLoginRedirectUrl={typeof window !== "undefined" ? window.location.href : ""} />}
+      >
+        <AdminPage title="Blog" isAdmin={false}>
+          <Typography>You do not have permission to view this page.</Typography>
+        </AdminPage>
+      </RequiredAuthProvider>
+    );
+  }
+
+  const SectionComponent = sectionLoaders[activeSection];
+
+  return (
+    <RequiredAuthProvider
+      authUrl={process.env.NEXT_PUBLIC_REACT_APP_AUTH_URL}
+      displayIfLoggedOut={<RedirectToLogin postLoginRedirectUrl={typeof window !== "undefined" ? window.location.href : ""} />}
+    >
+      <AdminPage
+        title="Blog"
+        isAdmin={isAdmin}
+        snackbar={snackbar}
+        onSnackbarClose={() => setSnackbar({ ...snackbar, open: false })}
+      >
+        {admin.loading && (
+          <Box display="flex" justifyContent="center" py={6}>
+            <CircularProgress />
+          </Box>
+        )}
+        {admin.loadError && !admin.loading && (
+          <Alert severity="error" sx={{ mb: 2 }}>{admin.loadError}</Alert>
+        )}
+        {!admin.loading && admin.post && (
+          <BlogAdminLayout
+            post={admin.post}
+            activeSection={activeSection}
+            onSelectSection={navigateToSection}
+            saveState={admin.saveState}
+            dirtySections={admin.dirtySections}
+            onBack={() => router.push("/admin/blog")}
+          >
+            {SectionComponent && (
+              <SectionComponent
+                admin={admin}
+                accessToken={accessToken}
+                orgId={orgId}
+                onSnack={showSnack}
+              />
+            )}
+          </BlogAdminLayout>
+        )}
+      </AdminPage>
+    </RequiredAuthProvider>
+  );
+};
+
+export default AdminBlogEditPage;

--- a/src/pages/admin/blog/index.js
+++ b/src/pages/admin/blog/index.js
@@ -1,0 +1,440 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/router";
+import { useAuthInfo, RequiredAuthProvider, RedirectToLogin } from "@propelauth/react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  InputAdornment,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TablePagination,
+  TextField,
+  Tooltip,
+  Typography,
+  Paper,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  Search as SearchIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  Launch as LaunchIcon,
+  Clear as ClearIcon,
+} from "@mui/icons-material";
+import AdminPage from "../../../components/admin/AdminPage";
+import * as ga from "../../../lib/ga";
+
+const STATUS_FILTERS = [
+  { value: "all", label: "All" },
+  { value: "published", label: "Published" },
+  { value: "draft", label: "Drafts" },
+  { value: "archived", label: "Archived" },
+];
+
+const statusChipColor = (status) => {
+  if (status === "draft") return "warning";
+  if (status === "archived") return "default";
+  return "success";
+};
+
+const formatDate = (post) => {
+  const raw = post.published_at || post.slack_ts_human_readable || post.last_updated;
+  if (!raw) return "—";
+  try {
+    return new Date(raw).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  } catch {
+    return raw;
+  }
+};
+
+const AdminBlogList = () => {
+  const router = useRouter();
+  const { accessToken, userClass } = useAuthInfo();
+  const org = userClass?.getOrgByName("Opportunity Hack Org");
+  const isAdmin = !!org?.hasPermission("volunteer.admin");
+  const orgId = org?.orgId;
+
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
+  const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "success" });
+  const [confirmDelete, setConfirmDelete] = useState(null);
+  const [creating, setCreating] = useState(false);
+
+  const apiBase = process.env.NEXT_PUBLIC_API_SERVER_URL;
+
+  const fetchPosts = useCallback(async () => {
+    if (!isAdmin || !accessToken) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiBase}/api/messages/admin/news?limit=2000`, {
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "content-type": "application/json",
+          ...(orgId ? { "X-Org-Id": orgId } : {}),
+        },
+      });
+      if (!res.ok) throw new Error(`Failed to load posts (${res.status})`);
+      const data = await res.json();
+      setPosts(data.text || []);
+    } catch (err) {
+      console.error("Blog list fetch failed:", err);
+      setError(err.message || "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBase, accessToken, orgId, isAdmin]);
+
+  useEffect(() => {
+    if (isAdmin) {
+      fetchPosts();
+      ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_view_list", "list");
+    }
+  }, [isAdmin, fetchPosts]);
+
+  const filteredPosts = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return posts.filter((p) => {
+      const postStatus = p.status || "published";
+      if (statusFilter !== "all" && postStatus !== statusFilter) return false;
+      if (!q) return true;
+      const haystack = [
+        p.title,
+        p.description,
+        p.slug,
+        p.author?.name,
+        p.author?.email,
+        Array.isArray(p.tags) ? p.tags.join(" ") : "",
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [posts, search, statusFilter]);
+
+  const pagedPosts = useMemo(() => {
+    const start = page * rowsPerPage;
+    return filteredPosts.slice(start, start + rowsPerPage);
+  }, [filteredPosts, page, rowsPerPage]);
+
+  const statusCounts = useMemo(() => {
+    const counts = { all: posts.length, published: 0, draft: 0, archived: 0 };
+    posts.forEach((p) => {
+      const s = p.status || "published";
+      counts[s] = (counts[s] || 0) + 1;
+    });
+    return counts;
+  }, [posts]);
+
+  const handleCreate = async () => {
+    if (!accessToken) return;
+    setCreating(true);
+    try {
+      const res = await fetch(`${apiBase}/api/messages/admin/news`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "content-type": "application/json",
+          ...(orgId ? { "X-Org-Id": orgId } : {}),
+        },
+        body: JSON.stringify({
+          title: "Untitled draft",
+          description: "",
+          content_format: "markdown",
+          content_markdown: "",
+          status: "draft",
+          tags: [],
+        }),
+      });
+      if (!res.ok) throw new Error(`Create failed (${res.status})`);
+      const data = await res.json();
+      const newId = data?.id;
+      ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_create", newId);
+      if (newId) {
+        router.push(`/admin/blog/${newId}`);
+      } else {
+        await fetchPosts();
+      }
+    } catch (err) {
+      console.error("Create draft failed:", err);
+      setSnackbar({ open: true, message: err.message || "Create failed", severity: "error" });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirmDelete) return;
+    const target = confirmDelete;
+    setConfirmDelete(null);
+    try {
+      const res = await fetch(`${apiBase}/api/messages/admin/news/${target.id}`, {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          ...(orgId ? { "X-Org-Id": orgId } : {}),
+        },
+      });
+      if (!res.ok) throw new Error(`Delete failed (${res.status})`);
+      setPosts((prev) => prev.filter((p) => p.id !== target.id));
+      setSnackbar({ open: true, message: `Deleted "${target.title}"`, severity: "success" });
+      ga.trackStructuredEvent(ga.EventCategory.ADMIN, "admin_blog_delete", target.id);
+    } catch (err) {
+      console.error("Delete failed:", err);
+      setSnackbar({ open: true, message: err.message || "Delete failed", severity: "error" });
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <RequiredAuthProvider
+        authUrl={process.env.NEXT_PUBLIC_REACT_APP_AUTH_URL}
+        displayIfLoggedOut={<RedirectToLogin postLoginRedirectUrl={typeof window !== "undefined" ? window.location.href : ""} />}
+      >
+        <AdminPage title="Blog" isAdmin={false}>
+          <Typography>You do not have permission to view this page.</Typography>
+        </AdminPage>
+      </RequiredAuthProvider>
+    );
+  }
+
+  return (
+    <RequiredAuthProvider
+      authUrl={process.env.NEXT_PUBLIC_REACT_APP_AUTH_URL}
+      displayIfLoggedOut={<RedirectToLogin postLoginRedirectUrl={typeof window !== "undefined" ? window.location.href : ""} />}
+    >
+      <AdminPage
+        title="Blog"
+        isAdmin={isAdmin}
+        snackbar={snackbar}
+        onSnackbarClose={() => setSnackbar({ ...snackbar, open: false })}
+      >
+        <Stack spacing={3}>
+          <Stack
+            direction={{ xs: "column", md: "row" }}
+            spacing={2}
+            alignItems={{ xs: "stretch", md: "center" }}
+            justifyContent="space-between"
+          >
+            <Typography variant="body1" color="text.secondary" sx={{ flex: 1 }}>
+              Write, edit, and manage every blog post. New posts start as drafts so you can polish before publishing.
+            </Typography>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={handleCreate}
+              disabled={creating}
+              size="large"
+            >
+              {creating ? "Creating…" : "New post"}
+            </Button>
+          </Stack>
+
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems={{ xs: "stretch", md: "center" }}>
+              <TextField
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value);
+                  setPage(0);
+                }}
+                placeholder="Search title, description, author, tag…"
+                size="small"
+                fullWidth
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon fontSize="small" />
+                    </InputAdornment>
+                  ),
+                  endAdornment: search ? (
+                    <InputAdornment position="end">
+                      <IconButton size="small" onClick={() => setSearch("")} aria-label="Clear search">
+                        <ClearIcon fontSize="small" />
+                      </IconButton>
+                    </InputAdornment>
+                  ) : null,
+                }}
+              />
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                {STATUS_FILTERS.map((f) => (
+                  <Chip
+                    key={f.value}
+                    label={`${f.label} (${statusCounts[f.value] ?? 0})`}
+                    onClick={() => {
+                      setStatusFilter(f.value);
+                      setPage(0);
+                    }}
+                    color={statusFilter === f.value ? "primary" : "default"}
+                    variant={statusFilter === f.value ? "filled" : "outlined"}
+                  />
+                ))}
+              </Stack>
+            </Stack>
+          </Paper>
+
+          {loading && (
+            <Box display="flex" justifyContent="center" py={6}>
+              <CircularProgress />
+            </Box>
+          )}
+
+          {error && !loading && (
+            <Alert severity="error">{error}</Alert>
+          )}
+
+          {!loading && !error && (
+            <Paper variant="outlined">
+              <TableContainer>
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Title</TableCell>
+                      <TableCell>Status</TableCell>
+                      <TableCell>Author</TableCell>
+                      <TableCell>Tags</TableCell>
+                      <TableCell>Published</TableCell>
+                      <TableCell align="right">Actions</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {pagedPosts.map((post) => {
+                      const status = post.status || "published";
+                      return (
+                        <TableRow key={post.id} hover>
+                          <TableCell sx={{ maxWidth: 360 }}>
+                            <Typography
+                              sx={{
+                                fontWeight: 600,
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                display: "-webkit-box",
+                                WebkitLineClamp: 2,
+                                WebkitBoxOrient: "vertical",
+                              }}
+                            >
+                              {post.title || "(untitled)"}
+                            </Typography>
+                            {post.description && (
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{
+                                  display: "-webkit-box",
+                                  WebkitLineClamp: 1,
+                                  WebkitBoxOrient: "vertical",
+                                  overflow: "hidden",
+                                }}
+                              >
+                                {post.description}
+                              </Typography>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <Chip
+                              label={status}
+                              size="small"
+                              color={statusChipColor(status)}
+                              variant={status === "draft" ? "filled" : "outlined"}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Typography variant="body2">{post.author?.name || "—"}</Typography>
+                          </TableCell>
+                          <TableCell>
+                            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                              {(post.tags || []).slice(0, 3).map((t) => (
+                                <Chip key={t} label={`#${t}`} size="small" variant="outlined" />
+                              ))}
+                              {(post.tags || []).length > 3 && (
+                                <Chip label={`+${post.tags.length - 3}`} size="small" />
+                              )}
+                            </Stack>
+                          </TableCell>
+                          <TableCell>{formatDate(post)}</TableCell>
+                          <TableCell align="right">
+                            <Tooltip title="Edit">
+                              <IconButton size="small" onClick={() => router.push(`/admin/blog/${post.id}`)}>
+                                <EditIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                            <Tooltip title="View public page">
+                              <IconButton size="small" href={`/blog/${post.id}`} target="_blank" rel="noopener noreferrer">
+                                <LaunchIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                            <Tooltip title="Delete">
+                              <IconButton size="small" onClick={() => setConfirmDelete(post)} color="error">
+                                <DeleteIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                    {pagedPosts.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={6}>
+                          <Typography variant="body2" color="text.secondary" align="center" sx={{ py: 4 }}>
+                            {posts.length === 0 ? "No posts yet — click New post to start." : "No posts match the current filters."}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              <TablePagination
+                component="div"
+                count={filteredPosts.length}
+                page={page}
+                onPageChange={(_e, p) => setPage(p)}
+                rowsPerPage={rowsPerPage}
+                onRowsPerPageChange={(e) => {
+                  setRowsPerPage(parseInt(e.target.value, 10));
+                  setPage(0);
+                }}
+                rowsPerPageOptions={[10, 25, 50, 100]}
+              />
+            </Paper>
+          )}
+        </Stack>
+
+        <Dialog open={!!confirmDelete} onClose={() => setConfirmDelete(null)}>
+          <DialogTitle>Delete this post?</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              This permanently deletes <strong>{confirmDelete?.title || "this post"}</strong> from Firestore. The public page will start returning 404 immediately.
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setConfirmDelete(null)}>Cancel</Button>
+            <Button onClick={handleDelete} color="error" variant="contained">Delete</Button>
+          </DialogActions>
+        </Dialog>
+      </AdminPage>
+    </RequiredAuthProvider>
+  );
+};
+
+export default AdminBlogList;

--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -28,6 +28,7 @@ import {
   Group as TeamsIcon,
   Dashboard as DashboardIcon,
   Share as ShareIcon,
+  Article as ArticleIcon,
 } from "@mui/icons-material";
 import HandshakeIcon from '@mui/icons-material/Handshake';
 
@@ -98,11 +99,17 @@ const adminPages = [
     description: "Manage prizes and giveaways",
     icon: <GiftIcon fontSize="large" style={{ color: "#ff9800" }} />
   },
-  { 
-    path: "/admin/social-media", 
-    label: "Social Media", 
+  {
+    path: "/admin/social-media",
+    label: "Social Media",
     description: "Post news to Threads and other social platforms",
     icon: <ShareIcon fontSize="large" style={{ color: "#1DA1F2" }} />
+  },
+  {
+    path: "/admin/blog",
+    label: "Blog",
+    description: "Write, edit, and manage blog posts with markdown + SEO",
+    icon: <ArticleIcon fontSize="large" style={{ color: "#093170" }} />
   },
 ];
 

--- a/src/pages/blog/[blog_id].js
+++ b/src/pages/blog/[blog_id].js
@@ -74,6 +74,17 @@ export default function BlogPostPage({ title, openGraphData, blogData }) {
         );
     }
 
+    const canonicalUrl = blogData?.seo?.canonical || `https://ohack.dev/blog/${blog_id}`;
+    const datePublished = blogData?.published_at || blogData?.slack_ts_human_readable || new Date().toISOString();
+    const dateModified = blogData?.last_updated || datePublished;
+    const ogImage = openGraphData?.find((og) => og.property === "og:image")?.content || "";
+    const ogDescription = openGraphData?.find((og) => og.property === "og:description")?.content || "";
+    const safeHeadline = String(title).replace("News: ", "").replace(/"/g, '\\"');
+    const safeDescription = String(ogDescription).replace(/"/g, '\\"');
+    const authorBlock = blogData?.author?.name
+      ? `, "author": { "@type": "Person", "name": "${String(blogData.author.name).replace(/"/g, '\\"')}" }`
+      : '';
+
     return (
       <>
         <Head>
@@ -87,18 +98,18 @@ export default function BlogPostPage({ title, openGraphData, blogData }) {
             />
           ))}
           <meta name="robots" content="index, follow" />
-          <link rel="canonical" href={`https://ohack.dev/blog/${blog_id}`} />
+          <link rel="canonical" href={canonicalUrl} />
           <script type="application/ld+json">
             {`
                     {
                         "@context": "https://schema.org",
                         "@type": "BlogPosting",
-                        "headline": "${title.replace("News: ", "")}",
-                        "image": "${openGraphData?.find((og) => og.property === "og:image")?.content || ""}",
-                        "datePublished": "${blogData?.slack_ts_human_readable || new Date().toISOString()}",
-                        "dateModified": "${blogData?.slack_ts_human_readable || new Date().toISOString()}",
-                        "description": "${openGraphData?.find((og) => og.property === "og:description")?.content || ""}",
-                        "url": "https://ohack.dev/blog/${blog_id}",
+                        "headline": "${safeHeadline}",
+                        "image": "${ogImage}",
+                        "datePublished": "${datePublished}",
+                        "dateModified": "${dateModified}",
+                        "description": "${safeDescription}",
+                        "url": "${canonicalUrl}"${authorBlock},
                         "publisher": {
                             "@type": "Organization",
                             "name": "Opportunity Hack",
@@ -109,7 +120,7 @@ export default function BlogPostPage({ title, openGraphData, blogData }) {
                         },
                         "mainEntityOfPage": {
                             "@type": "WebPage",
-                            "@id": "https://ohack.dev/blog/${blog_id}"
+                            "@id": "${canonicalUrl}"
                         }
                     }
                     `}
@@ -176,15 +187,22 @@ export const getStaticProps = async ({ params = {} } = {}) => {
         }
 
         const blogPost = data.text;
-        const title = "OHack Blog: " + blogPost.title; // Improved title format
-        const metaDescription = blogPost.description ? 
-            (blogPost.description.length > 160 ? 
-                blogPost.description.substring(0, 157) + '...' : 
-                blogPost.description) : 
+        const seo = blogPost.seo || {};
+        const title = seo.title || ("OHack Blog: " + blogPost.title);
+        const rawDescription = seo.description || blogPost.description;
+        const metaDescription = rawDescription ?
+            (rawDescription.length > 160 ?
+                rawDescription.substring(0, 157) + '...' :
+                rawDescription) :
             'Read the latest insights from Opportunity Hack, where tech volunteers create solutions for nonprofits.';
         const image =
+          seo.og_image ||
+          blogPost.featured_image ||
           blogPost.image ||
           "https://cdn.ohack.dev/ohack.dev/2024_hackathon_2.webp";
+        const canonicalUrl = seo.canonical || `https://ohack.dev/blog/${params.blog_id}`;
+        const publishedTime = blogPost.published_at || blogPost.slack_ts_human_readable || new Date().toISOString();
+        const authorName = blogPost.author?.name || 'Opportunity Hack';
         
         // Extract keywords from the blog post content
         const extractKeywords = (text) => {
@@ -208,7 +226,9 @@ export const getStaticProps = async ({ params = {} } = {}) => {
             return uniqueWords.slice(0, 8).join(', ');
         };
         
-        const keywords = extractKeywords(blogPost.description + ' ' + blogPost.title);
+        const seoKeywords = Array.isArray(seo.keywords) ? seo.keywords.join(', ') : (typeof seo.keywords === 'string' ? seo.keywords : '');
+        const tagKeywords = Array.isArray(blogPost.tags) ? blogPost.tags.join(', ') : '';
+        const keywords = seoKeywords || tagKeywords || extractKeywords((blogPost.description || '') + ' ' + (blogPost.title || ''));
 
         return {
             props: {
@@ -252,7 +272,7 @@ export const getStaticProps = async ({ params = {} } = {}) => {
                     },
                     {
                         property: 'og:url',
-                        content: `https://ohack.dev/blog/${params.blog_id}`,
+                        content: canonicalUrl,
                         key: 'ogurl',
                     },
                     {
@@ -287,12 +307,12 @@ export const getStaticProps = async ({ params = {} } = {}) => {
                     },
                     {
                         property: 'article:published_time',
-                        content: blogPost.slack_ts_human_readable || new Date().toISOString(),
+                        content: publishedTime,
                         key: 'articlepublished',
                     },
                     {
                         property: 'article:author',
-                        content: 'Opportunity Hack',
+                        content: authorName,
                         key: 'articleauthor',
                     },
                 ],


### PR DESCRIPTION
## Summary

Adds `/admin/blog` — a full CMS for the existing `news` Firestore collection — so we can finally write, edit, publish, and unpublish blog posts without round-tripping through Slack or backend scripts.

- **List page** with search + status filter chips, inline edit/view/delete, "+ New post" → drafts into the editor.
- **Per-post editor** at `/admin/blog/[id]` with sidebar (Content / SEO / Metadata). Mirrors the `/admin/hackathons/[event_id]` hybrid save model — Content + SEO require explicit Save (no surprise saves mid-keystroke); Metadata autosaves debounced 1.5s; status toggle flushes immediately. URL state via shallow router replace.
- **Markdown** authoring via `@uiw/react-md-editor` (already installed; lazy-loaded so it doesn't bloat the SEO/Metadata views). Rendered with `react-markdown` in `SingleNews.js` when `content_format === "markdown"`. Legacy HTML posts render unchanged.
- **Per-post SEO** — title, meta description, keywords, canonical, OG image — with character counts and live Google SERP + social card previews.
- Public `/blog/[id]` now honors `seo.*` overrides for `<title>`, OG / Twitter meta, canonical, `article:published_time`, and `article:author`; falls back to current auto-extraction when blank.
- New `EventCategory.ADMIN` + `admin_blog_*` GA events for view_list, create, edit_save (per section), publish/unpublish/archive, delete, open_ga.

## Backend companion

Needs the matching backend PR for the new admin-gated CRUD routes at `/api/messages/admin/news` (GET/POST/PATCH/DELETE, all behind `volunteer.admin`) and the public `news` filter that hides `status="draft"|"archived"`. The existing public `POST /news` (X-Api-Key, Slack integration) is untouched.

## Schema (all new fields optional; legacy posts stay valid)

- `content_markdown`, `content_format` (`"html" | "markdown"`)
- `featured_image` (overrides auto-generated `image`)
- `author: { name, email, propel_user_id, db_id }`
- `tags: string[]`, `slug`, `status` (`"draft" | "published" | "archived"`), `published_at` (ISO)
- `seo: { title, description, keywords[], canonical, og_image }`
- `last_updated_by`, `created_by`

## Reviewer notes

- Hard delete from the admin list — Firestore doc gone immediately. Confirm dialog has the post title spelled out so it's hard to nuke the wrong one.
- Status changes use a dedicated `setStatus()` that bypasses autosave debounce so the chip updates instantly.
- Markdown-rendered `<img>`s get `loading="lazy"` + `max-width: 100%; height: auto` to keep CWV green.
- `beforeunload` warns when any explicit-save section is dirty.
- No new npm deps — `@uiw/react-md-editor` and `react-markdown` were already in `package.json`.

## Test plan

- [ ] Visit `/admin/blog` logged out → redirect to login. Logged in as non-admin → 403 panel. Logged in as `volunteer.admin` → list loads.
- [ ] Filter chips and search filter the table correctly; counts in the chip labels match.
- [ ] "+ New post" creates a draft and lands on the editor at `/admin/blog/{id}?section=content`.
- [ ] Type in title + description, watch the SEO section's SERP/social previews update live.
- [ ] Edit markdown body — autosave does NOT fire; the Save bar appears; click Save → persists.
- [ ] Toggle Status → Published immediately and the public `/blog/{id}` becomes visible.
- [ ] Toggle Status → Draft and confirm the post disappears from `/blog` and `GET /api/messages/news/{id}` returns empty for the public endpoint.
- [ ] Open `/blog/{id}` for a markdown post → headers, lists, links, code, blockquotes render correctly.
- [ ] In DevTools, confirm GA `google-analytics.com/g/collect` fires on view_list, save (per section), publish, and delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)