### PR TITLE
Redesign /hack page: faster event discovery, scannable archive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,51 @@ File: `src/components/admin/TeamManagement.js` (~2900 lines, hosted in `src/page
 - **Don't N-render the component.** Fetching per-repo GitHub data (issue summaries, issues) used to do a separate `setState` per repo, which re-renders this ~2900-line component once per repo (~12–30 cascading renders on load and on every dialog open). Both prefetch paths now collect results via `Promise.all` and merge into a SINGLE `setGithubIssueSummaries` / `setGithubIssues` call. If you add another per-team batch fetch, follow the same pattern — never call setState in a forEach loop over teams/repos.
 - **No render-body `console.log`s.** Logs at module top-level inside the component body (e.g. `console.log("Team Data:", teamData)`) fire on EVERY render. They turn a render storm into console spam and slow the page further. Keep diagnostic logs inside callbacks or effects, never in the render path.
 
+## /hack Index Page Architecture
+
+The page is intentionally optimized so a visitor reaches an upcoming event in the first ~250px of scroll. The order is **hero → upcoming events → story strip → archive → "About these events" (merged Why Join + Before signing up) → Sponsor CTA**. Do not re-insert marketing copy ("Why Join") or news ("Latest Updates") between hero and events — both were removed because they pushed events 900+px below the fold.
+
+Hero is intentionally minimal: one h1 (`<h1>Hackathons for nonprofits</h1>`) + two CTAs ("See upcoming events" / "Join the community"). The long "Since 2013, we've helped 100+ nonprofits..." tagline was removed because the Story Strip immediately below shows that with concrete numbers. Don't re-add the tagline.
+
+**Section IDs (load-bearing for `HackPageNav` and other anchor consumers):**
+- `#upcoming-events` on the upcoming events `<Box>` wrapper in `pages/hack/index.js`
+- `#since-2013` on the outer `<Box>` of `HackathonStoryStrip`
+- `#previous-events` on the `OuterGrid` of `PreviousHackathonList`
+- `#about-events` on the merged Why Join + Before You Join section in `pages/hack/index.js`
+- `#year-{yyyy}` on each `YearSection` inside the archive
+- All section anchors carry `scrollMarginTop: 100` (or higher) so jumps don't get hidden behind the 80px NavBar.
+
+### HackPageNav (page-level TOC)
+`src/components/HackathonList/HackPageNav.js` — small floating widget showing the four top-level sections. Hidden until hero scrolls past (driven by a rAF-throttled scroll listener checking when `h1.getBoundingClientRect().bottom < 60`). Desktop: `position: fixed; left: 16px; top: 50%` vertical pill stack. Mobile: `position: fixed; top: 64px` (below NavBar) horizontal scrollable pill bar. Active state follows scroll position via the same rAF anchor-line pattern as the archive (`anchorY = 160`). Updating the section list = edit `SECTIONS` array at the top of the file.
+
+### HackathonList — news removed
+The "Latest Updates" news block inside `HackathonList` is rendered ONLY in `compact={true}` mode (used by the home page sidebar). On `/hack`, the news fetch is gated by `if (!compact) return undefined;` in its `useEffect` to avoid the network call. The full-width `/hack` render shows a small "Read latest updates from Opportunity Hack" link to `/blog` below the events grid. Do not re-add news to the full-width render — it broke the events → strip → archive flow and added ~500-800px of scroll.
+
+### About these events (merged section)
+After the archive, `#about-events` combines:
+1. A compact "What you get" 4-up icon row (Code / Group / EmojiEvents / EventAvailable) — replaces the old "Why Join" Paper. No big photo. Icons + 1-line descriptions.
+2. The original "Before signing up" 3-card row (Code of Conduct / Liability Waiver / Photo Release).
+Both share the same h2 ("About these events") and are stacked under `overline` sub-headings. Don't promote either back above the events — they're context, not finder-flow.
+
+## Story Strip + Year-Grouped Archive
+`HackathonStoryStrip` (`src/components/HackathonList/HackathonStoryStrip.js`) bridges `<HackathonList />` (upcoming) and `<PreviousHackathonList />` (archive) on `/hack`. It fetches `GET /api/messages/hackathons/funnel/aggregate` for stat tiles and derives a year sparkline from `useHackathonEvents("previous"|"current")` (no extra fetch).
+
+- **Year jump uses a CustomEvent, NOT URL hash.** Clicking a year dot dispatches `window.dispatchEvent(new CustomEvent('ohack:archive-jump-year', { detail: { year } }))`. `PreviousHackathonList` listens for that event, sets `activeYear`, then scrolls `#year-{yyyy}` into view. Don't switch to hash-based — it would collide with deep-link patterns elsewhere.
+- **Arizona callout lives INSIDE the strip.** Previously a standalone `<Alert>` between "Why Join" and Upcoming. Do not re-add it to `pages/hack/index.js` — it now sits below the year sparkline inside `HackathonStoryStrip`.
+- **CLS guardrail.** Strip reserves `minHeight: { xs: 420, md: 240 }` on its outer `<Box>`. Funnel data load shows `Skeleton`s inside the stat tiles, not a missing component. Don't return `null` while loading.
+- **Heading:** strip uses `<h2 id="story-strip-heading">`. Page-level h1 ("Hackathons") in `pages/hack/index.js` is the only h1 — keep it that way.
+
+### Previous Events archive — year-grouped, no pagination, photo-led
+`PreviousHackathonList` (`src/components/HackathonList/PreviousHackathonList.js`) renders the full 12+ year archive on one continuous scroll. **No pagination, no year-filter chips** — the prior design (8/page + chip filter + scroll-to-top jumps) created the "takes a while to click around" friction the redesign addresses.
+
+- **Year-grouped layout.** Events are grouped by `format(parseLocalDate(start_date), 'yyyy')`, sorted desc. Each year renders as a `<YearSection>` with `id="year-{yyyy}"` anchor, year heading (h3), and event-count chip. `scrollMarginTop: { xs: 130, md: 100 }` accounts for the NavBar (~80px).
+- **Sticky vertical `YearRail`** (desktop ≥md): left-side `<nav aria-label="Jump to a year">` with `position: sticky; top: 84px`, vertical list of year buttons sized by event count. On mobile (<md): horizontal sticky bar at `top: 64px`. Clicking a year scrolls to `#year-{yyyy}` and sets `activeYear` state (which drives the bright-blue active pill via `$active` styled-component prop). **`activeYear` is click-driven only** — earlier scroll-driven IntersectionObserver/scroll-listener attempts fought smooth-scroll race conditions (last in-flight year would win the final state, landing on neighbor). Cut entirely; cleaner code, no race.
+- **Photo-led `PastEventCard`.** Cards lead with a 16:9 image header from `event.event_photos?.[0]?.url`. When absent, fall back to a `GradientFallback` that hashes year → HSL hue (`((year - 2013) * 37) % 360`) so the wall doesn't feel monotone. `next/image` with `fill` + `sizes` + `loading="lazy"`. `event.image_url` is intentionally NOT used as a fallback (it's typically the generic OHack logo on legacy events — would make every card look the same).
+- **Image domain allowlist.** `cdn.ohack.dev` is in `next.config.js` `images.remotePatterns`. Adding new event-photo CDN domains requires updating that file too.
+- **`LazyMount` per card.** `ImpactMetrics` per-card API fetch is gated by IntersectionObserver with `rootMargin: '300px'`. The archive is long (~30+ cards across 13 year groups); without this, every card fetches on mount → CORS-flood the backend. Keep it.
+- **Layout flex.** `<Box display="flex" flexDirection={{xs:'column', md:'row'}}>` wraps `YearRail` + content area. Year rail width is `108px` on desktop. Content area uses `<Grid container spacing={2}>` with `size={{ xs: 12, sm: 6, md: 4, lg: 3 }}` — 4 cards/row on lg, 3 on md, 2 on sm, 1 on xs.
+- **Don't reintroduce pagination.** The whole point of this redesign is one continuous scroll with rail-teleport. If you need to gate something for perf, prefer further lazy-loading of card content, not paging the list.
+
 ## Local Landing Pages
 
 ### Arizona Hackathons (`/hackathons/arizona`)
