### PR TITLE
[Admin] Hackathon edit — consistent section frame width

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,23 @@
 - E2E tests located in `/src/tests/e2e/`
 - Mock implementation examples available in test files
 
+## Admin layout width
+`AdminPage`'s `AdminPageContainer` (`src/components/admin/AdminPage.js`) is a plain `Box` (NOT MUI `Container`) with `width: 100%`, `maxWidth: none` at all breakpoints. The Container variant kept reintroducing a 1400px desktop cap via its internal media-query rules even with `maxWidth={false}` — using `Box` avoids that. Admin tables (teams, volunteer, profile, hackathon edit) need the full viewport on desktop. Don't switch back to `Container` or add a maxWidth here. If a specific admin section wants centered narrower content, scope it to that section's wrapper. `SectionContainer` (`src/components/admin/hackathon-edit/SectionContainer.js`) carries explicit `width: 100%; boxSizing: border-box` on its Paper so every section renders to the same visible width regardless of inner content (TextField stack vs. Grid of cards).
+
+### Hackathon admin section frame contract
+Every section under `/admin/hackathons/[event_id]?section=...` MUST render through `SectionContainer` so the outer frame width is identical across sidebar tabs. Heavy sections (Teams, Judging, Volunteer, CheckIn) that embed their own Paper-laden workbenches/tabs use `<SectionContainer disableGutters>` — the outer Paper border + `width:100%; boxSizing:border-box` contract is preserved, but the inner 24px padding is dropped so the embedded content doesn't double-pad. Heavy sections add their own `Box sx={{ p: { xs:2, md:3 } }}` around the body (after the Tabs strip if any) so spacing inside the frame still feels right. `HackathonAdminLayout`'s content Box uses `scrollbarGutter: stable` so a section with internal scrolling doesn't shift the visible width by ~17px. Don't reintroduce bare `<Box>` section roots — that breaks the frame consistency and is the bug that motivated this contract.
+
+#### Width clipping layers (don't remove)
+Initially the section frame alone wasn't enough — `MealsSection` was visibly wider than `ScheduleSection` because something deep in its tree (Grid item width math or a fixed-width input row) was pushing horizontal overflow up to the document body, which made the whole `AdminPage` card grow and shift the sidebar sideways between section navigations. The fix is layered `overflowX: hidden` clips at every level above the section so overflow never escapes:
+1. `AdminPage` root `<Box>`: `overflowX: hidden` + `maxWidth: 100%`
+2. `AdminPageContainer` styled: `overflowX: hidden` + `minWidth: 0`
+3. `AdminPageContent` styled: `overflowX: hidden` + `width: 100%; maxWidth: 100%; minWidth: 0; boxSizing: border-box`
+4. `HackathonAdminLayout` root flex: already has `overflow: hidden`
+5. `HackathonAdminLayout` content scroll box: `overflowX: hidden; minWidth: 0; scrollbarGutter: stable; overflowY: auto`
+6. `SectionContainer` Paper: `width: 100%; maxWidth: 100%; minWidth: 0; boxSizing: border-box`
+
+Removing any of these and a section that contains wide intrinsic min-content (e.g. side-by-side fixed-width inputs, a wide table, a long unbreakable label) will start shifting the whole admin layout sideways again. Tooltips/dialogs render through MUI Portal so they're not affected by these clips.
+
 ## Core Web Vitals (CLS hygiene)
 Patterns that must stay in place to keep Google Search Console CWV green:
 - `NavBar` and `Footer` are `ssr: true` in `_app.js`; their loading placeholders in `_app.js` match the rendered heights (NavBar 64px, Footer 760px/560px mobile/desktop). Don't flip them back to `ssr: false`.

--- a/src/components/admin/AdminPage.js
+++ b/src/components/admin/AdminPage.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Typography, Box, Snackbar, Alert, useTheme, useMediaQuery, Container } from "@mui/material";
+import { Typography, Box, Snackbar, Alert, useTheme, useMediaQuery } from "@mui/material";
 import Head from "next/head";
 import { styled } from "@mui/system";
 import dynamic from "next/dynamic";
@@ -8,12 +8,20 @@ const AdminNavigation = dynamic(() => import("./AdminNavigation"), {
   ssr: false,
 });
 
