### PR TITLE
[Blog] /blog index honors explicit tags, featured_image, author

### DIFF
--- a/src/components/Blog/BlogPage.js
+++ b/src/components/Blog/BlogPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import { TitleContainer, LayoutContainer } from '../../styles/nonprofit/styles';
 import { Typography, Box, Chip, TextField, InputAdornment, Grid, Divider, Paper } from '@mui/material';
 import Button from '@mui/material/Button';
@@ -74,35 +75,53 @@ const SearchContainer = styled(Paper)(({ theme }) => ({
 }));
 
 const BlogPage = ({ posts }) => {
+    const router = useRouter();
     const [newsData, setNewsData] = useState([]);
     const [filteredData, setFilteredData] = useState([]);
     const [searchTerm, setSearchTerm] = useState('');
     const [selectedTag, setSelectedTag] = useState('');
     const [loading, setLoading] = useState(true);
-    
-    // Extract all unique tags from blog posts
+
+    // Extract all unique tags from blog posts.
+    // Prefers explicit tags[] from the admin CMS, then falls back to hashtags in
+    // the description and Slack channel links for legacy posts.
     const getAllTags = (data) => {
         if (!data) return [];
-        
+
         const tagsSet = new Set();
         data.forEach(post => {
-            // Extract hashtags from the description
+            if (Array.isArray(post.tags)) {
+                post.tags.forEach(t => t && tagsSet.add(String(t)));
+            }
+
             const hashtagRegex = /#(\w+)/g;
             const matches = post.description?.match(hashtagRegex) || [];
-            
-            matches.forEach(tag => {
-                tagsSet.add(tag.substring(1)); // Remove the # character
-            });
-            
-            // Also include any Slack channels as tags
+            matches.forEach(tag => tagsSet.add(tag.substring(1)));
+
             post.links?.forEach(link => {
-                if (link.url.startsWith('#')) {
+                if (link.url?.startsWith('#')) {
                     tagsSet.add(link.name);
                 }
             });
         });
-        
-        return Array.from(tagsSet);
+
+        return Array.from(tagsSet).sort((a, b) => a.localeCompare(b));
+    };
+
+    // Whether a post should be included for the given selected tag.
+    const postMatchesTag = (post, tag) => {
+        if (!tag) return true;
+        const lower = tag.toLowerCase();
+        if (Array.isArray(post.tags) && post.tags.some(t => String(t).toLowerCase() === lower)) {
+            return true;
+        }
+        if (post.description?.toLowerCase().includes(`#${lower}`)) {
+            return true;
+        }
+        if (post.links?.some(link => link.url?.startsWith('#') && link.name?.toLowerCase() === lower)) {
+            return true;
+        }
+        return false;
     };
 
     useEffect(() => {
@@ -128,63 +147,84 @@ const BlogPage = ({ posts }) => {
         }
     }, [posts]);
 
+    // Hydrate selectedTag from ?tag= so chip clicks from SingleNews.js land here filtered.
     useEffect(() => {
-        // Filter data based on search term and selected tag
-        if (newsData) {
-            let filtered = [...newsData];
-            
-            if (searchTerm) {
-                const term = searchTerm.toLowerCase();
-                filtered = filtered.filter(post => 
-                    post.title?.toLowerCase().includes(term) || 
-                    post.description?.toLowerCase().includes(term)
-                );
-                
-                // Track search event
-                ga.trackStructuredEvent(
-                    ga.EventCategory.CONTENT,
-                    'search',
-                    'blog_content',
-                    null,
-                    { search_term: searchTerm }
-                );
-            }
-            
-            if (selectedTag) {
-                filtered = filtered.filter(post => {
-                    // Check description for hashtags
-                    const hasTagInDescription = post.description?.toLowerCase().includes(`#${selectedTag.toLowerCase()}`);
-                    
-                    // Check if any Slack channel matches the tag
-                    const hasTagInLinks = post.links?.some(link => 
-                        link.url.startsWith('#') && link.name.toLowerCase() === selectedTag.toLowerCase()
-                    );
-                    
-                    return hasTagInDescription || hasTagInLinks;
-                });
-                
-                // Track tag selection event
-                ga.trackStructuredEvent(
-                    ga.EventCategory.CONTENT,
-                    'filter',
-                    'blog_tag',
-                    null,
-                    { selected_tag: selectedTag }
-                );
-            }
-            
-            setFilteredData(filtered);
+        if (!router.isReady) return;
+        const urlTag = Array.isArray(router.query.tag) ? router.query.tag[0] : router.query.tag;
+        setSelectedTag(urlTag || '');
+    }, [router.isReady, router.query.tag]);
+
+    useEffect(() => {
+        if (!newsData) return;
+        let filtered = [...newsData];
+
+        if (searchTerm) {
+            const term = searchTerm.toLowerCase();
+            filtered = filtered.filter(post => {
+                const tagBlob = Array.isArray(post.tags) ? post.tags.join(' ') : '';
+                const authorBlob = post.author?.name || '';
+                return [
+                    post.title,
+                    post.description,
+                    post.content_markdown,
+                    tagBlob,
+                    authorBlob,
+                ]
+                    .filter(Boolean)
+                    .join(' ')
+                    .toLowerCase()
+                    .includes(term);
+            });
+
+            ga.trackStructuredEvent(
+                ga.EventCategory.CONTENT,
+                'search',
+                'blog_content',
+                null,
+                { search_term: searchTerm }
+            );
         }
+
+        if (selectedTag) {
+            filtered = filtered.filter(post => postMatchesTag(post, selectedTag));
+
+            ga.trackStructuredEvent(
+                ga.EventCategory.CONTENT,
+                'filter',
+                'blog_tag',
+                null,
+                { selected_tag: selectedTag }
+            );
+        }
+
+        setFilteredData(filtered);
     }, [searchTerm, selectedTag, newsData]);
 
     const handleSearch = (event) => {
         setSearchTerm(event.target.value);
     };
-    
-    const handleTagClick = (tag) => {
-        setSelectedTag(tag === selectedTag ? '' : tag);
+
+    const updateTagInUrl = (tag) => {
+        const { tag: _drop, ...rest } = router.query;
+        const nextQuery = tag ? { ...rest, tag } : rest;
+        router.replace({ pathname: router.pathname, query: nextQuery }, undefined, {
+            shallow: true,
+            scroll: false,
+        });
     };
-    
+
+    const handleTagClick = (tag) => {
+        const next = tag === selectedTag ? '' : tag;
+        setSelectedTag(next);
+        updateTagInUrl(next);
+    };
+
+    const clearFilters = () => {
+        setSearchTerm('');
+        setSelectedTag('');
+        updateTagInUrl('');
+    };
+
     const tags = getAllTags(newsData);
 
     return (
@@ -243,13 +283,10 @@ const BlogPage = ({ posts }) => {
                             <Typography variant="h6">
                                 No blog posts found matching your criteria.
                             </Typography>
-                            <Button 
-                                variant="contained" 
-                                color="primary" 
-                                onClick={() => {
-                                    setSearchTerm('');
-                                    setSelectedTag('');
-                                }}
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={clearFilters}
                                 sx={{ mt: 2 }}
                             >
                                 Clear Filters

--- a/src/components/News/News.js
+++ b/src/components/News/News.js
@@ -2,8 +2,9 @@ import React, { useState, useEffect } from "react";
 import Head from "next/head";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import PersonIcon from "@mui/icons-material/Person";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
-import { Alert, Snackbar, Skeleton, Box, Typography } from "@mui/material";
+import { Alert, Chip, Snackbar, Skeleton, Stack, Box, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import {
   BlankContainer,
@@ -61,18 +62,17 @@ const formatDate = (dateString) => {
 // Generate structured data for SEO
 const generateStructuredData = (newsData) => {
   if (!newsData || newsData.length === 0) return null;
-  
+
   const articles = newsData.map(item => ({
     "@type": "NewsArticle",
     "headline": item.title,
     "description": item.description,
     "url": `https://ohack.dev/blog/${item.id}`,
-    "datePublished": item.slack_ts_human_readable,
-    "dateModified": item.slack_ts_human_readable,
-    "author": {
-      "@type": "Organization",
-      "name": "Opportunity Hack"
-    },
+    "datePublished": item.published_at || item.slack_ts_human_readable,
+    "dateModified": item.last_updated || item.published_at || item.slack_ts_human_readable,
+    "author": item.author?.name
+      ? { "@type": "Person", "name": item.author.name }
+      : { "@type": "Organization", "name": "Opportunity Hack" },
     "publisher": {
       "@type": "Organization",
       "name": "Opportunity Hack",
@@ -81,7 +81,7 @@ const generateStructuredData = (newsData) => {
         "url": "https://ohack.dev/logo.png"
       }
     },
-    "image": item.image || "https://ohack.dev/default-news.png",
+    "image": item.featured_image || item.image || "https://ohack.dev/default-news.png",
     "mainEntityOfPage": {
       "@type": "WebPage",
       "@id": `https://ohack.dev/blog/${item.id}`
@@ -176,8 +176,28 @@ function News({ newsData, frontpage, loading }) {
           </React.Fragment>
         ))
       ) : (
-        newsData?.map((newsItem, index) => (
-          <BlankContainer 
+        newsData?.map((newsItem, index) => {
+          const heroImage = newsItem.featured_image || newsItem.image;
+          const publishedDate = newsItem.published_at || newsItem.slack_ts_human_readable;
+          const authorName = newsItem.author?.name;
+          const explicitTags = Array.isArray(newsItem.tags) ? newsItem.tags.slice(0, 4) : [];
+          // For markdown posts, fall back to a markdown-stripped excerpt when
+          // description is missing or short.
+          const stripMd = (md) =>
+            (md || '')
+              .replace(/```[\s\S]*?```/g, '')
+              .replace(/`[^`]*`/g, '')
+              .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+              .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+              .replace(/^[#>\-*\d.\s]+/gm, '')
+              .replace(/[*_~`]/g, '')
+              .replace(/\s+/g, ' ')
+              .trim();
+          const previewText = (newsItem.description && newsItem.description.length > 40)
+            ? newsItem.description
+            : (newsItem.content_format === 'markdown' ? stripMd(newsItem.content_markdown).slice(0, 280) : newsItem.description);
+          return (
+          <BlankContainer
             key={newsItem.id}
             component="article"
             role="article"
@@ -185,7 +205,7 @@ function News({ newsData, frontpage, loading }) {
           >
             <TitleContainer component="header">
               <Box display="flex" alignItems="flex-start" mb={2} gap={2}>
-                {newsItem.image && (
+                {heroImage && (
                   <Box
                     sx={{
                       width: 70,
@@ -197,7 +217,7 @@ function News({ newsData, frontpage, loading }) {
                     }}
                   >
                     <Image
-                      src={normalizeImageUrl(newsItem.image)}
+                      src={normalizeImageUrl(heroImage)}
                       alt={`Featured image for ${newsItem.title}`}
                       fill
                       style={{ objectFit: 'cover' }}
@@ -206,11 +226,11 @@ function News({ newsData, frontpage, loading }) {
                   </Box>
                 )}
                 <Box flex={1} minWidth={0}>
-                  <Typography 
-                    variant="h3" 
+                  <Typography
+                    variant="h3"
                     component="h2"
                     id={`news-title-${newsItem.id}`}
-                    sx={{ 
+                    sx={{
                       fontSize: { xs: '1.25rem', sm: '1.5rem' },
                       fontWeight: 600,
                       lineHeight: 1.3,
@@ -218,33 +238,59 @@ function News({ newsData, frontpage, loading }) {
                       color: '#1a1a1a'
                     }}
                   >
-                    <Link 
-                      href={`/blog/${newsItem.id}`} 
+                    <Link
+                      href={`/blog/${newsItem.id}`}
                       style={{ textDecoration: 'none', color: 'inherit' }}
                       aria-label={`Read full article: ${newsItem.title}`}
                     >
                       {newsItem.title}
                     </Link>
                   </Typography>
-                  
-                  <Box display="flex" alignItems="center" gap={1} mb={1}>
-                    <AccessTimeIcon 
-                      sx={{ fontSize: '1rem', color: 'text.secondary' }} 
-                      aria-hidden="true" 
-                    />
-                    <Typography 
-                      component="time" 
-                      dateTime={newsItem.slack_ts_human_readable}
-                      sx={{ 
-                        fontSize: '0.875rem', 
-                        color: 'text.secondary',
-                        fontWeight: 500
-                      }}
-                    >
-                      {formatDate(newsItem.slack_ts_human_readable)}
-                    </Typography>
-                  </Box>
-                  
+
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={2}
+                    flexWrap="wrap"
+                    useFlexGap
+                    sx={{ mb: 1 }}
+                  >
+                    <Box display="flex" alignItems="center" gap={0.5}>
+                      <AccessTimeIcon
+                        sx={{ fontSize: '1rem', color: 'text.secondary' }}
+                        aria-hidden="true"
+                      />
+                      <Typography
+                        component="time"
+                        dateTime={publishedDate}
+                        sx={{
+                          fontSize: '0.875rem',
+                          color: 'text.secondary',
+                          fontWeight: 500
+                        }}
+                      >
+                        {formatDate(publishedDate)}
+                      </Typography>
+                    </Box>
+                    {authorName && (
+                      <Box display="flex" alignItems="center" gap={0.5}>
+                        <PersonIcon
+                          sx={{ fontSize: '1rem', color: 'text.secondary' }}
+                          aria-hidden="true"
+                        />
+                        <Typography
+                          sx={{
+                            fontSize: '0.875rem',
+                            color: 'text.secondary',
+                            fontWeight: 500
+                          }}
+                        >
+                          {authorName}
+                        </Typography>
+                      </Box>
+                    )}
+                  </Stack>
+
                   <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
                     {newsItem.slack_permalink && (
                       <SlackButton
@@ -262,8 +308,8 @@ function News({ newsData, frontpage, loading }) {
                       onClick={() => handleCopy(
                         `${newsItem.title} ${newsItem.description} More at https://ohack.dev/blog/${newsItem.id}`
                       )}
-                      sx={{ 
-                        cursor: "pointer", 
+                      sx={{
+                        cursor: "pointer",
                         fontSize: '1.2rem',
                         color: 'text.secondary',
                         '&:hover': { color: 'primary.main' }
@@ -275,17 +321,40 @@ function News({ newsData, frontpage, loading }) {
               </Box>
             </TitleContainer>
 
-            <CaptionContainer 
+            <CaptionContainer
               component="div"
               sx={{
                 fontSize: '1rem',
                 lineHeight: 1.6,
                 color: 'text.primary',
-                mb: 3
+                mb: explicitTags.length > 0 ? 2 : 3
               }}
             >
-              {newsItem.description}
+              {previewText}
             </CaptionContainer>
+
+            {explicitTags.length > 0 && (
+              <Box sx={{ mb: 3 }}>
+                <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+                  {explicitTags.map((tag) => (
+                    <Link
+                      key={tag}
+                      href={`/blog?tag=${encodeURIComponent(tag)}`}
+                      style={{ textDecoration: 'none' }}
+                    >
+                      <Chip
+                        label={`#${tag}`}
+                        size="small"
+                        variant="outlined"
+                        clickable
+                        onClick={() => gaButton("tag_click", tag)}
+                        sx={{ borderRadius: 1 }}
+                      />
+                    </Link>
+                  ))}
+                </Stack>
+              </Box>
+            )}
             
             {newsItem.links && newsItem.links.length > 0 && (
               <Box component="nav" aria-label="Related links" sx={{ mb: 2 }}>
@@ -331,7 +400,8 @@ function News({ newsData, frontpage, loading }) {
             )}
             
           </BlankContainer>
-        ))
+          );
+        })
       )}
       
       <Snackbar


### PR DESCRIPTION
## Summary

Follow-up to #293. The first PR added the `/admin/blog` CMS and updated the single-post page (`/blog/[id]`), but the blog **index** and the card list (`News.js`) were still ignoring the new admin fields. This pulls them through so posts authored via the new CMS show up correctly on `/blog` without losing any legacy behavior.

## What changed

**`BlogPage.js`**
- Tag chip strip now prefers explicit `post.tags[]` from the CMS, then falls back to hashtag regex + Slack channel links for legacy posts. Sorted alphabetically.
- Search filter also matches `tags[]`, `author.name`, and the markdown body — so a post titled in markdown still surfaces.
- Selected tag is now URL-driven via `?tag=foo` (shallow `router.replace`). Chip clicks from `SingleNews.js` (and any external `/blog?tag=...` link) hydrate the filter on landing, so the URL actually behaves like a deep link.
- "Clear Filters" also clears the URL.

**`News.js` (card list used on `/blog` and the homepage)**
- Hero image prefers `featured_image` over the legacy auto-generated `image`.
- Author name shown next to the timestamp when `post.author.name` is set.
- Explicit `tags[]` render as clickable chips on each card; they link back to `/blog?tag=foo`.
- For markdown posts with no/short `description`, the card excerpt falls back to a stripped markdown preview so cards aren't blank.
- `ItemList` JSON-LD updated: `datePublished/dateModified` use `published_at`, `author` becomes a `Person` when `post.author.name` exists, `image` uses `featured_image`.

## Reviewer notes

- Backward compatible — every change is `featured_image || image`, `published_at || slack_ts_human_readable`, `tags[] OR regex`. Legacy posts render identically.
- No new deps. No new env vars. Only `BlogPage.js` and `News.js` are touched.
- The markdown excerpt stripper is intentionally simple (regex-based) — it handles fenced code, inline code, images, links, list markers, and emphasis. Anything more complex would warrant a real markdown→text lib, but for a 280-char card preview the regex is fine.
- `?tag=` hydration uses `router.isReady` to avoid a flash of unfiltered content on first render.

## Test plan

- [ ] `/blog` loads — chip strip shows explicit tags first, then legacy hashtags. Click a chip → URL becomes `/blog?tag=foo` and only matching posts show.
- [ ] Paste `/blog?tag=foo` directly into the address bar → page hydrates with that tag pre-selected.
- [ ] Click a tag chip on `/blog/[id]` → lands on `/blog?tag=foo` filtered correctly.
- [ ] Edit a post in `/admin/blog/[id]`, set `featured_image`, save, reload `/blog` → card hero uses the new image.
- [ ] Set author name + tags in MetadataSection, save, reload `/blog` → both appear on the card.
- [ ] Create a markdown-only post (no description), reload `/blog` → card shows a stripped excerpt rather than a blank body.
- [ ] View page source on `/blog` → `ItemList` JSON-LD has `Person` author when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)