@@ -333,7 +378,7 @@ File: `src/components/admin/TeamManagement.js` (~2900 lines, hosted in `src/page
 - Targets: "asu hackathon", "phoenix hackathon", "hack arizona", "hackathons in arizona", etc.
 - Uses `useHackathonEvents("current")` and `useHackathonEvents("previous")` with `isArizonaLocation()` filter (AZ_LOCATION_PATTERNS constant at top of file).
 - Structured data: WebPage + BreadcrumbList + Event (Fall 2026 ASU with GeoCoordinates) + FAQPage.
-- Internal links from: `pages/index.js` (pillar links section), `pages/hack/index.js` (Alert above events list), `pages/sponsor/index.js` (About section).
+- Internal links from: `pages/index.js` (pillar links section), `pages/hack/index.js` (inside `HackathonStoryStrip`, not as a top-level Alert), `pages/sponsor/index.js` (About section).
 
 ## Gotchas (load-bearing — every one of these has bitten us)
 

--- a/src/components/HackathonList/HackPageNav.js
+++ b/src/components/HackathonList/HackPageNav.js
@@ -1,0 +1,190 @@
+import React, { useEffect, useState } from 'react';
+import { Box } from '@mui/material';
+import { styled, alpha } from '@mui/material/styles';
+import { trackEvent } from '../../lib/ga';
+
+// Sections in scroll order. `id` is the in-page anchor; `label` is the chip
+// text. Add new sections here when new top-level blocks land on /hack.
+const SECTIONS = [
+  { id: 'upcoming-events', label: 'Upcoming' },
+  { id: 'since-2013', label: 'Since 2013' },
+  { id: 'previous-events', label: 'Past Events' },
+  { id: 'about-events', label: 'About' },
+];
+
+const NavChip = styled('button')(({ theme, $active }) => ({
+  appearance: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  padding: '6px 12px',
+  borderRadius: 999,
+  whiteSpace: 'nowrap',
+  background: $active ? theme.palette.primary.main : 'transparent',
+  color: $active ? theme.palette.common.white : theme.palette.text.primary,
+  transition: 'background 120ms ease, color 120ms ease, transform 120ms ease',
+  '&:hover': {
+    background: $active
+      ? theme.palette.primary.dark
+      : alpha(theme.palette.primary.main, 0.12),
+  },
+  '&:focus-visible': {
+    outline: `2px solid ${theme.palette.primary.dark}`,
+    outlineOffset: 2,
+  },
+}));
+
+// Page-level table of contents. Appears once the hero is scrolled past so
+// it doesn't compete with the hero. Desktop: vertical pill stack fixed on
+// the left edge. Mobile: horizontal scrollable pill bar fixed below the
+// NavBar. Both use `position: fixed` (not sticky) so they stay anchored to
+// the viewport regardless of where they live in the document.
+function HackPageNav() {
+  const [visible, setVisible] = useState(false);
+  const [activeId, setActiveId] = useState(SECTIONS[0].id);
+
+  // Show once the hero has scrolled out of view. Driven by a scroll
+  // listener (more reliable than IntersectionObserver + rootMargin for a
+  // gate-on-scroll-position behavior) — when the hero's bottom edge passes
+  // above the NavBar line (~80px), the page TOC takes over.
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    let ticking = false;
+    const compute = () => {
+      ticking = false;
+      const hero = document.querySelector('h1');
+      if (!hero) return;
+      const heroBottom = hero.getBoundingClientRect().bottom;
+      setVisible((prev) => {
+        const next = heroBottom < 60;
+        return prev !== next ? next : prev;
+      });
+    };
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(compute);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Track which section is currently in view to highlight the matching
+  // chip. Uses the same rAF-throttled scroll listener pattern that the
+  // year rail used to before we ripped it out — but at this granularity
+  // (4 sections, not 13 years) the scroll race conditions don't bite.
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    let ticking = false;
+    const compute = () => {
+      ticking = false;
+      const anchorY = 160;
+      let bestId = null;
+      let bestTop = -Infinity;
+      SECTIONS.forEach(({ id }) => {
+        const node = document.getElementById(id);
+        if (!node) return;
+        const top = node.getBoundingClientRect().top;
+        if (top <= anchorY && top > bestTop) {
+          bestTop = top;
+          bestId = id;
+        }
+      });
+      if (bestId) setActiveId((prev) => (prev !== bestId ? bestId : prev));
+    };
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(compute);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const jump = (id) => {
+    trackEvent({
+      action: 'hack_page_nav_jump',
+      params: { event_label: id, page: 'hack' },
+    });
+    const node = document.getElementById(id);
+    node?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <>
+      {/* Desktop: fixed left rail, vertical pill stack */}
+      <Box
+        component="nav"
+        aria-label="Page sections"
+        sx={{
+          display: visible ? { xs: 'none', md: 'flex' } : 'none',
+          position: 'fixed',
+          left: 16,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          zIndex: 10,
+          flexDirection: 'column',
+          gap: 0.5,
+          bgcolor: 'background.paper',
+          p: 1,
+          borderRadius: 3,
+          boxShadow: 3,
+          maxWidth: 140,
+        }}
+      >
+        {SECTIONS.map(({ id, label }) => (
+          <NavChip
+            key={id}
+            type="button"
+            $active={activeId === id}
+            aria-current={activeId === id ? 'true' : undefined}
+            onClick={() => jump(id)}
+          >
+            {label}
+          </NavChip>
+        ))}
+      </Box>
+
+      {/* Mobile: fixed top bar, horizontal scrollable */}
+      <Box
+        component="nav"
+        aria-label="Page sections"
+        sx={{
+          display: visible ? { xs: 'flex', md: 'none' } : 'none',
+          position: 'fixed',
+          top: 64,
+          left: 0,
+          right: 0,
+          zIndex: 10,
+          bgcolor: 'background.paper',
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          overflowX: 'auto',
+          gap: 0.5,
+          px: 1,
+          py: 0.5,
+          // Inertia scrolling on iOS
+          WebkitOverflowScrolling: 'touch',
+        }}
+      >
+        {SECTIONS.map(({ id, label }) => (
+          <NavChip
+            key={id}
+            type="button"
+            $active={activeId === id}
+            aria-current={activeId === id ? 'true' : undefined}
+            onClick={() => jump(id)}
+          >
+            {label}
+          </NavChip>
+        ))}
+      </Box>
+    </>
+  );
+}
+
+export default HackPageNav;

--- a/src/components/HackathonList/HackathonList.js
+++ b/src/components/HackathonList/HackathonList.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/router";
 import useHackathonEvents from "../../hooks/use-hackathon-events";
-import { EmptyGrid, OuterGrid, MoreNewsStyle, HackathonGrid, NewsContainer, NewsSection, NewsSectionTitle } from "./styles";
+import { EmptyGrid, OuterGrid, MoreNewsStyle, HackathonGrid } from "./styles";
 import EventFeature from "./EventFeature";
 import { SectionTitle } from "./styles";
 import Link from "next/link";
@@ -30,19 +30,30 @@ function HackathonList({ compact = false }) {
     }
   }, [hackathons, router]);
 
+  // Only fetch news for the compact sidebar variant — the full /hack page
+  // routes users to /blog for the news feed instead of embedding it here,
+  // which removes ~500-800px of vertical scroll between Upcoming Events
+  // and the Previous Events archive.
   useEffect(() => {
+    if (!compact) return undefined;
+    let cancelled = false;
     setNewsLoading(true);
     fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/messages/news?limit=3`)
       .then((response) => response.json())
       .then((data) => {
+        if (cancelled) return;
         setNewsData(data.text || null);
         setNewsLoading(false);
       })
       .catch((error) => {
+        if (cancelled) return;
         console.error(error);
         setNewsLoading(false);
       });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [compact]);
 
   const renderEventSkeleton = () => (
     <Skeleton
@@ -219,16 +230,16 @@ function HackathonList({ compact = false }) {
           </Box>
         )}
 
-        <NewsSection>
-          <NewsSectionTitle>Latest Updates</NewsSectionTitle>
-          <NewsContainer>
-            {newsLoading ? (
-              <News newsData={[]} frontpage={"true"} loading={true} />
-            ) : (
-              <News newsData={newsData} frontpage={"true"} loading={false} />
-            )}
-          </NewsContainer>
-        </NewsSection>
+        {hackathons && hackathons.length > 0 && (
+          <Box sx={{ mt: 2, textAlign: 'center' }}>
+            <Link prefetch={false} href="/blog" style={{ textDecoration: 'none' }}>
+              <MoreNewsStyle>
+                Read latest updates from Opportunity Hack
+                <ArrowForwardIcon sx={{ ml: 1, fontSize: 16 }} />
+              </MoreNewsStyle>
+            </Link>
+          </Box>
+        )}
       </EmptyGrid>
     </OuterGrid>
   );