-const AdminPageContainer = styled(Container)(({ theme }) => ({
+const AdminPageContainer = styled(Box)(({ theme }) => ({
   width: "100%",
+  maxWidth: "100%",
+  minWidth: 0,
+  marginLeft: 0,
+  marginRight: 0,
   padding: theme.spacing(2),
+  // Backstop: clip any horizontal overflow from descendants so deep child
+  // content (e.g. a wide grid in a section) can't push the document body
+  // wider than the viewport. Without this, sections that render wider
+  // intrinsic min-content shift the whole AdminPage card horizontally
+  // (sidebar appears at a different x between sections).
+  overflowX: "hidden",
   [theme.breakpoints.up("md")]: {
-    width: "95%",
-    maxWidth: "1400px",
     padding: theme.spacing(3),
   },
 }));
@@ -31,6 +39,13 @@ const AdminPageContent = styled(Box)(({ theme }) => ({
   background: theme.palette.background.paper,
   borderRadius: theme.shape.borderRadius,
   padding: theme.spacing(2),
+  width: "100%",
+  maxWidth: "100%",
+  minWidth: 0,
+  boxSizing: "border-box",
+  // Same backstop as the container — a deep grandchild can't widen this
+  // card past its containing block.
+  overflowX: "hidden",
   [theme.breakpoints.up("md")]: {
     padding: theme.spacing(3),
   },
@@ -42,12 +57,19 @@ const AdminPage = ({ title, children, snackbar, onSnackbarClose, isAdmin }) => {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   return (
-    <Box 
-      sx={{ 
+    <Box
+      sx={{
         minHeight: "100vh",
-        backgroundColor: "#f5f5f5", 
+        backgroundColor: "#f5f5f5",
         pb: 4,
-        pt: isMobile ? 0 : 2
+        pt: isMobile ? 0 : 2,
+        // Highest-level horizontal-overflow clip. Prevents any deep child
+        // from widening the document body past the viewport (which was
+        // shifting the entire AdminPage card sideways between sections —
+        // e.g. Meals vs Overview).
+        width: "100%",
+        maxWidth: "100%",
+        overflowX: "hidden",
       }}
     >
       <Head>
@@ -55,7 +77,7 @@ const AdminPage = ({ title, children, snackbar, onSnackbarClose, isAdmin }) => {
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
       </Head>
 
-      <AdminPageContainer maxWidth={false}>
+      <AdminPageContainer>
         {isAdmin && <AdminNavigation />}
         
         <AdminPageTitle isMobile={isMobile}>

--- a/src/components/admin/hackathon-edit/HackathonAdminLayout.js
+++ b/src/components/admin/hackathon-edit/HackathonAdminLayout.js
@@ -171,8 +171,16 @@ const HackathonAdminLayout = ({
           </Stack>
         </Box>
 
-        {/* Content */}
-        <Box sx={{ p: { xs: 2, md: 3 }, flex: 1, overflowY: "auto" }}>{children}</Box>
+        {/* Content — width contract:
+            - `overflowY: auto` + `scrollbarGutter: stable` keep width identical between
+              scrollable and non-scrollable sections (no ~17px scrollbar jitter).
+            - `overflowX: hidden` + `minWidth: 0` are critical: MUI Grid container's
+              negative margins (e.g. `spacing={3}` in MealsSection) extend the grid
+              past its parent's content area. Without these, sections containing
+              `<Grid container spacing=...>` visibly bleed wider than sections built
+              with `<Stack>` (e.g. ScheduleSection). Clipping here pins every section
+              to the same outer width. */}
+        <Box sx={{ p: { xs: 2, md: 3 }, flex: 1, minWidth: 0, overflowY: "auto", overflowX: "hidden", scrollbarGutter: "stable" }}>{children}</Box>
       </Box>
     </Box>
   );

--- a/src/components/admin/hackathon-edit/SectionContainer.js
+++ b/src/components/admin/hackathon-edit/SectionContainer.js
@@ -16,17 +16,58 @@ const SectionContainer = ({
   onSave,
   onDiscard,
   saveLabel = "Save changes",
+  // When true, drops the Paper's internal padding so heavy content
+  // (Tabs, workbenches with their own Paper elements) renders flush
+  // inside the same outer frame. The border + width contract stay
+  // so every section has the same outer width regardless of variant.
+  disableGutters = false,
 }) => {
+  const hasHeader = !!(title || description);
   return (
-    <Paper elevation={0} sx={{ p: { xs: 2, md: 3 }, border: "1px solid", borderColor: "divider", position: "relative" }}>
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ xs: "flex-start", sm: "center" }} justifyContent="space-between" sx={{ mb: description ? 1 : 2 }}>
-        <Typography variant="h5" component="h2" sx={{ fontWeight: 700 }}>{title}</Typography>
-        {actions && <Box>{actions}</Box>}
-      </Stack>
-      {description && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          {description}
-        </Typography>
+    <Paper
+      elevation={0}
+      sx={{
+        p: disableGutters ? 0 : { xs: 2, md: 3 },
+        border: "1px solid",
+        borderColor: "divider",
+        position: "relative",
+        // Width contract: every section's Paper renders at exactly the
+        // parent content area's width. `width: 100%` + `boxSizing: border-box`
+        // is enforcement, `maxWidth: 100%` + `minWidth: 0` are belts so a
+        // child with intrinsic min-content larger than the parent can't push
+        // the Paper wider (the content overflow is then clipped by the
+        // scroll container's `overflowX: hidden`).
+        width: "100%",
+        maxWidth: "100%",
+        minWidth: 0,
+        boxSizing: "border-box",
+      }}
+    >
+      {hasHeader && (
+        <Box
+          sx={{
+            px: disableGutters ? { xs: 2, md: 3 } : 0,
+            pt: disableGutters ? { xs: 2, md: 3 } : 0,
+          }}
+        >
+          {title && (
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1}
+              alignItems={{ xs: "flex-start", sm: "center" }}
+              justifyContent="space-between"
+              sx={{ mb: description ? 1 : 2 }}
+            >
+              <Typography variant="h5" component="h2" sx={{ fontWeight: 700 }}>{title}</Typography>
+              {actions && <Box>{actions}</Box>}
+            </Stack>
+          )}
+          {description && (
+            <Typography variant="body2" color="text.secondary" sx={{ mb: disableGutters ? 2 : 3 }}>
+              {description}
+            </Typography>
+          )}
+        </Box>
       )}
       <Box>{children}</Box>
 
@@ -36,8 +77,8 @@ const SectionContainer = ({
             position: "sticky",
             bottom: 0,
             mt: 4,
-            mx: { xs: -2, md: -3 },
-            mb: { xs: -2, md: -3 },
+            mx: disableGutters ? 0 : { xs: -2, md: -3 },
+            mb: disableGutters ? 0 : { xs: -2, md: -3 },
             px: { xs: 2, md: 3 },
             py: 1.5,
             bgcolor: "warning.50",

--- a/src/components/admin/hackathon-edit/sections/CheckInSection.js
+++ b/src/components/admin/hackathon-edit/sections/CheckInSection.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useAuthInfo } from "@propelauth/react";
 import { Alert, Box } from "@mui/material";
 import { CheckInWorkbench } from "../../checkin/CheckInWorkbench";
+import SectionContainer from "../SectionContainer";
 
 const CheckInSection = ({ admin, onSnack }) => {
   const { userClass } = useAuthInfo();
@@ -9,21 +10,25 @@ const CheckInSection = ({ admin, onSnack }) => {
 
   if (!eventId) {
     return (
-      <Alert severity="warning">
-        Save the event ID under Overview before running check-in.
-      </Alert>
+      <SectionContainer title="Check-In">
+        <Alert severity="warning">
+          Save the event ID under Overview before running check-in.
+        </Alert>
+      </SectionContainer>
     );
   }
 
   return (
-    <Box>
-      <CheckInWorkbench
-        userClass={userClass}
-        embedded
-        externalEventId={eventId}
-        onSnack={onSnack}
-      />
-    </Box>
+    <SectionContainer disableGutters>
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <CheckInWorkbench
+          userClass={userClass}
+          embedded
+          externalEventId={eventId}
+          onSnack={onSnack}
+        />
+      </Box>
+    </SectionContainer>
   );
 };
 

--- a/src/components/admin/hackathon-edit/sections/JudgingSection.js
+++ b/src/components/admin/hackathon-edit/sections/JudgingSection.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { Alert, Box, Tab, Tabs } from "@mui/material";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
+import SectionContainer from "../SectionContainer";
 
 const JudgingRound1 = dynamic(() => import("../../JudgingRound1"), { ssr: false });
 const JudgingRound2 = dynamic(() => import("../../JudgingRound2"), { ssr: false });
@@ -43,9 +44,11 @@ const JudgingSection = ({ admin, orgId }) => {
 
   if (!eventId) {
     return (
-      <Alert severity="warning">
-        Save the event ID under Overview before managing judging.
-      </Alert>
+      <SectionContainer title="Judging">
+        <Alert severity="warning">
+          Save the event ID under Overview before managing judging.
+        </Alert>
+      </SectionContainer>
     );
   }
 
@@ -57,8 +60,8 @@ const JudgingSection = ({ admin, orgId }) => {
   };
 
   return (
-    <Box>
-      <Box sx={{ borderBottom: 1, borderColor: "divider", mb: 3 }}>
+    <SectionContainer disableGutters>
+      <Box sx={{ borderBottom: 1, borderColor: "divider", px: { xs: 2, md: 3 } }}>
         <Tabs value={activeTab} onChange={handleTabChange} aria-label="Judging tabs">
           <Tab label="Round 1 - Initial Judging" />
           <Tab label="Round 2 - Final Judging" />
@@ -66,10 +69,12 @@ const JudgingSection = ({ admin, orgId }) => {
         </Tabs>
       </Box>
 
-      {activeTab === 0 && <JudgingRound1 {...shared} />}
-      {activeTab === 1 && <JudgingRound2 {...shared} />}
-      {activeTab === 2 && <JudgingResults {...shared} />}
-    </Box>
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        {activeTab === 0 && <JudgingRound1 {...shared} />}
+        {activeTab === 1 && <JudgingRound2 {...shared} />}
+        {activeTab === 2 && <JudgingResults {...shared} />}
+      </Box>
+    </SectionContainer>
   );
 };
 

--- a/src/components/admin/hackathon-edit/sections/TeamsSection.js
+++ b/src/components/admin/hackathon-edit/sections/TeamsSection.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Alert, Box, Tab, Tabs } from "@mui/material";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
+import SectionContainer from "../SectionContainer";
 
 // Heavy admin sub-pages — lazy-loaded so the section bundle stays small.
 const TeamManagement = dynamic(
@@ -49,15 +50,17 @@ const TeamsSection = ({ admin, orgId }) => {
 
   if (!eventId || !hackathonDocId) {
     return (
-      <Alert severity="warning">
-        Save the event under Overview before managing teams for this hackathon.
-      </Alert>
+      <SectionContainer title="Teams">
+        <Alert severity="warning">
+          Save the event under Overview before managing teams for this hackathon.
+        </Alert>
+      </SectionContainer>
     );
   }
 
   return (
-    <Box>
-      <Box sx={{ borderBottom: 1, borderColor: "divider", mb: 3 }}>
+    <SectionContainer disableGutters>
+      <Box sx={{ borderBottom: 1, borderColor: "divider", px: { xs: 2, md: 3 } }}>
         <Tabs value={activeTab} onChange={handleTabChange} aria-label="Team management tabs">
           <Tab label="Team Management" />
           <Tab label="Team Assignments" />
@@ -65,15 +68,17 @@ const TeamsSection = ({ admin, orgId }) => {
         </Tabs>
       </Box>
 
-      {activeTab === 0 && <TeamManagement orgId={orgId} embeddedHackathonId={hackathonDocId} />}
-      {activeTab === 1 && <TeamAssignments orgId={orgId} embeddedHackathonId={hackathonDocId} />}
-      {activeTab === 2 && (
-        <Alert severity="info">
-          Team statistics dashboard is coming soon. This will include insights on team
-          performance, engagement metrics, and project progress tracking.
-        </Alert>
-      )}
-    </Box>
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        {activeTab === 0 && <TeamManagement orgId={orgId} embeddedHackathonId={hackathonDocId} />}
+        {activeTab === 1 && <TeamAssignments orgId={orgId} embeddedHackathonId={hackathonDocId} />}
+        {activeTab === 2 && (
+          <Alert severity="info">
+            Team statistics dashboard is coming soon. This will include insights on team
+            performance, engagement metrics, and project progress tracking.
+          </Alert>
+        )}
+      </Box>
+    </SectionContainer>
   );
 };
 

--- a/src/components/admin/hackathon-edit/sections/VolunteerSection.js
+++ b/src/components/admin/hackathon-edit/sections/VolunteerSection.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useAuthInfo } from "@propelauth/react";
 import { Box, Alert } from "@mui/material";
 import { VolunteerWorkbench } from "../../volunteer/VolunteerWorkbench";
+import SectionContainer from "../SectionContainer";
 
 const VolunteerSection = ({ admin, onSnack }) => {
   const { userClass } = useAuthInfo();
@@ -9,21 +10,25 @@ const VolunteerSection = ({ admin, onSnack }) => {
 
   if (!eventId) {
     return (
-      <Alert severity="warning">
-        Save the event ID under Overview before managing applications.
-      </Alert>
+      <SectionContainer title="Applications">
+        <Alert severity="warning">
+          Save the event ID under Overview before managing applications.
+        </Alert>
+      </SectionContainer>
     );
   }
 
   return (
-    <Box>
-      <VolunteerWorkbench
-        userClass={userClass}
-        embedded
-        externalEventId={eventId}
-        onSnack={onSnack}
-      />
-    </Box>
+    <SectionContainer disableGutters>
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <VolunteerWorkbench
+          userClass={userClass}
+          embedded
+          externalEventId={eventId}
+          onSnack={onSnack}
+        />
+      </Box>
+    </SectionContainer>
   );
 };
 

--- a/src/components/admin/hackathon-edit/useHackathonAdmin.js
+++ b/src/components/admin/hackathon-edit/useHackathonAdmin.js
@@ -64,7 +64,13 @@ export function useHackathonAdmin({ eventId, accessToken, orgId, isAdmin }) {
       });
       if (!res.ok) throw new Error(`Failed to load hackathons (${res.status})`);
       const data = await res.json();
-      const found = (data.hackathons || []).find((h) => h.event_id === eventId);
+      // Prefer event_id (the slug) but fall back to the Firestore doc id —
+      // legacy hackathons + some of the per-event admin shortcut buttons end
+      // up routing here with the doc id instead of the slug.
+      const list = data.hackathons || [];
+      const found =
+        list.find((h) => h.event_id === eventId) ||
+        list.find((h) => h.id === eventId);
       if (!found) {
         setLoadError(`No hackathon with event_id "${eventId}"`);
         setDraft(null);

--- a/src/pages/admin/hackathons/index.js
+++ b/src/pages/admin/hackathons/index.js
@@ -81,7 +81,7 @@ const AdminHackathonPage = () => {
   }, [isAdmin, fetchHackathons]);
 
   const handleEdit = (hackathon) => {
-    router.push(`/admin/hackathons/${hackathon.event_id}`);
+    router.push(`/admin/hackathons/${hackathon.event_id || hackathon.id}`);
   };
 
   const handleOpenCreate = () => {
@@ -238,7 +238,7 @@ const AdminHackathonPage = () => {
                           size="small"
                           startIcon={<TeamsIcon />}
                           variant="outlined"
-                          onClick={() => router.push(`/admin/teams?event_id=${hackathon.event_id}`)}
+                          onClick={() => router.push(`/admin/teams?event_id=${hackathon.event_id || hackathon.id}`)}
                           sx={{ flex: 1, textTransform: "none", fontSize: "0.7rem", minHeight: 32, px: 0.5, "& .MuiButton-startIcon": { mr: 0.5 } }}
                         >
                           Teams
@@ -247,7 +247,7 @@ const AdminHackathonPage = () => {
                           size="small"
                           startIcon={<VolunteerIcon />}
                           variant="outlined"
-                          onClick={() => router.push(`/admin/volunteer?event_id=${hackathon.event_id}`)}
+                          onClick={() => router.push(`/admin/volunteer?event_id=${hackathon.event_id || hackathon.id}`)}
                           sx={{ flex: 1, textTransform: "none", fontSize: "0.7rem", minHeight: 32, px: 0.5, "& .MuiButton-startIcon": { mr: 0.5 } }}
                         >
                           Volunteer
@@ -258,7 +258,7 @@ const AdminHackathonPage = () => {
                           size="small"
                           startIcon={<CheckInIcon />}
                           variant="outlined"
-                          onClick={() => router.push(`/admin/check-in?event_id=${hackathon.event_id}`)}
+                          onClick={() => router.push(`/admin/check-in?event_id=${hackathon.event_id || hackathon.id}`)}
                           sx={{ flex: 1, textTransform: "none", fontSize: "0.7rem", minHeight: 32, px: 0.5, "& .MuiButton-startIcon": { mr: 0.5 } }}
                         >
                           Check-in
@@ -267,7 +267,7 @@ const AdminHackathonPage = () => {
                           size="small"
                           startIcon={<JudgingIcon />}
                           variant="outlined"
-                          onClick={() => router.push(`/admin/judging?event_id=${hackathon.event_id}`)}
+                          onClick={() => router.push(`/admin/judging?event_id=${hackathon.event_id || hackathon.id}`)}
                           sx={{ flex: 1, textTransform: "none", fontSize: "0.7rem", minHeight: 32, px: 0.5, "& .MuiButton-startIcon": { mr: 0.5 } }}
                         >
                           Judging
@@ -279,7 +279,7 @@ const AdminHackathonPage = () => {
                       fullWidth
                       variant="outlined"
                       startIcon={<LaunchIcon />}
-                      onClick={() => window.open(`/hack/${hackathon.event_id}`, "_blank")}
+                      onClick={() => window.open(`/hack/${hackathon.event_id || hackathon.id}`, "_blank")}
                       sx={{ textTransform: "none", minHeight: 36 }}
                     >
                       View public event page


### PR DESCRIPTION
## Summary

Sections under `/admin/hackathons/[event_id]?section=...` were rendering at different widths between sidebar tabs. The worst case was Meals visibly expanding the entire AdminPage card ~150px wider than Overview — the whole layout (sidebar included) was shifting sideways depending on which section was active.

## Root cause

A deep grandchild in `MealsSection` had intrinsic min-content wider than its container. The horizontal overflow propagated all the way up to the document body, which made the AdminPage's `width: 100%` resolve to body width (which was > viewport). Result: the page card stretched and shifted left.

## Fix

Layered `overflowX: hidden` clips at every ancestor above the section so overflow can't escape, regardless of what a section renders:

1. `AdminPage` root `<Box>` — `overflowX: hidden` + `maxWidth: 100%`
2. `AdminPageContainer` — `overflowX: hidden` + `minWidth: 0`
3. `AdminPageContent` — `overflowX: hidden` + `width/maxWidth: 100%` + `minWidth: 0` + `boxSizing: border-box`
4. `HackathonAdminLayout` content scroll box — `overflowX: hidden` + `minWidth: 0` + `scrollbarGutter: stable`
5. `SectionContainer` Paper — pins `width/maxWidth: 100%` + `minWidth: 0` + `boxSizing: border-box`

Also in this PR:
- Wrap the four "heavy" sections (Teams / Judging / Volunteer / CheckIn) in `<SectionContainer disableGutters>` so they share the identical outer frame contract (border + width) without double-padding the embedded workbench.
- Add doc-id fallback to `useHackathonAdmin` and to the per-event admin shortcut buttons in `/admin/hackathons` (legacy hackathons route here with the Firestore doc id, not the `event_id` slug).
- Document the full clip-layer contract in `CLAUDE.md` so a future change doesn't strip one of them.

Tooltips/dialogs render through MUI Portal so they're unaffected by the clips.

## Test plan

- [ ] Hard-reload `/admin/hackathons/<event_id>?section=overview` and `?section=meals`; sidebar 'CONFIGURE' label should be at the exact same x-position in both
- [ ] Click through every sidebar item (Overview → Schedule → Meals → Participants → Judges → Nonprofits → Media → Planning → Funding → Links → Volunteer admin → Teams → Judging → Check-in); section frame should be the same width on each
- [ ] Verify no horizontal scrollbar appears at the page level on any section
- [ ] Open Teams → confirm tabs (Management / Assignments / Stats) still work and the workbench renders inside the frame without double padding
- [ ] Same for Judging and Volunteer admin
- [ ] Confirm sticky save bar at the bottom of Overview / Schedule still slides with scroll and isn't clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)