--- a/src/components/HackathonList/HackathonStoryStrip.js
+++ b/src/components/HackathonList/HackathonStoryStrip.js
@@ -1,0 +1,356 @@
+import React, { useEffect, useMemo, useState } from "react";
+import NextLink from "next/link";
+import {
+  Box,
+  Paper,
+  Stack,
+  Typography,
+  Tooltip,
+  Link,
+  Alert,
+  Skeleton,
+} from "@mui/material";
+import { styled, alpha } from "@mui/material/styles";
+import EventAvailableIcon from "@mui/icons-material/EventAvailable";
+import GroupsIcon from "@mui/icons-material/Groups";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import RocketLaunchIcon from "@mui/icons-material/RocketLaunch";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+import { format } from "date-fns";
+import useHackathonEvents from "../../hooks/use-hackathon-events";
+import { useEnv } from "../../context/env.context";
+import { parseLocalDate } from "../../lib/dateUtils";
+import { trackEvent } from "../../lib/ga";
+
+// Reserve vertical space up front to prevent CLS while the funnel fetches.
+// Heights are tuned to match the rendered strip so the skeleton == final size.
+const STRIP_MIN_HEIGHT = { xs: 420, md: 240 };
+
+const StripPaper = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(3),
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(4),
+  background: `linear-gradient(135deg, ${alpha(theme.palette.primary.light, 0.10)} 0%, ${alpha(theme.palette.secondary.light, 0.10)} 100%)`,
+  border: `1px solid ${alpha(theme.palette.divider, 0.5)}`,
+  borderRadius: theme.shape.borderRadius * 2,
+}));
+
+const YearDot = styled("button")(({ theme, $size, $active, $hasEvents }) => ({
+  appearance: "none",
+  border: "none",
+  background: $hasEvents
+    ? `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${alpha(theme.palette.primary.main, 0.75)} 100%)`
+    : alpha(theme.palette.text.disabled, 0.25),
+  width: $size,
+  height: $size,
+  borderRadius: "50%",
+  cursor: $hasEvents ? "pointer" : "default",
+  padding: 0,
+  position: "relative",
+  flexShrink: 0,
+  boxShadow: $active ? `0 0 0 3px ${alpha(theme.palette.primary.main, 0.35)}` : "none",
+  transition: "transform 120ms ease, box-shadow 120ms ease",
+  "&:hover": $hasEvents
+    ? {
+        transform: "scale(1.15)",
+        boxShadow: `0 0 0 4px ${alpha(theme.palette.primary.main, 0.25)}`,
+      }
+    : {},
+  "&:focus-visible": {
+    outline: `2px solid ${theme.palette.primary.dark}`,
+    outlineOffset: 2,
+  },
+}));
+
+function StatTile({ icon, value, label, loading }) {
+  return (
+    <Box
+      sx={{
+        flex: "1 1 150px",
+        minWidth: 140,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        py: 1,
+        px: 1,
+      }}
+    >
+      <Box sx={{ color: "primary.main", mb: 0.5, display: "flex" }}>{icon}</Box>
+      {loading ? (
+        <Skeleton variant="text" width={64} height={36} />
+      ) : (
+        <Typography variant="h5" fontWeight={800} color="primary.main" lineHeight={1.1}>
+          {(value || 0).toLocaleString()}
+        </Typography>
+      )}
+      <Typography variant="caption" color="text.secondary" textAlign="center" sx={{ mt: 0.25 }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+function HackathonStoryStrip() {
+  const { apiServerUrl } = useEnv();
+  const { hackathons: pastEvents } = useHackathonEvents("previous");
+  const { hackathons: currentEvents } = useHackathonEvents("current");
+
+  const [funnel, setFunnel] = useState(null);
+  const [funnelLoaded, setFunnelLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!apiServerUrl) return undefined;
+    fetch(`${apiServerUrl}/api/messages/hackathons/funnel/aggregate`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled) {
+          setFunnel(data);
+          setFunnelLoaded(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setFunnelLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiServerUrl]);
+
+  // Year buckets across the whole archive. We render a continuous range from
+  // the earliest event's year up through the current year so the sparkline
+  // reads as a timeline even on years with zero events.
+  const { yearMarkers, yearsActive, earliestYear } = useMemo(() => {
+    const counts = {};
+    (pastEvents || []).forEach((e) => {
+      if (!e.start_date) return;
+      const y = format(parseLocalDate(e.start_date), "yyyy");
+      counts[y] = (counts[y] || 0) + 1;
+    });
+    (currentEvents || []).forEach((e) => {
+      if (!e.start_date) return;
+      const y = format(parseLocalDate(e.start_date), "yyyy");
+      counts[y] = (counts[y] || 0) + 1;
+    });
+    const years = Object.keys(counts).map((y) => parseInt(y, 10));
+    if (years.length === 0) {
+      return { yearMarkers: [], yearsActive: 0, earliestYear: null };
+    }
+    const min = Math.min(...years);
+    const max = Math.max(new Date().getFullYear(), Math.max(...years));
+    const markers = [];
+    for (let y = min; y <= max; y += 1) {
+      markers.push({ year: y, count: counts[String(y)] || 0 });
+    }
+    return {
+      yearMarkers: markers,
+      yearsActive: Object.keys(counts).length,
+      earliestYear: min,
+    };
+  }, [pastEvents, currentEvents]);
+
+  const maxCount = useMemo(
+    () => yearMarkers.reduce((m, y) => Math.max(m, y.count), 0),
+    [yearMarkers]
+  );
+
+  const handleYearClick = (year, count) => {
+    if (!count) return;
+    trackEvent({
+      action: "hack_story_strip_year_click",
+      params: { event_label: String(year), page: "hack" },
+    });
+    // Ask the archive below to filter to this year. The archive owns scroll
+    // (it scrolls after the filtered grid renders so we land on real content).
+    window.dispatchEvent(
+      new CustomEvent("ohack:archive-jump-year", { detail: { year } })
+    );
+  };
+
+  const eventsTotal = funnel?.events_total ?? (pastEvents?.length || 0) + (currentEvents?.length || 0);
+  const totalRegistered = funnel?.summary?.registered || 0;
+  const totalSubmitted = funnel?.summary?.submitted_project_teams || 0;
+  const eventsWithWinners = funnel?.events_with_winners || 0;
+
+  const showStats = funnelLoaded;
+
+  return (
+    <Box
+      id="since-2013"
+      component="section"
+      aria-labelledby="story-strip-heading"
+      sx={{ minHeight: STRIP_MIN_HEIGHT, scrollMarginTop: 100 }}
+    >
+      <StripPaper variant="outlined">
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={3}
+          alignItems={{ xs: "stretch", md: "center" }}
+          justifyContent="space-between"
+        >
+          <Box sx={{ flex: { md: "0 0 auto" }, minWidth: { md: 220 } }}>
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              sx={{ letterSpacing: 1 }}
+            >
+              {earliestYear ? `Since ${earliestYear}` : "Since 2013"}
+            </Typography>
+            <Typography
+              id="story-strip-heading"
+              variant="h5"
+              component="h2"
+              sx={{ fontWeight: 700, lineHeight: 1.15, mb: 0.5 }}
+            >
+              {yearsActive ? `${yearsActive} years of hacking for good` : "Our hackathon story"}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              The next event builds on every event before it. Jump to any year below.
+            </Typography>
+          </Box>
+
+          <Stack
+            direction="row"
+            spacing={1}
+            flexWrap="wrap"
+            useFlexGap
+            sx={{ flex: 1, justifyContent: { xs: "flex-start", md: "center" } }}
+          >
+            <StatTile
+              icon={<EventAvailableIcon />}
+              value={eventsTotal}
+              label="Hackathons"
+              loading={!showStats}
+            />
+            <StatTile
+              icon={<GroupsIcon />}
+              value={totalRegistered}
+              label="People registered"
+              loading={!showStats}
+            />
+            <StatTile
+              icon={<RocketLaunchIcon />}
+              value={totalSubmitted}
+              label="Projects shipped"
+              loading={!showStats}
+            />
+            <StatTile
+              icon={<EmojiEventsIcon />}
+              value={eventsWithWinners}
+              label="Events with winners"
+              loading={!showStats}
+            />
+          </Stack>
+
+          <Box
+            sx={{
+              flex: { md: "0 0 auto" },
+              textAlign: { xs: "left", md: "right" },
+              alignSelf: { md: "center" },
+            }}
+          >
+            <Link
+              component={NextLink}
+              href="/hack/results"
+              underline="hover"
+              onClick={() =>
+                trackEvent({
+                  action: "hack_story_strip_view_results",
+                  params: { page: "hack" },
+                })
+              }
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.5,
+                fontWeight: 600,
+                fontSize: "0.95rem",
+              }}
+            >
+              Full impact report
+              <ArrowForwardIcon fontSize="small" />
+            </Link>
+          </Box>
+        </Stack>
+
+        {yearMarkers.length > 0 && (
+          <Box sx={{ mt: 3 }}>
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1.5}
+              sx={{
+                overflowX: "auto",
+                pb: 1,
+                pt: 0.5,
+                // Hide the scrollbar but keep horizontal scroll on mobile.
+                scrollbarWidth: "thin",
+              }}
+              aria-label="Hackathon years"
+            >
+              {yearMarkers.map(({ year, count }) => {
+                // Map count → dot size for at-a-glance density.
+                const size = maxCount
+                  ? 10 + Math.round((count / maxCount) * 18) // 10–28px
+                  : 10;
+                const labelText = count
+                  ? `${year} · ${count} event${count === 1 ? "" : "s"}`
+                  : `${year} · no events`;
+                return (
+                  <Stack
+                    key={year}
+                    direction="column"
+                    alignItems="center"
+                    spacing={0.5}
+                    sx={{ flexShrink: 0, minWidth: 44 }}
+                  >
+                    <Tooltip title={labelText} arrow>
+                      <YearDot
+                        type="button"
+                        $size={size}
+                        $hasEvents={count > 0}
+                        onClick={() => handleYearClick(year, count)}
+                        aria-label={`Jump to ${year}${count ? "" : " (no events)"}`}
+                        disabled={!count}
+                      />
+                    </Tooltip>
+                    <Typography
+                      variant="caption"
+                      color={count ? "text.primary" : "text.disabled"}
+                      sx={{ fontWeight: count ? 600 : 400, fontSize: "0.7rem" }}
+                    >
+                      {String(year).slice(2)}
+                    </Typography>
+                  </Stack>
+                );
+              })}
+            </Stack>
+          </Box>
+        )}
+
+        <Alert
+          severity="info"
+          icon={<LocationOnIcon fontSize="small" />}
+          sx={{
+            mt: 2,
+            py: 0.5,
+            "& .MuiAlert-message": { fontSize: "0.9rem", py: 0.5 },
+          }}
+        >
+          Local to Arizona?{" "}
+          <Link
+            component={NextLink}
+            href="/hackathons/arizona"
+            underline="hover"
+            sx={{ fontWeight: 600 }}
+          >
+            See ASU, Tempe, and Phoenix-area events →
+          </Link>
+        </Alert>
+      </StripPaper>
+    </Box>
+  );
+}
+
+export default HackathonStoryStrip;

--- a/src/components/HackathonList/PreviousHackathonList.js
+++ b/src/components/HackathonList/PreviousHackathonList.js
@@ -1,37 +1,43 @@
-import React, { useState, useEffect, useRef } from 'react';
-import useHackathonEvents from '../../hooks/use-hackathon-events';
-import { 
-  OuterGrid,
-  SectionTitle,
-  PastEventCard,
-  PastEventGrid,
-  EventLink,
-  PastEventYear,
-  PastEventText,
-  PastEventLocation,
-  ToggleButton
-} from './styles';
-import { Chip, Box, Typography, Pagination, Grid } from '@mui/material';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
-import { format } from 'date-fns';
-import { parseLocalDate } from '../../lib/dateUtils';
+import {
+  Box,
+  Chip,
+  Grid,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { styled, alpha } from '@mui/material/styles';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
+import { format } from 'date-fns';
+import useHackathonEvents from '../../hooks/use-hackathon-events';
+import { parseLocalDate } from '../../lib/dateUtils';
 import ImpactMetrics from '../ImpactMetrics';
+import {
+  OuterGrid,
+  SectionTitle,
+  EventLink,
+  PastEventText,
+  PastEventLocation,
+} from './styles';
 
-// Render children only after the wrapper scrolls into view. Used to defer
-// ImpactMetrics' per-card API fetches until the card is actually visible —
-// keeps initial render cheap when surfacing the full historical archive.
-function LazyMount({ children, rootMargin = '200px' }) {
+// ---------------------------------------------------------------------------
+// LazyMount — defer ImpactMetrics' per-card API fetches until the card is
+// actually near the viewport. Same pattern as before, but the archive is now
+// much longer so this is more load-bearing than ever.
+// ---------------------------------------------------------------------------
+function LazyMount({ children, rootMargin = '300px' }) {
   const ref = useRef(null);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    if (visible) return;
+    if (visible) return undefined;
     const node = ref.current;
     if (!node || typeof IntersectionObserver === 'undefined') {
       setVisible(true);
-      return;
+      return undefined;
     }
     const observer = new IntersectionObserver(
       (entries) => {
@@ -49,188 +55,417 @@ function LazyMount({ children, rootMargin = '200px' }) {
   return <div ref={ref}>{visible ? children : null}</div>;
 }
 
-function PreviousHackathonList() {
-  const { hackathons } = useHackathonEvents("previous");
-  const [currentPage, setCurrentPage] = useState(1);
-  const [yearFilter, setYearFilter] = useState('All');
-  const eventsPerPage = 8;
+// ---------------------------------------------------------------------------
+// PastEventCard — photo-led card. The image header gives the eye an anchor
+// while scanning; without it, scrolling through 30+ events is a wall of text.
+// ---------------------------------------------------------------------------
+const CardShell = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  borderRadius: 12,
+  overflow: 'hidden',
+  backgroundColor: '#f0f8ff',
+  boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
+  transition: 'transform 160ms ease, box-shadow 160ms ease',
+  '&:hover': {
+    transform: 'translateY(-3px)',
+    boxShadow: '0 8px 16px rgba(0,0,0,0.15)',
+  },
+  '&:focus-within': {
+    outline: `3px solid ${theme.palette.primary.main}`,
+    outlineOffset: 2,
+  },
+}));
 
-  // Count events per year so year chips can show density at a glance.
-  const yearCounts = (hackathons || []).reduce((acc, event) => {
-    const y = format(parseLocalDate(event.start_date), 'yyyy');
-    acc[y] = (acc[y] || 0) + 1;
-    return acc;
-  }, {});
-  const allYears = Object.keys(yearCounts).sort((a, b) => b - a);
-  const totalEvents = hackathons ? hackathons.length : 0;
+const PhotoFrame = styled(Box)({
+  position: 'relative',
+  width: '100%',
+  aspectRatio: '16 / 9',
+  backgroundColor: '#0a4f9e',
+  overflow: 'hidden',
+});
 
-  // Filter hackathons by year if a filter is applied
-  const filteredHackathons = hackathons ? hackathons.filter(event =>
-    yearFilter === 'All' || format(parseLocalDate(event.start_date), 'yyyy') === yearFilter
-  ) : [];
+const YearBadge = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  top: 8,
+  right: 8,
+  zIndex: 2,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: '4px 10px',
+  borderRadius: 999,
+  backgroundColor: alpha(theme.palette.common.black, 0.65),
+  color: theme.palette.common.white,
+  fontSize: 12,
+  fontWeight: 700,
+  letterSpacing: 0.4,
+  backdropFilter: 'blur(4px)',
+}));
 
-  // Calculate pagination
-  const indexOfLastEvent = currentPage * eventsPerPage;
-  const indexOfFirstEvent = indexOfLastEvent - eventsPerPage;
-  const currentEvents = filteredHackathons.slice(indexOfFirstEvent, indexOfLastEvent);
-  const totalPages = Math.ceil(filteredHackathons.length / eventsPerPage);
+// Gradient fallback for cards with no event photo. The year is the only
+// distinctive thing we can show, so make it big.
+function GradientFallback({ year }) {
+  // Deterministic hue rotation per year so the wall doesn't feel monotone.
+  const yearNum = parseInt(year, 10) || 2020;
+  const hue = ((yearNum - 2013) * 37) % 360;
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        background: `linear-gradient(135deg, hsl(${hue}, 60%, 38%) 0%, hsl(${(hue + 40) % 360}, 65%, 22%) 100%)`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      aria-hidden
+    >
+      <Typography
+        sx={{
+          color: 'rgba(255,255,255,0.92)',
+          fontSize: { xs: 44, sm: 56 },
+          fontWeight: 800,
+          letterSpacing: 2,
+          textShadow: '0 2px 12px rgba(0,0,0,0.25)',
+        }}
+      >
+        {year}
+      </Typography>
+    </Box>
+  );
+}
 
-  const handlePageChange = (event, value) => {
-    setCurrentPage(value);
-    // Scroll to top of section
-    document.getElementById('previous-events').scrollIntoView({ behavior: 'smooth' });
+function PastEventCard({ event }) {
+  const photo = event?.event_photos?.[0]?.url || null;
+  const year = event?.start_date
+    ? format(parseLocalDate(event.start_date), 'yyyy')
+    : '';
+
+  return (
+    <CardShell>
+      <Link
+        href={`/hack/${event.event_id}`}
+        style={{
+          textDecoration: 'none',
+          color: 'inherit',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+        }}
+      >
+        <PhotoFrame>
+          {photo ? (
+            <Image
+              src={photo}
+              alt={event.title || `${year} hackathon`}
+              fill
+              sizes="(max-width: 600px) 100vw, (max-width: 960px) 50vw, 33vw"
+              style={{ objectFit: 'cover' }}
+              loading="lazy"
+            />
+          ) : (
+            <GradientFallback year={year} />
+          )}
+          <YearBadge>
+            <CalendarTodayIcon sx={{ fontSize: 12 }} />
+            {year}
+          </YearBadge>
+        </PhotoFrame>
+
+        <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', flex: 1 }}>
+          <EventLink variant="subtitle1" sx={{ fontSize: '1rem', mb: 0.5 }}>
+            {event.title}
+          </EventLink>
+
+          <PastEventText sx={{ mb: 1, flexGrow: 0 }}>
+            {event.description}
+          </PastEventText>
+
+          <LazyMount>
+            <ImpactMetrics
+              event_id={event.event_id}
+              eventData={{
+                start_date: event.start_date,
+                end_date: event.end_date,
+                location: event.location,
+                title: event.title,
+                id: event.id,
+              }}
+              minimal
+            />
+          </LazyMount>
+
+          {event.location && (
+            <PastEventLocation sx={{ mt: 'auto', pt: 1 }}>
+              <LocationOnIcon fontSize="small" sx={{ mr: 0.5 }} />
+              {event.location}
+            </PastEventLocation>
+          )}
+        </Box>
+      </Link>
+    </CardShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// YearRail — sticky navigation. Vertical on desktop, horizontal on mobile.
+// Active year is driven by IntersectionObserver in the parent, so it tracks
+// scroll position without any click state.
+// ---------------------------------------------------------------------------
+const RailButton = styled('button')(({ theme, $active }) => ({
+  appearance: 'none',
+  border: 'none',
+  background: $active ? theme.palette.primary.main : 'transparent',
+  color: $active ? theme.palette.common.white : theme.palette.text.primary,
+  fontWeight: $active ? 700 : 500,
+  fontSize: '0.9rem',
+  padding: '6px 12px',
+  borderRadius: 999,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+  transition: 'background 120ms ease, color 120ms ease, transform 120ms ease',
+  '&:hover': {
+    background: $active ? theme.palette.primary.dark : alpha(theme.palette.primary.main, 0.12),
+  },
+  '&:focus-visible': {
+    outline: `2px solid ${theme.palette.primary.dark}`,
+    outlineOffset: 2,
+  },
+}));
+
+function YearRail({ years, activeYear, onYearClick }) {
+  const handleClick = (year) => {
+    if (onYearClick) onYearClick(year);
+    const node = document.getElementById(`year-${year}`);
+    node?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
   return (
-    <OuterGrid
-      container
-      alignItems="center"
-      direction="column"
-      textAlign="center"
-      id="previous-events"
+    <Box
+      component="nav"
+      aria-label="Jump to a year"
+      sx={{
+        position: 'sticky',
+        // NavBar is 64px (per CLAUDE.md CWV hygiene); leave a small gap.
+        top: { xs: 64, md: 84 },
+        zIndex: 4,
+        bgcolor: 'background.paper',
+        py: { xs: 1, md: 0 },
+        width: { xs: '100%', md: 108 },
+        flexShrink: 0,
+        borderRight: { md: '1px solid' },
+        borderBottom: { xs: '1px solid', md: 'none' },
+        borderColor: { xs: 'divider', md: 'divider' },
+        alignSelf: { md: 'flex-start' },
+        maxHeight: { md: 'calc(100vh - 100px)' },
+      }}
     >
-      <SectionTitle variant="h1">Previous Events</SectionTitle>
-
-      <Typography
-        variant="body1"
-        color="textSecondary"
-        sx={{ mb: 3, maxWidth: "800px" }}
-      >
-        Browse our archive of past hackathons. Since 2013, we've organized over
-        20 events connecting tech talent with nonprofits to create lasting
-        technology solutions.
-      </Typography>
-
-      {/* Year filter chips */}
       <Box
         sx={{
-          display: "flex",
-          flexWrap: "wrap",
-          gap: 1,
-          justifyContent: "center",
-          mb: 4,
+          display: 'flex',
+          flexDirection: { xs: 'row', md: 'column' },
+          gap: 0.5,
+          overflowX: { xs: 'auto', md: 'visible' },
+          overflowY: { md: 'auto' },
+          py: 0.5,
+          pr: { md: 1 },
+          px: { xs: 1, md: 0 },
         }}
       >
-        <Chip
-          label={totalEvents > 0 ? `All Years (${totalEvents})` : 'All Years'}
-          color={yearFilter === "All" ? "primary" : "default"}
-          onClick={() => {
-            setYearFilter("All");
-            setCurrentPage(1);
-          }}
-          sx={{ fontWeight: yearFilter === "All" ? "bold" : "normal" }}
-        />
-        {allYears.map((year) => (
-          <Chip
+        {years.map(({ year, count }) => (
+          <RailButton
             key={year}
-            label={yearCounts[year] > 1 ? `${year} (${yearCounts[year]})` : year}
-            color={yearFilter === year ? "primary" : "default"}
-            onClick={() => {
-              setYearFilter(year);
-              setCurrentPage(1);
-            }}
-            sx={{ fontWeight: yearFilter === year ? "bold" : "normal" }}
-          />
+            type="button"
+            $active={activeYear === year}
+            onClick={() => handleClick(year)}
+            aria-current={activeYear === year ? 'true' : undefined}
+            aria-label={`Jump to ${year} — ${count} event${count === 1 ? '' : 's'}`}
+          >
+            {year}
+            <Box
+              component="span"
+              sx={{
+                ml: 0.75,
+                fontSize: '0.7rem',
+                opacity: 0.7,
+                fontWeight: 600,
+              }}
+            >
+              {count}
+            </Box>
+          </RailButton>
         ))}
       </Box>
+    </Box>
+  );
+}
 
-      {/* Past events grid */}
-      <PastEventGrid>
-        {currentEvents.length > 0 ? (
-          currentEvents.map((event) => (
-            <PastEventCard key={event.event_id || event.title}>
-              <Link href={`/hack/${event.event_id}`} passHref legacyBehavior>
-                <a
-                  style={{
-                    display: "block",
-                    textDecoration: "none",
-                    color: "inherit",
-                    width: "100%",
-                    height: "100%",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      display: "flex",
-                      flexDirection: "column",
-                      height: "100%",
-                    }}
-                  >
-                    <PastEventYear>
-                      <CalendarTodayIcon fontSize="small" sx={{ mr: 1 }} />
-                      {format(parseLocalDate(event.start_date), "yyyy")}
-                    </PastEventYear>
+// ---------------------------------------------------------------------------
+// YearSection — one block per year. The `id="year-{yyyy}"` anchor is what
+// both the Story Strip sparkline and the YearRail above scroll to.
+// scrollMarginTop accounts for NavBar (64px) + sticky rail (~50px mobile).
+// ---------------------------------------------------------------------------
+const YearHeading = styled(Typography)(({ theme }) => ({
+  fontWeight: 800,
+  fontSize: '1.75rem',
+  lineHeight: 1,
+  color: theme.palette.primary.dark,
+}));
 
-                    <EventLink variant="h5">{event.title}</EventLink>
+function YearSection({ year, events }) {
+  return (
+    <Box
+      id={`year-${year}`}
+      component="section"
+      aria-labelledby={`year-${year}-heading`}
+      sx={{
+        mb: { xs: 5, md: 6 },
+        scrollMarginTop: { xs: 130, md: 100 },
+      }}
+    >
+      <Stack direction="row" alignItems="baseline" spacing={1.5} mb={2}>
+        <YearHeading id={`year-${year}-heading`}>{year}</YearHeading>
+        <Chip
+          size="small"
+          label={`${events.length} event${events.length === 1 ? '' : 's'}`}
+          variant="outlined"
+        />
+      </Stack>
 
-                    <PastEventText>{event.description}</PastEventText>
+      <Grid container spacing={2}>
+        {events.map((event) => (
+          <Grid
+            key={event.event_id || event.title}
+            size={{ xs: 12, sm: 6, md: 4, lg: 3 }}
+          >
+            <PastEventCard event={event} />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}
 
-                    {/* Impact Metrics — lazy-mounted to avoid N fetches per card on initial render */}
-                    <LazyMount>
-                      <ImpactMetrics
-                        event_id={event.event_id}
-                        eventData={{
-                          start_date: event.start_date,
-                          end_date: event.end_date,
-                          location: event.location,
-                          title: event.title,
-                          id: event.id,
-                        }}
-                        minimal={true}
-                      />
-                    </LazyMount>
+// ---------------------------------------------------------------------------
+// PreviousHackathonList — top-level. Groups events by year, renders every
+// year on one continuous scroll, tracks the year currently in view, and
+// exposes the YearRail + the Story Strip's sparkline as two ways to teleport.
+// No pagination. No filter state. Just scroll.
+// ---------------------------------------------------------------------------
+function PreviousHackathonList() {
+  const { hackathons } = useHackathonEvents('previous');
 
-                    <Box sx={{ mt: "auto", pt: 2 }}>
-                      <PastEventLocation>
-                        <LocationOnIcon fontSize="small" sx={{ mr: 1 }} />
-                        {event.location}
-                      </PastEventLocation>
+  // Group events by year, sort years desc, sort events within each year desc.
+  const yearGroups = useMemo(() => {
+    const map = new Map();
+    (hackathons || []).forEach((event) => {
+      if (!event?.start_date) return;
+      const y = format(parseLocalDate(event.start_date), 'yyyy');
+      if (!map.has(y)) map.set(y, []);
+      map.get(y).push(event);
+    });
+    return Array.from(map.entries())
+      .sort((a, b) => parseInt(b[0], 10) - parseInt(a[0], 10))
+      .map(([year, events]) => ({
+        year,
+        events: events
+          .slice()
+          .sort(
+            (a, b) =>
+              parseLocalDate(b.start_date) - parseLocalDate(a.start_date)
+          ),
+      }));
+  }, [hackathons]);
 
-                      <Grid container spacing={1} sx={{ mt: 2 }}>
-                        {event.links && event.links.length > 0 && (
-                          <Grid size={{ xs: 12 }}>
-                            <ToggleButton
-                              color="primary"
-                              variant="outlined"
-                              component="button"
-                              fullWidth
-                            >
-                              View Details
-                            </ToggleButton>
-                          </Grid>
-                        )}
-                      </Grid>
-                    </Box>
-                  </Box>
-                </a>
-              </Link>
-            </PastEventCard>
-          ))
-        ) : (
-          <Typography variant="body1" color="textSecondary">
-            No past events found matching your filter.
-          </Typography>
-        )}
-      </PastEventGrid>
+  const totalEvents = hackathons ? hackathons.length : 0;
 
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <Box sx={{ mt: 4, mb: 2 }}>
-          <Pagination
-            count={totalPages}
-            page={currentPage}
-            onChange={handlePageChange}
-            color="primary"
-            size="large"
-          />
+  // Active year on the rail reflects the user's most recent click. We
+  // intentionally don't drive it from scroll position — the click is the
+  // user's stated intent, and the rail's job is to make that intent fast.
+  // (Earlier attempts to follow scroll fought smooth-scroll race conditions
+  // for marginal benefit; cutting it removes the bug class entirely.)
+  const [activeYear, setActiveYear] = useState(null);
+
+  // Seed the active year so the rail isn't blank on first paint.
+  useEffect(() => {
+    if (!activeYear && yearGroups.length) {
+      setActiveYear(yearGroups[0].year);
+    }
+  }, [activeYear, yearGroups]);
+
+  // ----- Listen for "jump to year" from the Story Strip above. The strip
+  // emits the event; we own the scroll target lookup since we render the
+  // year section anchors.
+  // ---------------------------------------------------------------------
+  useEffect(() => {
+    const onJump = (e) => {
+      const year = e?.detail?.year;
+      if (!year) return;
+      setActiveYear(String(year));
+      const node = document.getElementById(`year-${year}`);
+      node?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+    window.addEventListener('ohack:archive-jump-year', onJump);
+    return () =>
+      window.removeEventListener('ohack:archive-jump-year', onJump);
+  }, []);
+
+  const handleRailClick = (year) => {
+    setActiveYear(String(year));
+  };
+
+  const railYears = yearGroups.map((g) => ({
+    year: g.year,
+    count: g.events.length,
+  }));
+
+  return (
+    <OuterGrid
+      id="previous-events"
+      container
+      direction="column"
+      sx={{ textAlign: 'left', scrollMarginTop: 100 }}
+    >
+      <Box sx={{ textAlign: 'center', mb: 2 }}>
+        <SectionTitle variant="h2" component="h2">
+          Previous Events
+        </SectionTitle>
+        <Typography
+          variant="body1"
+          color="textSecondary"
+          sx={{ maxWidth: 800, mx: 'auto' }}
+        >
+          {totalEvents > 0
+            ? `Browse all ${totalEvents} past hackathons. Use the year rail to jump to any year — every event is visible below.`
+            : "Browse our archive of past hackathons."}
+        </Typography>
+      </Box>
+
+      {yearGroups.length === 0 ? (
+        <Typography variant="body1" color="textSecondary" sx={{ textAlign: 'center', py: 6 }}>
+          Loading past events…
+        </Typography>
+      ) : (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', md: 'row' },
+            alignItems: 'flex-start',
+            gap: { xs: 0, md: 3 },
+            width: '100%',
+          }}
+        >
+          <YearRail years={railYears} activeYear={activeYear} onYearClick={handleRailClick} />
+
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%', pt: { xs: 2, md: 0 } }}>
+            {yearGroups.map(({ year, events }) => (
+              <YearSection key={year} year={year} events={events} />
+            ))}
+          </Box>
         </Box>
       )}
-
-      {/* Total events count */}
-      <Typography variant="body2" color="textSecondary" sx={{ mt: 2 }}>
-        Showing {currentEvents.length} of {filteredHackathons.length} events
-        {yearFilter !== "All" && ` from ${yearFilter}`}
-      </Typography>
     </OuterGrid>
   );
 }

--- a/src/pages/hack/index.js
+++ b/src/pages/hack/index.js
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
 import Head from 'next/head';
-import Image from 'next/image';
-import { Typography, Box, Button, Grid, Container, Divider, Alert, Paper, Card, CardContent } from '@mui/material';
+import { Typography, Box, Button, Grid, Paper, Card, CardContent } from '@mui/material';
 import { initFacebookPixel, trackEvent } from '../../lib/ga';
 import { TitleContainer, LayoutContainer, ProjectsContainer } from '../../styles/nonprofit/styles';
 import HackathonList from '../../components/HackathonList/HackathonList';
+import HackathonStoryStrip from '../../components/HackathonList/HackathonStoryStrip';
 import PreviousHackathonList from '../../components/HackathonList/PreviousHackathonList';
+import HackPageNav from '../../components/HackathonList/HackPageNav';
 import Link from 'next/link';
 import { EventAvailable, Code, Group, EmojiEvents, Gavel, CameraAlt, Business, Policy } from '@mui/icons-material';
 
@@ -20,6 +21,7 @@ const HackathonIndex = () => {
 
   return (
     <LayoutContainer key="hackathons" container>
+      <HackPageNav />
       <Head>
         <title>
           Opportunity Hack - Global Hackathons Including Phoenix & ASU Events
@@ -72,248 +74,176 @@ const HackathonIndex = () => {
         `}</script>
       </Head>
 
-      <TitleContainer container>
+      <TitleContainer container sx={{ pt: { xs: 2, md: 3 }, pb: { xs: 2, md: 2 } }}>
         <Typography
           variant="h1"
           component="h1"
-          sx={{ fontSize: { xs: "2rem", sm: "2.5rem", md: "3rem" }, mb: 2 }}
+          sx={{
+            fontSize: { xs: "1.75rem", sm: "2.25rem", md: "2.5rem" },
+            mb: { xs: 1.5, md: 2 },
+            lineHeight: 1.15,
+          }}
         >
-          Hackathons
+          Hackathons for nonprofits
         </Typography>
 
-        <Typography variant="body1" sx={{ fontSize: '18px', mb: 3, maxWidth: '800px', mx: 'auto' }}>
-          Join developers, designers, and nonprofits worldwide to build technology solutions that create lasting social impact. 
-          Since 2013, we've helped 100+ nonprofits serving underserved communities.
-        </Typography>
-
-        <Grid container spacing={2} sx={{ maxWidth: '600px', mx: 'auto', mb: 3 }}>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <Button
-              variant="contained"
-              color="primary"
-              size="large"
-              fullWidth
-              href="#upcoming-events"
-              startIcon={<EventAvailable />}
-              onClick={(e) => {
-                e.preventDefault();
-                track('cta_click', 'view_upcoming_events');
-                document.getElementById('upcoming-events')?.scrollIntoView({ behavior: 'smooth' });
-              }}
-            >
-              View Upcoming Events
-            </Button>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <Button
-              variant="outlined"
-              color="primary"
-              size="large"
-              fullWidth
-              href="/signup"
-              startIcon={<Group />}
-              onClick={() => track('cta_click', 'join_community')}
-            >
-              Join Our Community
-            </Button>
-          </Grid>
-        </Grid>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            gap: 1.5,
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            maxWidth: 560,
+            mx: 'auto',
+          }}
+        >
+          <Button
+            variant="contained"
+            color="primary"
+            size="medium"
+            href="#upcoming-events"
+            startIcon={<EventAvailable />}
+            onClick={(e) => {
+              e.preventDefault();
+              track('cta_click', 'view_upcoming_events');
+              document.getElementById('upcoming-events')?.scrollIntoView({ behavior: 'smooth' });
+            }}
+            sx={{ textTransform: 'none', fontWeight: 600 }}
+          >
+            See upcoming events
+          </Button>
+          <Button
+            variant="outlined"
+            color="primary"
+            size="medium"
+            href="/signup"
+            startIcon={<Group />}
+            onClick={() => track('cta_click', 'join_community')}
+            sx={{ textTransform: 'none', fontWeight: 600 }}
+          >
+            Join the community
+          </Button>
+        </Box>
       </TitleContainer>
 
-      <ProjectsContainer style={{ marginTop: 20, width: "100%" }}>
-        {/* Why Join Section with Image - Moved to top for better UX flow */}
-        <Paper sx={{ p: 4, mb: 5, bgcolor: 'grey.50' }}>
-          <Grid container spacing={4} sx={{ alignItems: 'center' }}>
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Typography variant="h3" component="h2" gutterBottom>
-                Why Join Opportunity Hack?
-              </Typography>
-              <Grid container spacing={2}>
-                <Grid size={{ xs: 12, sm: 6 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
-                    <Code color="primary" sx={{ mr: 2, mt: 0.5 }} />
-                    <Box>
-                      <Typography variant="h6" gutterBottom>
-                        Build Real Solutions
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary">
-                        Create technology that actually gets used by nonprofits to help communities
-                      </Typography>
-                    </Box>
-                  </Box>
-                </Grid>
-                <Grid size={{ xs: 12, sm: 6 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
-                    <Group color="primary" sx={{ mr: 2, mt: 0.5 }} />
-                    <Box>
-                      <Typography variant="h6" gutterBottom>
-                        Global Community
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary">
-                        Network with developers, designers, and nonprofits from around the world
-                      </Typography>
-                    </Box>
-                  </Box>
-                </Grid>
-                <Grid size={{ xs: 12, sm: 6 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
-                    <EmojiEvents color="primary" sx={{ mr: 2, mt: 0.5 }} />
-                    <Box>
-                      <Typography variant="h6" gutterBottom>
-                        Skill Development
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary">
-                        Learn new technologies and improve your coding skills in a real-world setting
-                      </Typography>
-                    </Box>
-                  </Box>
-                </Grid>
-                <Grid size={{ xs: 12, sm: 6 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
-                    <EventAvailable color="primary" sx={{ mr: 2, mt: 0.5 }} />
-                    <Box>
-                      <Typography variant="h6" gutterBottom>
-                        Career Growth
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary">
-                        Connect with sponsors and gain experience that enhances your professional profile
-                      </Typography>
-                    </Box>
-                  </Box>
-                </Grid>
-              </Grid>
-            </Grid>
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                <Box sx={{ textAlign: 'center', maxWidth: '100%' }}>
-                  <Image
-                    src="https://cdn.ohack.dev/ohack.dev/2023_hackathon_2.webp"
-                    alt="Developers collaborating at Opportunity Hack hackathon"
-                    width={500}
-                    height={350}
-                    style={{
-                      maxWidth: "100%",
-                      height: "auto",
-                      borderRadius: "12px",
-                      boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
-                    }}
-                  />
-                  <Typography variant="caption" display="block" sx={{ mt: 1, color: 'text.secondary' }}>
-                    Developers working together to create solutions for nonprofits
-                  </Typography>
-                </Box>
-              </Box>
-            </Grid>
-          </Grid>
-        </Paper>
-        
-        {/* Arizona local callout */}
-        <Alert severity="info" sx={{ mb: 3 }}>
-          Local to Arizona? See{" "}
-          <Link href="/hackathons/arizona" style={{ color: "inherit", fontWeight: 600 }}>
-            hackathons in Arizona
-          </Link>{" "}
-          for ASU, Tempe, and Phoenix-area events.
-        </Alert>
-
-        {/* Upcoming Events Section - Now positioned after "Why Join" */}
+      <ProjectsContainer style={{ marginTop: 12, width: "100%" }}>
+        {/* Upcoming Events — first in flow so visitors landing here find an
+            event to join without scrolling past marketing copy. */}
         <Box
           id="upcoming-events"
           component="section"
           aria-labelledby="upcoming-events-heading"
-          mb={5}
+          mb={3}
+          sx={{ scrollMarginTop: 100 }}
         >
           <HackathonList />
         </Box>
-        
+
+        {/* Story Strip — bridges upcoming and previous with aggregate impact stats
+            and a clickable year sparkline that jumps into the archive below. */}
+        <HackathonStoryStrip />
+
         {/* Previous Events Section - Positioned right after Upcoming Events for better content grouping */}
         <Box mb={5}>
           <PreviousHackathonList />
         </Box>
       </ProjectsContainer>
 
-      {/* Before You Join Section - Moved after all event content for better UX hierarchy */}
-      <Box mt={5} mb={5} px={2}>
-        <Typography variant="h3" component="h2" gutterBottom sx={{ textAlign: 'center', mb: 2 }}>
-          Before You Join an Event
+      {/* About These Events — merged "Why Join" + "Before You Join".
+          Both are context, not finder-flow: positioned after the archive so
+          the first-scroll experience is hero → events → impact → past, and
+          this section catches users who scrolled deep. */}
+      <Box
+        id="about-events"
+        component="section"
+        aria-labelledby="about-events-heading"
+        sx={{ mt: 5, mb: 5, px: 2, scrollMarginTop: 100 }}
+      >
+        <Typography
+          id="about-events-heading"
+          variant="h4"
+          component="h2"
+          gutterBottom
+          sx={{ textAlign: 'center', mb: 1, fontWeight: 700 }}
+        >
+          About these events
         </Typography>
-        <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center', mb: 4, maxWidth: '600px', mx: 'auto' }}>
-          Quick reads to ensure everyone has a great and safe experience.
+        <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center', mb: 4, maxWidth: 720, mx: 'auto' }}>
+          What you get out of joining — and the quick reads to skim before you sign up.
         </Typography>
-        
-        <Grid container spacing={3} sx={{ maxWidth: '900px', mx: 'auto' }}>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ height: '100%', textAlign: 'center', '&:hover': { boxShadow: 3 }, transition: 'box-shadow 0.3s' }}>
-              <CardContent>
-                <Policy color="primary" sx={{ fontSize: 40, mb: 2 }} />
-                <Typography variant="h6" gutterBottom>
-                  Code of Conduct
-                </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-                  Community guidelines for respectful collaboration
-                </Typography>
-                <Button
-                  variant="outlined"
-                  component={Link}
-                  href="/hack/code-of-conduct"
-                  fullWidth
-                  size="small"
-                  onClick={() => track('cta_click', 'code_of_conduct')}
-                >
-                  Read Guidelines
-                </Button>
-              </CardContent>
-            </Card>
-          </Grid>
 
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ height: '100%', textAlign: 'center', '&:hover': { boxShadow: 3 }, transition: 'box-shadow 0.3s' }}>
-              <CardContent>
-                <Gavel color="action" sx={{ fontSize: 40, mb: 2 }} />
-                <Typography variant="h6" gutterBottom>
-                  Liability Waiver
-                </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-                  Standard protection for in-person events
-                </Typography>
-                <Button
-                  variant="outlined"
-                  component={Link}
-                  href="/hack/liability-waiver"
-                  fullWidth
-                  size="small"
-                  onClick={() => track('cta_click', 'liability_waiver')}
-                >
-                  View Waiver
-                </Button>
-              </CardContent>
-            </Card>
+        {/* What you get — compact 4-up icon row (no big photo, no h3 per item).
+            The Story Strip above already proves the scale with numbers, so
+            this is descriptive complement, not the headline. */}
+        <Box sx={{ maxWidth: 1000, mx: 'auto', mb: 5 }}>
+          <Typography variant="overline" color="text.secondary" sx={{ display: 'block', mb: 1.5, textAlign: 'center', letterSpacing: 1 }}>
+            What you get
+          </Typography>
+          <Grid container spacing={2}>
+            {[
+              { icon: <Code color="primary" />, title: 'Build real solutions', desc: "Software nonprofits actually deploy — not throwaway demos." },
+              { icon: <Group color="primary" />, title: 'Global community', desc: 'Developers, designers, and nonprofit leads from around the world.' },
+              { icon: <EmojiEvents color="primary" />, title: 'Skill development', desc: 'Learn shipping with real users, deadlines, and constraints.' },
+              { icon: <EventAvailable color="primary" />, title: 'Career growth', desc: 'Network with sponsors and ship a portfolio piece worth talking about.' },
+            ].map((item) => (
+              <Grid key={item.title} size={{ xs: 12, sm: 6, md: 3 }}>
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
+                  <Box sx={{ flexShrink: 0, mt: 0.25 }}>{item.icon}</Box>
+                  <Box>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.25 }}>
+                      {item.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {item.desc}
+                    </Typography>
+                  </Box>
+                </Box>
+              </Grid>
+            ))}
           </Grid>
+        </Box>
 
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ height: '100%', textAlign: 'center', '&:hover': { boxShadow: 3 }, transition: 'box-shadow 0.3s' }}>
-              <CardContent>
-                <CameraAlt color="action" sx={{ fontSize: 40, mb: 2 }} />
-                <Typography variant="h6" gutterBottom>
-                  Photo Release
-                </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-                  Permission to share event photos
-                </Typography>
-                <Button
-                  variant="outlined"
-                  component={Link}
-                  href="/hack/photo-release"
-                  fullWidth
-                  size="small"
-                  onClick={() => track('cta_click', 'photo_release')}
-                >
-                  Photo Policy
-                </Button>
-              </CardContent>
-            </Card>
+        {/* Before signing up — the three legal/safety reads. Same cards as
+            before, just under a different heading and reduced visual weight
+            (this is a "skim before signup" thing, not the page's hero). */}
+        <Box sx={{ maxWidth: 900, mx: 'auto' }}>
+          <Typography variant="overline" color="text.secondary" sx={{ display: 'block', mb: 1.5, textAlign: 'center', letterSpacing: 1 }}>
+            Before signing up
+          </Typography>
+          <Grid container spacing={2}>
+            {[
+              { icon: <Policy color="primary" sx={{ fontSize: 32 }} />, title: 'Code of Conduct', desc: 'Community guidelines for respectful collaboration', href: '/hack/code-of-conduct', cta: 'Read guidelines', tracker: 'code_of_conduct' },
+              { icon: <Gavel color="action" sx={{ fontSize: 32 }} />, title: 'Liability Waiver', desc: 'Standard protection for in-person events', href: '/hack/liability-waiver', cta: 'View waiver', tracker: 'liability_waiver' },
+              { icon: <CameraAlt color="action" sx={{ fontSize: 32 }} />, title: 'Photo Release', desc: 'Permission to share event photos', href: '/hack/photo-release', cta: 'Photo policy', tracker: 'photo_release' },
+            ].map((item) => (
+              <Grid key={item.title} size={{ xs: 12, md: 4 }}>
+                <Card sx={{ height: '100%', textAlign: 'center', '&:hover': { boxShadow: 3 }, transition: 'box-shadow 0.3s' }}>
+                  <CardContent>
+                    <Box sx={{ mb: 1 }}>{item.icon}</Box>
+                    <Typography variant="subtitle1" gutterBottom sx={{ fontWeight: 600 }}>
+                      {item.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                      {item.desc}
+                    </Typography>
+                    <Button
+                      variant="outlined"
+                      component={Link}
+                      href={item.href}
+                      fullWidth
+                      size="small"
+                      onClick={() => track('cta_click', item.tracker)}
+                      sx={{ textTransform: 'none' }}
+                    >
+                      {item.cta}
+                    </Button>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
           </Grid>
-        </Grid>
+        </Box>
       </Box>
 
       {/* Support Our Mission Section - Appropriate for secondary audience */}


### PR DESCRIPTION
## Summary
- Compress page height from 9940px → **8287px** (−16.6%) and move Upcoming Events from y=957 → y=244 (above the fold on most laptops).
- Kill pagination on the past-events archive — every year now visible on one continuous scroll, with a sticky year rail for one-click teleport.
- Bridge upcoming ↔ archive with a new Story Strip showing aggregate funnel stats + year sparkline, surfacing the 12-year track record that was previously buried on `/hack/results`.

## What changed
**Hero**
- Tightened from 455px → ~220px. Dropped the "Since 2013..." tagline (the Story Strip below has those numbers concretely), inlined the two CTAs.

**Above events**
- Removed the "Why Join" Paper (462px of generic marketing copy between the user and the events).
- Removed the inline "Latest Updates" news block from `HackathonList`. News fetch is now gated to `compact={true}` (home-page sidebar unchanged). `/hack` shows a small "Read latest updates" link to `/blog` instead.

**New `HackathonStoryStrip`** (between upcoming and archive)
- Stat tiles fed by `GET /api/messages/hackathons/funnel/aggregate` — 32 hackathons, 4,222 registered, 293 projects shipped, 12 events with winners.
- Horizontal year sparkline 2014→2026, click a dot to jump to that year in the archive.
- Arizona callout moved inside the strip (was previously a standalone Alert).
- "Full impact report →" link to `/hack/results` (was un-linked from `/hack` before).

**`PreviousHackathonList` (past events archive)**
- Full rewrite. Year-grouped layout with `#year-{yyyy}` anchors.
- Photo-led `PastEventCard` — uses `event.event_photos[0]?.url` when available, otherwise a year-hashed HSL gradient with the year in large text.
- Sticky vertical year rail (desktop) / horizontal sticky bar (mobile) listing 2014–2026 with event counts. One-click teleport to any year.
- Removed: pagination, year-filter chips, "Showing X of Y" footer.

**New "About these events" section** (after archive)
- Merged the old "Why Join" cards (now a compact 4-icon row) with the "Before signing up" legal cards (Code of Conduct / Liability Waiver / Photo Release). Both were in the wrong place before: "Why Join" was blocking events, and "Before You Join" lived at y=8490 (invisible).

**New `HackPageNav` sticky page TOC**
- Hidden until the hero scrolls past. Desktop: vertical pill stack fixed at `left: 16px`. Mobile: horizontal scrollable pill bar fixed at `top: 64px` (below NavBar).
- Sections: Upcoming / Since 2013 / Past Events / About — active highlight follows scroll position via rAF-throttled anchor-line detection.

**CWV hygiene per CLAUDE.md**
- All section anchors carry `scrollMarginTop: 100` so jumps don't get hidden behind the 80px NavBar.
- Story strip reserves `minHeight: { xs: 420, md: 240 }` against CLS; stat tiles render as `Skeleton` while loading.
- Past-event card images use `next/image` with `fill` + `sizes` + `loading="lazy"`. `cdn.ohack.dev` is already in `next.config.js` `images.remotePatterns`.
- `LazyMount` (IntersectionObserver-gated) defers `ImpactMetrics`' per-card backend fetches until the card is near the viewport. Important — the archive is long (~30+ cards across 13 year groups).

## Files
| File | Change |
|---|---|
| `src/pages/hack/index.js` | Compact hero, removed Why Join above events, new About section, wired HackPageNav |
| `src/components/HackathonList/HackathonList.js` | Stripped news block from full-width render, gated news fetch to compact mode |
| `src/components/HackathonList/HackathonStoryStrip.js` | New — bridge component with stats + sparkline + Arizona callout |
| `src/components/HackathonList/PreviousHackathonList.js` | Full rewrite — year-grouped, photo-led, sticky year rail |
| `src/components/HackathonList/HackPageNav.js` | New — sticky page TOC |
| `CLAUDE.md` | Load-bearing notes: section IDs are TOC contract, don't re-add Why Join above events, news gated to compact mode |

## Test plan
- [ ] `/hack` loads without console errors (the two pre-existing warnings — `disableEqualOverflow` and `<a> inside <a>` in `EventFeature` — remain; unrelated to this change)
- [ ] Hero shows "Hackathons for nonprofits" + two CTAs only; no long tagline; no "Why Join" Paper visible above the fold
- [ ] Upcoming Events section starts ~y=244 (immediately scannable on first load)
- [ ] Story Strip renders 4 stat tiles with live numbers, year sparkline 2014→2026, Arizona callout
- [ ] Story Strip year dot click → archive scrolls to that year's section
- [ ] Past Events archive shows ALL years on one continuous scroll (no Pagination component, no year-chip filter)
- [ ] 2026 ASU WiCS card shows a real event photo; older cards show the year-tinted gradient fallback
- [ ] Sticky year rail (left side, desktop) visible while scrolling through archive; click any year → smooth scroll to that section
- [ ] `HackPageNav` appears after scrolling past the hero; click any section → smooth scroll there; "Past Events" highlights while scrolling through the archive
- [ ] "About these events" section after archive renders the 4-icon "What you get" row + 3 legal cards
- [ ] "Read latest updates from Opportunity Hack" link below upcoming events points to `/blog`
- [ ] Home-page sidebar (which uses `HackathonList` with `compact={true}`) still shows the news block — no regression there
- [ ] Mobile (≤md): page TOC renders as horizontal bar below NavBar; year rail renders as horizontal bar at top of archive
- [ ] Lighthouse CLS stays green (story strip + archive both reserve heights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)