### PR TITLE
[Letters] Self-service volunteer letter generator (/hack/[event_id]/letters)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,14 @@ if (env.TWITTER_API_KEY && env.TWITTER_API_SECRET) {
 3. Add environment variables to `.env`
 4. Update `SUPPORTED_PLATFORMS` in `src/lib/social-media/index.js`
 
+## Volunteer Letter Generator (`/hack/[event_id]/letters`)
+Self-service page where a volunteer answers a branching checklist that *picks* one of four letter types (General Volunteer, SE/OPT, Mentor, Judge), fills details against a live preview, and submits to OHack to review/sign. Auth-gated (`RequiredAuthProvider`, like the application forms) with profile prefill of recipient name/email.
+- Files: page `src/pages/hack/[event_id]/letters.js`; logic/templates in `src/components/Letters/` — `letterConfig.js` (pure: `ORG` constants, `runChecklist(answers)`, `*_FIELDS`, `encode/decodeLetterState`), `LetterChecklist.js` (Q1–Q4 branching UI), `LetterPreview.js` (the print surface; renders all 4 letters).
+- **Decision safety (do not regress):** OPT letter is offered ONLY when Q3=initial post-completion OPT AND all 4 Q4 acks checked. STEM extension → blocked to General; "not sure" → advisory + General; mentor/judge branches never reach OPT. `runChecklist` is unit-coverable in isolation — keep its branch table intact.
+- **Wording:** General + SE/OPT bodies reproduce the two reference `.docx` verbatim (with variable substitution); Mentor/Judge are event-based service confirmations. Every letter carries the guardrail bullets (volunteer not employee; no compensation; no visa sponsorship; no immigration advice/certification) — never add immigration/legal certifications.
+- **Submission reuses `POST /api/contact`** (no backend change) with `inquiryType: "volunteer_letter"`. The message packs a readable summary + a shareable `?d=<base64>` link that re-renders the *filled* letter so the reviewer types the signer block and prints. `volunteer_letter` is mapped in `ContactSubmissionDetailDialog.js` `INQUIRY_TYPE_DISPLAY` (mirror in backend `contact_service.py` for reply threading if needed).
+- **Signer block** (`SIGNER_FIELDS`) is OHack-filled at sign time, left blank by the volunteer. **Print** uses a global `@media print { visibility }` trick (only `#letter-print-root` shows) + `@page { size: Letter; margin: 1in }` — no `react-to-print`. Page is `noindex`. Shareable state via `?d=` follows the "Shareable dialog state" pattern (hydrate-once ref + debounced shallow `router.replace`).
+
 ## Application Forms (`/hack/[event_id]/{judge,mentor,hacker,volunteer}-application.js`)
 Shared scaffolding lives in `src/components/ApplicationForm/`. Use these instead of re-implementing in each form:
 - `PronounsPicker` — chip-based picker with curated pronouns + "Add your own". Stores a comma-joined string (back-compatible with old free-text values). All four forms use it.

--- a/src/components/Letters/LetterChecklist.js
+++ b/src/components/Letters/LetterChecklist.js
@@ -1,0 +1,144 @@
+import React from "react";
+import {
+  Box,
+  Typography,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Checkbox,
+  FormControl,
+  FormLabel,
+  Alert,
+  Paper,
+} from "@mui/material";
+import {
+  ROLE_OPTIONS,
+  IMMIGRATION_OPTIONS,
+  OPT_TYPE_OPTIONS,
+  OPT_ACKNOWLEDGMENTS,
+  LETTER_LABELS,
+} from "./letterConfig";
+
+function Question({ label, children }) {
+  return (
+    <FormControl component="fieldset" sx={{ display: "block", mb: 2.5 }}>
+      <FormLabel
+        component="legend"
+        sx={{ fontWeight: 700, color: "text.primary", mb: 1, "&.Mui-focused": { color: "text.primary" } }}
+      >
+        {label}
+      </FormLabel>
+      {children}
+    </FormControl>
+  );
+}
+
+export default function LetterChecklist({ answers, setAnswers, result }) {
+  const { role, needsImmigration, optType, ack = {} } = answers;
+
+  const setField = (key, value) =>
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+
+  const setAck = (key, checked) =>
+    setAnswers((prev) => ({ ...prev, ack: { ...prev.ack, [key]: checked } }));
+
+  // Branching: reset downstream answers when an upstream answer changes.
+  const onRole = (value) =>
+    setAnswers((prev) => ({ ...prev, role: value, needsImmigration: "", optType: "", ack: {} }));
+  const onImmigration = (value) =>
+    setAnswers((prev) => ({ ...prev, needsImmigration: value, optType: "", ack: {} }));
+  const onOptType = (value) =>
+    setAnswers((prev) => ({ ...prev, optType: value, ack: {} }));
+
+  return (
+    <Paper variant="outlined" sx={{ p: { xs: 2, md: 3 }, mb: 3 }}>
+      <Typography variant="h6" component="h2" sx={{ fontWeight: 700, mb: 0.5 }}>
+        Which letter do you need?
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2.5 }}>
+        Answer a few questions and we'll pick the right letter for you.
+      </Typography>
+
+      {/* Q1 */}
+      <Question label="1. What was your role at this event?">
+        <RadioGroup value={role || ""} onChange={(e) => onRole(e.target.value)}>
+          {ROLE_OPTIONS.map((o) => (
+            <FormControlLabel key={o.value} value={o.value} control={<Radio />} label={o.label} />
+          ))}
+        </RadioGroup>
+      </Question>
+
+      {/* Q2 — software branch only */}
+      {role === "software" && (
+        <Question label="2. Do you need this letter to count as employment for an immigration status (for example, F-1 OPT)?">
+          <RadioGroup
+            value={needsImmigration || ""}
+            onChange={(e) => onImmigration(e.target.value)}
+          >
+            {IMMIGRATION_OPTIONS.map((o) => (
+              <FormControlLabel key={o.value} value={o.value} control={<Radio />} label={o.label} />
+            ))}
+          </RadioGroup>
+        </Question>
+      )}
+
+      {/* Q3 — OPT branch */}
+      {role === "software" && needsImmigration === "yes" && (
+        <Question label="3. Which OPT are you on?">
+          <RadioGroup value={optType || ""} onChange={(e) => onOptType(e.target.value)}>
+            {OPT_TYPE_OPTIONS.map((o) => (
+              <FormControlLabel key={o.value} value={o.value} control={<Radio />} label={o.label} />
+            ))}
+          </RadioGroup>
+        </Question>
+      )}
+
+      {/* Block / advisory messages */}
+      {result.block && (
+        <Alert severity="warning" sx={{ mb: 2.5 }}>
+          {result.blockMessage} We've selected the <strong>General Volunteer</strong> letter
+          for you instead.
+        </Alert>
+      )}
+      {result.advisory && !result.block && (
+        <Alert severity="info" sx={{ mb: 2.5 }}>
+          {result.advisory}
+        </Alert>
+      )}
+
+      {/* Q4 — only for initial post-completion OPT */}
+      {role === "software" && needsImmigration === "yes" && optType === "initial" && (
+        <Question label="4. Please confirm all of the following to generate the OPT letter:">
+          <Box>
+            {OPT_ACKNOWLEDGMENTS.map((a) => (
+              <FormControlLabel
+                key={a.key}
+                sx={{ alignItems: "flex-start", mb: 1, display: "flex" }}
+                control={
+                  <Checkbox
+                    checked={Boolean(ack[a.key])}
+                    onChange={(e) => setAck(a.key, e.target.checked)}
+                    sx={{ pt: 0 }}
+                  />
+                }
+                label={<Typography variant="body2">{a.label}</Typography>}
+              />
+            ))}
+          </Box>
+          {result.needsAck && (
+            <Alert severity="info" sx={{ mt: 1 }}>
+              Check all four boxes above to unlock the OPT letter.
+            </Alert>
+          )}
+        </Question>
+      )}
+
+      {result.letterType && (
+        <Alert severity="success" sx={{ mt: 1 }}>
+          We'll generate your <strong>{LETTER_LABELS[result.letterType]}</strong> letter. Fill
+          in the details below to complete it.
+        </Alert>
+      )}
+    </Paper>
+  );
+}

--- a/src/components/Letters/LetterPreview.js
+++ b/src/components/Letters/LetterPreview.js
@@ -1,0 +1,429 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import { format, parseISO } from "date-fns";
+import { ORG, LETTER_TYPES } from "./letterConfig";
+
+const FONT = '"Arial", "Helvetica", sans-serif';
+
+// Renders a typed value, or a muted bracket placeholder so OHack can fill by hand.
+function V({ value, placeholder }) {
+  if (value && String(value).trim()) return <>{value}</>;
+  return (
+    <span style={{ color: "#9aa0a6", fontStyle: "italic" }}>
+      {placeholder}
+    </span>
+  );
+}
+
+function prettyDate(raw, fallback = "[Date]") {
+  if (!raw) return fallback;
+  // letterDate / startDate come from <input type="date"> as yyyy-mm-dd.
+  try {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+      return format(parseISO(raw), "MMMM d, yyyy");
+    }
+  } catch {
+    /* fall through to raw */
+  }
+  return raw;
+}
+
+const headingSx = { fontFamily: FONT, fontWeight: 700, fontSize: "11pt", mt: 2, mb: 0.5 };
+const bodySx = { fontFamily: FONT, fontSize: "11pt", lineHeight: 1.45, mb: 1.25, color: "#000" };
+
+function Letterhead() {
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography sx={{ fontFamily: FONT, fontWeight: 700, fontSize: "15pt", color: "#000" }}>
+        {ORG.name}
+      </Typography>
+      <Box sx={{ borderBottom: "1px solid #000", my: 0.5 }} />
+      <Typography sx={{ fontFamily: FONT, fontSize: "9.5pt", color: "#000" }}>
+        A {ORG.taxStatus} | EIN {ORG.ein} | {ORG.website}
+      </Typography>
+    </Box>
+  );
+}
+
+function RecipientBlock({ f }) {
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography sx={bodySx} component="div">
+        {prettyDate(f.letterDate)}
+      </Typography>
+      <Typography sx={{ ...bodySx, mb: 0 }} component="div">
+        <V value={f.recipientName} placeholder="[Volunteer Full Name]" />
+      </Typography>
+      <Typography sx={{ ...bodySx, mb: 0, whiteSpace: "pre-line" }} component="div">
+        <V value={f.recipientAddress} placeholder={"[Street Address]\n[City, State ZIP]"} />
+      </Typography>
+    </Box>
+  );
+}
+
+function SignatureBlock({ s }) {
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Typography sx={{ ...bodySx, mb: 3 }}>Sincerely,</Typography>
+      <Typography sx={{ ...bodySx, mb: 0 }}>
+        <V value={s.signerName} placeholder="[Name]" />
+      </Typography>
+      <Typography sx={{ ...bodySx, mb: 0 }}>
+        <V value={s.signerTitle} placeholder="[Title]" />, {ORG.name}
+      </Typography>
+      <Typography sx={{ ...bodySx, mb: 0 }}>
+        <V value={s.signerEmail} placeholder="[email]" /> |{" "}
+        <V value={s.signerPhone} placeholder="[phone]" />
+      </Typography>
+    </Box>
+  );
+}
+
+function Bullet({ children }) {
+  return (
+    <Box component="li" sx={{ ...bodySx, mb: 0.75 }}>
+      {children}
+    </Box>
+  );
+}
+
+function GuardrailBullets({ name }) {
+  const n = name && name.trim() ? name : "The volunteer";
+  return (
+    <Box component="ul" sx={{ pl: 3, my: 1 }}>
+      <Bullet>
+        This was a volunteer role; {n} is not an employee of {ORG.shortName}.
+      </Bullet>
+      <Bullet>
+        No compensation of any kind was provided — no wages, stipend, prize money,
+        meals, travel, lodging, or benefits.
+      </Bullet>
+      <Bullet>No visa sponsorship was offered or implied.</Bullet>
+      <Bullet>
+        {ORG.shortName} does not provide legal or immigration advice and does not
+        certify immigration status.
+      </Bullet>
+      <Bullet>
+        This is an event-based service confirmation, not an OPT-employment letter.
+      </Bullet>
+    </Box>
+  );
+}
+
+function EngagementTable({ f }) {
+  const rows = [
+    ["Organization", ORG.name],
+    ["Tax status", ORG.taxStatus],
+    ["EIN", ORG.ein],
+    ["Organization address", <V key="a" value={f.orgAddress || ORG.address} placeholder="[Organization mailing address]" />],
+    ["Volunteer role", "Volunteer Software Engineer"],
+    ["Engagement type", "Unpaid volunteer (no employer-employee relationship)"],
+    ["Start date", <V key="s" value={prettyDate(f.startDate, "")} placeholder="[Start date]" />],
+    ["End date", <V key="e" value={f.endDate} placeholder='[End date, or "ongoing"]' />],
+    ["Hours per week", <><V value={f.hoursPerWeek} placeholder="at least 20" /> hours per week</>],
+    ["Hours record", `Self-logged by volunteer at ${ORG.trackUrl}, verified by supervisor`],
+    ["Work location", <V key="w" value={f.workLocation} placeholder="Remote / [Phoenix, AZ]" />],
+    [
+      "Supervisor",
+      <>
+        <V value={f.supervisorName} placeholder="[Supervisor name]" />,{" "}
+        <V value={f.supervisorTitle} placeholder="[title]" />
+      </>,
+    ],
+    [
+      "Supervisor contact",
+      <>
+        <V value={f.supervisorEmail} placeholder="[email]" /> |{" "}
+        <V value={f.supervisorPhone} placeholder="[phone]" />
+      </>,
+    ],
+  ];
+  return (
+    <Box component="table" sx={{ width: "100%", borderCollapse: "collapse", my: 1.5 }}>
+      <Box component="tbody">
+        {rows.map(([label, value], i) => (
+          <Box component="tr" key={i}>
+            <Box
+              component="td"
+              sx={{
+                border: "1px solid #888",
+                p: "4px 8px",
+                fontFamily: FONT,
+                fontSize: "10pt",
+                fontWeight: 700,
+                width: "34%",
+                verticalAlign: "top",
+                color: "#000",
+              }}
+            >
+              {label}
+            </Box>
+            <Box
+              component="td"
+              sx={{
+                border: "1px solid #888",
+                p: "4px 8px",
+                fontFamily: FONT,
+                fontSize: "10pt",
+                verticalAlign: "top",
+                color: "#000",
+              }}
+            >
+              {value}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+// ---- Letter bodies -------------------------------------------------------
+
+function GeneralLetter({ f, s }) {
+  return (
+    <>
+      <RecipientBlock f={f} />
+      <Typography sx={{ ...bodySx, fontWeight: 700 }}>
+        Subject: Volunteer Role Confirmation and Responsibilities at {ORG.shortName}
+      </Typography>
+      <Typography sx={bodySx}>
+        Dear <V value={f.recipientName} placeholder="[Volunteer Name]" />,
+      </Typography>
+      <Typography sx={bodySx}>
+        Thank you for your interest in volunteering with {ORG.name} (“{ORG.shortName}”),
+        a {ORG.taxStatus} registered with the IRS and the State of Arizona. We are excited
+        about your eagerness to contribute to our mission of helping nonprofits and
+        developing individuals in software engineering and related fields. This letter
+        outlines your volunteer role and responsibilities.
+      </Typography>
+      <Typography sx={bodySx}>
+        <strong>Volunteer role:</strong> Volunteer Software Engineer
+      </Typography>
+      <Typography sx={headingSx}>Responsibilities</Typography>
+      <Box component="ul" sx={{ pl: 3, my: 1 }}>
+        <Bullet>
+          <strong>Project selection and contribution:</strong> You may select projects from
+          our pool of initiatives, primarily improving our platform ({ORG.website}) or
+          assisting other nonprofits with their software needs.
+        </Bullet>
+        <Bullet>
+          <strong>Communication:</strong> We use asynchronous communication via Slack
+          ({ORG.slack}). You are encouraged to ask questions and share comments. When async
+          is not enough, we offer bi-weekly Office Half-Hours for real-time support.
+        </Bullet>
+        <Bullet>
+          <strong>Mentorship and guidance:</strong> Engage in mentoring sessions and ad hoc
+          workshops to build your skills in software engineering, program management,
+          product management, and user experience design.
+        </Bullet>
+        <Bullet>
+          <strong>Documentation:</strong> Log your volunteer time at {ORG.trackUrl} and keep
+          records of your contributions and progress.
+        </Bullet>
+      </Box>
+      <Typography sx={bodySx}>
+        <strong>Duration and commitment:</strong> You may choose the duration and level of
+        commitment that suits your schedule. For this general volunteer role there is no
+        minimum or maximum time requirement.
+      </Typography>
+      <Typography sx={headingSx}>Legal considerations</Typography>
+      <Typography sx={bodySx}>
+        As a volunteer, you are not an employee of {ORG.shortName}. This role offers no
+        financial compensation, benefits, prize money, or visa sponsorship. Your
+        contributions are made on a voluntary basis. {ORG.shortName} does not provide legal
+        or immigration advice and does not certify your immigration status. If you hold a
+        visa or other status that may require work authorization even for unpaid work (for
+        example, F-1 students), please confirm with your Designated School Official or a
+        licensed immigration attorney before treating this as informal volunteering. If you
+        need this engagement to count toward post-completion OPT, ask us for our OPT
+        volunteer engagement confirmation letter instead, which documents specific hours and
+        a supervisor.
+      </Typography>
+      <Typography sx={headingSx}>Recognition and support</Typography>
+      <Typography sx={bodySx}>
+        Upon successful completion of your volunteer activities, and consistent with our
+        recognition guidelines ({ORG.heartsUrl}), we will provide a letter of recommendation
+        highlighting your contributions and milestones. We may also offer LinkedIn
+        endorsements and serve as a professional reference for future opportunities,
+        consistent with those guidelines.
+      </Typography>
+      <Typography sx={bodySx}>
+        We look forward to your contributions and are here to support you throughout your
+        volunteer journey with {ORG.shortName}. Please reach out with any questions.
+      </Typography>
+      <SignatureBlock s={s} />
+    </>
+  );
+}
+
+function OptLetter({ f, s }) {
+  return (
+    <>
+      <RecipientBlock f={f} />
+      <Typography sx={{ ...bodySx, fontWeight: 700 }}>
+        Re: Confirmation of Volunteer Engagement — Volunteer Software Engineer
+      </Typography>
+      <Typography sx={bodySx}>
+        Dear <V value={f.recipientName} placeholder="[Volunteer Name]" />,
+      </Typography>
+      <Typography sx={bodySx}>
+        Thank you for volunteering with {ORG.name} (“{ORG.shortName}”), a {ORG.taxStatus}{" "}
+        organization registered with the IRS and the State of Arizona. We are glad to have
+        you contributing to our mission of helping nonprofits through technology and
+        developing volunteers in software engineering and related fields. At your request,
+        this letter confirms the details of your volunteer engagement so that you may report
+        it accurately to your Designated School Official (DSO).
+      </Typography>
+      <Typography sx={headingSx}>Engagement details</Typography>
+      <EngagementTable f={f} />
+      <Typography sx={headingSx}>Role and responsibilities</Typography>
+      <Typography sx={bodySx}>
+        In this volunteer role you will perform software engineering work directly related
+        to your field of study, including:
+      </Typography>
+      <Box component="ul" sx={{ pl: 3, my: 1 }}>
+        <Bullet>
+          <strong>Software development:</strong> designing, developing, testing, and
+          reviewing software for {ORG.shortName} platforms (including {ORG.website}) and
+          partner nonprofit projects;
+        </Bullet>
+        <Bullet>
+          <strong>Technical collaboration:</strong> participating in technical design
+          discussions, code reviews, and documentation;
+        </Bullet>
+        <Bullet>
+          <strong>Communication and mentorship:</strong> coordinating asynchronously through
+          Slack ({ORG.slack}) and bi-weekly Office Half-Hours, with mentorship in software
+          engineering, product management, and UX as relevant.
+        </Bullet>
+      </Box>
+      <Typography sx={headingSx}>Compensation</Typography>
+      <Typography sx={bodySx}>
+        This is an unpaid volunteer engagement. {ORG.shortName} does not and will not provide
+        wages, salary, stipends, prize money, meals, transportation, lodging, equity,
+        benefits, or any other form of compensation for this role. There is no promise or
+        expectation of future paid employment, and no visa sponsorship is offered or implied.
+      </Typography>
+      <Typography sx={headingSx}>Hours, reporting, and legal note</Typography>
+      <Typography sx={bodySx}>
+        You are responsible for logging your volunteer hours at {ORG.trackUrl}. This
+        self-logged time record, which your supervisor can confirm, is the basis for
+        verifying the hours you report. We understand you intend to report this volunteer
+        engagement as part of your post-completion Optional Practical Training (OPT). The
+        information above is provided to support that reporting and your records. We will, on
+        request, verify your role, dates, and logged hours for your DSO or for U.S.
+        Citizenship and Immigration Services. {ORG.shortName} does not provide legal or
+        immigration advice and does not certify your immigration status or compliance.
+        Whether this engagement and the reported hours satisfy your specific OPT
+        requirements (including the requirement that qualifying employment relate to your
+        degree and average a sufficient number of hours per week) is a determination for
+        you, your DSO, and, if needed, a licensed immigration attorney. Please confirm these
+        details with your DSO before relying on this engagement for status purposes.
+      </Typography>
+      <Typography sx={headingSx}>Recognition</Typography>
+      <Typography sx={bodySx}>
+        Upon completion of your volunteer activities, and consistent with our recognition
+        guidelines ({ORG.heartsUrl}), we are glad to provide a letter of recommendation
+        summarizing your contributions and milestones, and we may serve as a professional
+        reference or provide a LinkedIn endorsement.
+      </Typography>
+      <Typography sx={bodySx}>
+        We are grateful for your contributions and look forward to working with you. Please
+        reach out with any questions.
+      </Typography>
+      <SignatureBlock s={s} />
+    </>
+  );
+}
+
+function ServiceLetter({ f, s, role }) {
+  const isMentor = role === "mentor";
+  const roleWord = isMentor ? "mentor" : "judge";
+  return (
+    <>
+      <RecipientBlock f={f} />
+      <Typography sx={{ ...bodySx, fontWeight: 700 }}>
+        Re: Confirmation of Volunteer Service — {isMentor ? "Mentor" : "Judge"}
+      </Typography>
+      <Typography sx={bodySx}>
+        Dear <V value={f.recipientName} placeholder="[Volunteer Name]" />,
+      </Typography>
+      <Typography sx={bodySx}>
+        Thank you for volunteering with {ORG.name} (“{ORG.shortName}”), a {ORG.taxStatus}{" "}
+        registered with the IRS and the State of Arizona. This letter confirms your volunteer
+        service at the event below.
+      </Typography>
+      <Typography sx={bodySx}>
+        This confirms that{" "}
+        <V value={f.recipientName} placeholder="[Volunteer Name]" /> served as a volunteer{" "}
+        {roleWord} at <V value={f.eventName} placeholder="[Event name]" /> on{" "}
+        <V value={f.eventDates} placeholder="[Event dates]" />
+        {f.eventLocation ? (
+          <> at {f.eventLocation}</>
+        ) : null}
+        ,{" "}
+        {isMentor
+          ? "providing technical and career mentorship to participating teams."
+          : "evaluating team submissions against the event's judging criteria and giving feedback to participating teams."}
+        {f.roleNote ? <> {f.roleNote}</> : null}
+      </Typography>
+      <Typography sx={bodySx}>
+        <strong>Hours contributed:</strong>{" "}
+        <V value={f.hoursContributed} placeholder="[hours]" /> during the event.
+      </Typography>
+      <GuardrailBullets name={f.recipientName} />
+      <Typography sx={bodySx}>
+        We are grateful for this contribution and are glad to serve as a professional
+        reference consistent with our recognition guidelines ({ORG.heartsUrl}). Please reach
+        out with any questions.
+      </Typography>
+      <SignatureBlock s={s} />
+    </>
+  );
+}
+
+export default function LetterPreview({ letterType, fields = {}, signer = {}, id = "letter-print-root" }) {
+  const inner = () => {
+    switch (letterType) {
+      case LETTER_TYPES.GENERAL:
+        return <GeneralLetter f={fields} s={signer} />;
+      case LETTER_TYPES.OPT:
+        return <OptLetter f={fields} s={signer} />;
+      case LETTER_TYPES.MENTOR:
+        return <ServiceLetter f={fields} s={signer} role="mentor" />;
+      case LETTER_TYPES.JUDGE:
+        return <ServiceLetter f={fields} s={signer} role="judge" />;
+      default:
+        return (
+          <Typography sx={{ ...bodySx, color: "#666" }}>
+            Answer the questions on the left to generate your letter preview.
+          </Typography>
+        );
+    }
+  };
+
+  return (
+    <Box
+      id={id}
+      sx={{
+        backgroundColor: "#fff",
+        color: "#000",
+        p: { xs: 2, md: 5 },
+        maxWidth: "8.5in",
+        mx: "auto",
+        boxShadow: { xs: 0, md: "0 0 8px rgba(0,0,0,0.12)" },
+        "@media print": {
+          boxShadow: "none",
+          p: 0,
+          maxWidth: "none",
+          WebkitPrintColorAdjust: "exact",
+          colorAdjust: "exact",
+        },
+      }}
+    >
+      <Letterhead />
+      {inner()}
+    </Box>
+  );
+}

--- a/src/components/Letters/letterConfig.js
+++ b/src/components/Letters/letterConfig.js
@@ -1,0 +1,199 @@
+// Pure config + logic for the volunteer letter generator.
+// No JSX here — consumed by LetterChecklist, LetterPreview, and the letters page.
+
+export const ORG = {
+  name: "Opportunity Hack, Inc.",
+  shortName: "Opportunity Hack",
+  taxStatus: "501(c)(3) nonprofit",
+  ein: "81-2917815",
+  website: "ohack.dev",
+  slack: "slack.ohack.dev",
+  heartsUrl: "ohack.dev/about/hearts",
+  trackUrl: "ohack.dev/volunteer/track",
+  // Org mailing address is editable on the form; blank by default.
+  address: "",
+};
+
+export const LETTER_TYPES = {
+  GENERAL: "general",
+  OPT: "opt",
+  MENTOR: "mentor",
+  JUDGE: "judge",
+};
+
+export const LETTER_LABELS = {
+  [LETTER_TYPES.GENERAL]: "General Volunteer",
+  [LETTER_TYPES.OPT]: "Software Engineering Volunteer (OPT)",
+  [LETTER_TYPES.MENTOR]: "Mentor",
+  [LETTER_TYPES.JUDGE]: "Judge",
+};
+
+export const STEM_BLOCK_MESSAGE =
+  "Volunteering cannot satisfy the STEM OPT extension employment requirement, so we can't issue an OPT-employment letter for this role. We're glad to provide a General Volunteer recognition letter instead. Please confirm your options with your DSO.";
+
+export const UNSURE_ADVISORY_MESSAGE =
+  "Please confirm your OPT type with your DSO before requesting this letter. You can proceed with the General Volunteer letter in the meantime; we can't offer the OPT letter until you confirm you're on initial post-completion OPT.";
+
+// Q4 acknowledgments — ALL must be true before the OPT letter is offered.
+export const OPT_ACKNOWLEDGMENTS = [
+  {
+    key: "degree",
+    label:
+      "The work is directly related to my degree field (software / computer science).",
+  },
+  {
+    key: "hours20",
+    label:
+      "If I need this to stop my OPT unemployment clock, I will average at least 20 hours per week.",
+  },
+  {
+    key: "logHours",
+    label:
+      "I will log my hours at ohack.dev/volunteer/track, and my supervisor can confirm them.",
+  },
+  {
+    key: "noAdvice",
+    label:
+      "I understand Opportunity Hack does not provide immigration advice or certify my status, and I will confirm with my DSO.",
+  },
+];
+
+export const ROLE_OPTIONS = [
+  {
+    value: "software",
+    label:
+      "Built / contributed to a software project, or did software engineering work",
+  },
+  { value: "mentor", label: "Mentored teams" },
+  { value: "judge", label: "Judged submissions" },
+];
+
+export const IMMIGRATION_OPTIONS = [
+  {
+    value: "no",
+    label: "No — I just want confirmation of my volunteer contribution",
+  },
+  {
+    value: "yes",
+    label:
+      "Yes — I'm on F-1 post-completion OPT and need to report this as OPT employment",
+  },
+];
+
+export const OPT_TYPE_OPTIONS = [
+  { value: "initial", label: "Initial post-completion OPT (12-month)" },
+  { value: "stem", label: "STEM OPT extension (24-month)" },
+  { value: "unsure", label: "Not sure" },
+];
+
+const allAck = (ack) =>
+  OPT_ACKNOWLEDGMENTS.every((a) => Boolean(ack && ack[a.key]));
+
+/**
+ * Resolves the decision checklist to a letter type (or a block / pending state).
+ * @returns {{
+ *   letterType: string|null,
+ *   block?: boolean,
+ *   blockMessage?: string,
+ *   advisory?: string,
+ *   needsAck?: boolean,   // OPT path chosen but Q4 not all checked yet
+ * }}
+ */
+export function runChecklist(answers) {
+  const { role, needsImmigration, optType, ack } = answers || {};
+
+  if (role === "mentor") return { letterType: LETTER_TYPES.MENTOR };
+  if (role === "judge") return { letterType: LETTER_TYPES.JUDGE };
+  if (role !== "software") return { letterType: null };
+
+  // Q2
+  if (needsImmigration === "no") return { letterType: LETTER_TYPES.GENERAL };
+  if (needsImmigration !== "yes") return { letterType: null };
+
+  // Q3
+  if (optType === "stem") {
+    return {
+      letterType: LETTER_TYPES.GENERAL,
+      block: true,
+      blockMessage: STEM_BLOCK_MESSAGE,
+    };
+  }
+  if (optType === "unsure") {
+    return {
+      letterType: LETTER_TYPES.GENERAL,
+      advisory: UNSURE_ADVISORY_MESSAGE,
+    };
+  }
+  if (optType === "initial") {
+    if (allAck(ack)) return { letterType: LETTER_TYPES.OPT };
+    return { letterType: null, needsAck: true };
+  }
+  return { letterType: null };
+}
+
+// Event fields shown (pre-filled from metadata, editable) on every letter.
+export const EVENT_FIELDS = [
+  { key: "eventName", label: "Event name" },
+  { key: "eventDates", label: "Event dates" },
+  { key: "eventLocation", label: "Location / venue" },
+  { key: "eventHost", label: "Host / partners" },
+  { key: "eventTheme", label: "Theme" },
+];
+
+// Recipient fields the volunteer types (name/email may be profile-prefilled).
+export const RECIPIENT_FIELDS = [
+  { key: "recipientName", label: "Your full name" },
+  { key: "recipientAddress", label: "Street address, City, State ZIP", multiline: true },
+  { key: "letterDate", label: "Letter date", type: "date" },
+];
+
+// Role-specific typed fields, keyed by letter type.
+export const ROLE_FIELDS = {
+  [LETTER_TYPES.GENERAL]: [],
+  [LETTER_TYPES.OPT]: [
+    { key: "orgAddress", label: "Organization mailing address" },
+    { key: "startDate", label: "Start date", type: "date" },
+    { key: "endDate", label: 'End date (or "ongoing")' },
+    { key: "hoursPerWeek", label: "Hours per week", default: "at least 20" },
+    { key: "workLocation", label: "Work location", default: "Remote" },
+    { key: "supervisorName", label: "Supervisor name" },
+    { key: "supervisorTitle", label: "Supervisor title" },
+    { key: "supervisorEmail", label: "Supervisor email" },
+    { key: "supervisorPhone", label: "Supervisor phone" },
+  ],
+  [LETTER_TYPES.MENTOR]: [
+    { key: "hoursContributed", label: "Hours contributed (event total)" },
+    { key: "roleNote", label: "Brief role note (optional)", multiline: true },
+  ],
+  [LETTER_TYPES.JUDGE]: [
+    { key: "hoursContributed", label: "Hours contributed (event total)" },
+    { key: "roleNote", label: "Brief role note (optional)", multiline: true },
+  ],
+};
+
+// Signer block — filled by OHack at review/sign time, not by the volunteer.
+export const SIGNER_FIELDS = [
+  { key: "signerName", label: "Signer name" },
+  { key: "signerTitle", label: "Signer title" },
+  { key: "signerEmail", label: "Signer email" },
+  { key: "signerPhone", label: "Signer phone" },
+];
+
+// Compact, dependency-free base64 round-trip for the shareable URL (?d=).
+export function encodeLetterState(payload) {
+  try {
+    const json = JSON.stringify(payload);
+    return btoa(unescape(encodeURIComponent(json)));
+  } catch {
+    return "";
+  }
+}
+
+export function decodeLetterState(encoded) {
+  try {
+    const json = decodeURIComponent(escape(atob(encoded)));
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}

--- a/src/components/admin/ContactSubmissionDetailDialog.js
+++ b/src/components/admin/ContactSubmissionDetailDialog.js
@@ -34,6 +34,7 @@ const INQUIRY_TYPE_DISPLAY = {
   nonprofit: "Nonprofit Partnership",
   judge: "Judging Opportunity",
   volunteer: "Volunteer Opportunity",
+  volunteer_letter: "Volunteer Letter Request",
   media: "Media Inquiry",
   other: "General Question",
 };

--- a/src/pages/hack/[event_id]/letters.js
+++ b/src/pages/hack/[event_id]/letters.js
@@ -1,0 +1,519 @@
+import React, { useState, useEffect, useRef, useMemo } from "react";
+import { useRouter } from "next/router";
+import Head from "next/head";
+import axios from "axios";
+import {
+  useAuthInfo,
+  RequiredAuthProvider,
+  RedirectToLogin,
+} from "@propelauth/react";
+import {
+  Typography,
+  Container,
+  Box,
+  TextField,
+  Button,
+  Paper,
+  Divider,
+  Alert,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  Snackbar,
+  Tooltip,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
+import PrintIcon from "@mui/icons-material/Print";
+import SendIcon from "@mui/icons-material/Send";
+import LinkIcon from "@mui/icons-material/Link";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import CheckIcon from "@mui/icons-material/Check";
+import { format, parseISO } from "date-fns";
+import { useEnv } from "../../../context/env.context";
+import { useRecaptcha } from "../../../hooks/use-recaptcha";
+import ReCaptchaProvider from "../../../components/ReCaptchaProvider";
+import { ProfileAutofillNotice } from "../../../components/ApplicationForm";
+import LetterChecklist from "../../../components/Letters/LetterChecklist";
+import LetterPreview from "../../../components/Letters/LetterPreview";
+import {
+  runChecklist,
+  EVENT_FIELDS,
+  RECIPIENT_FIELDS,
+  ROLE_FIELDS,
+  SIGNER_FIELDS,
+  LETTER_LABELS,
+  encodeLetterState,
+  decodeLetterState,
+} from "../../../components/Letters/letterConfig";
+
+function formatEventDates(start, end) {
+  try {
+    const s = start ? format(parseISO(start), "MMMM d, yyyy") : "";
+    const e = end ? format(parseISO(end), "MMMM d, yyyy") : "";
+    if (s && e && s !== e) return `${s} – ${e}`;
+    return s || e || "";
+  } catch {
+    return "";
+  }
+}
+
+const todayStr = () => format(new Date(), "yyyy-MM-dd");
+
+function FieldInput({ def, value, onChange }) {
+  return (
+    <TextField
+      fullWidth
+      label={def.label}
+      type={def.type === "date" ? "date" : "text"}
+      value={value || ""}
+      onChange={(e) => onChange(def.key, e.target.value)}
+      multiline={Boolean(def.multiline)}
+      minRows={def.multiline ? 2 : undefined}
+      InputLabelProps={def.type === "date" ? { shrink: true } : undefined}
+      sx={{ mb: 2 }}
+    />
+  );
+}
+
+function LettersComponent() {
+  const router = useRouter();
+  const { event_id } = router.query;
+  const { user } = useAuthInfo();
+  const { apiServerUrl } = useEnv();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const { getRecaptchaToken, error: recaptchaError } = useRecaptcha();
+
+  const [eventData, setEventData] = useState(null);
+  const [loadingEvent, setLoadingEvent] = useState(true);
+
+  const [answers, setAnswers] = useState({
+    role: "",
+    needsImmigration: "",
+    optType: "",
+    ack: {},
+  });
+  const [fields, setFields] = useState({ letterDate: todayStr() });
+  const [signer, setSigner] = useState({});
+  const [autofilled, setAutofilled] = useState(false);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const [success, setSuccess] = useState(false);
+  const [shareUrl, setShareUrl] = useState("");
+  const [copied, setCopied] = useState(false);
+  const shareInputRef = useRef(null);
+
+  const hydratedRef = useRef(false);
+  const urlTimerRef = useRef(null);
+
+  const result = useMemo(() => runChecklist(answers), [answers]);
+  const letterType = result.letterType;
+
+  const setField = (key, value) => setFields((p) => ({ ...p, [key]: value }));
+  const setSignerField = (key, value) => setSigner((p) => ({ ...p, [key]: value }));
+
+  // Hydrate from ?d= (shareable link) once on mount.
+  useEffect(() => {
+    if (hydratedRef.current || !router.isReady) return;
+    hydratedRef.current = true;
+    const d = router.query.d;
+    if (d) {
+      const decoded = decodeLetterState(Array.isArray(d) ? d[0] : d);
+      if (decoded) {
+        if (decoded.answers) setAnswers(decoded.answers);
+        if (decoded.fields) setFields(decoded.fields);
+        if (decoded.signer) setSigner(decoded.signer);
+        setAutofilled(false);
+      }
+    }
+  }, [router.isReady, router.query.d]);
+
+  // Fetch event metadata and prefill editable event fields + recipient from profile.
+  useEffect(() => {
+    if (!event_id || !apiServerUrl) return;
+    let cancelled = false;
+    (async () => {
+      setLoadingEvent(true);
+      try {
+        const res = await fetch(`${apiServerUrl}/api/messages/hackathon/${event_id}`);
+        const data = res.ok ? await res.json() : null;
+        if (cancelled) return;
+        setEventData(data);
+        // Only prefill when not arriving via a shareable link (which already carries values).
+        if (!router.query.d) {
+          setFields((prev) => ({
+            ...prev,
+            eventName: prev.eventName || data?.title || "",
+            eventDates:
+              prev.eventDates || formatEventDates(data?.start_date, data?.end_date),
+            eventLocation: prev.eventLocation || data?.location || "",
+            eventHost: prev.eventHost || data?.host || "",
+            eventTheme: prev.eventTheme || data?.theme || "",
+            recipientName:
+              prev.recipientName ||
+              (user?.firstName && user?.lastName
+                ? `${user.firstName} ${user.lastName}`
+                : user?.username || ""),
+            recipientEmail: prev.recipientEmail || user?.email || "",
+            letterDate: prev.letterDate || todayStr(),
+          }));
+          if (user?.email || user?.firstName) setAutofilled(true);
+        }
+      } catch {
+        if (!cancelled) setEventData(null);
+      } finally {
+        if (!cancelled) setLoadingEvent(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event_id, apiServerUrl, user]);
+
+  // Mirror current state into ?d= (debounced, shallow) so the link is shareable.
+  useEffect(() => {
+    if (!router.isReady || !hydratedRef.current) return;
+    if (urlTimerRef.current) clearTimeout(urlTimerRef.current);
+    urlTimerRef.current = setTimeout(() => {
+      const d = encodeLetterState({ answers, fields, signer });
+      router.replace(
+        { pathname: router.pathname, query: { ...router.query, d } },
+        undefined,
+        { shallow: true, scroll: false }
+      );
+    }, 400);
+    return () => urlTimerRef.current && clearTimeout(urlTimerRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [answers, fields, signer]);
+
+  // Keep the visible shareable link in sync with the encoded state.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const d = encodeLetterState({ answers, fields, signer });
+    setShareUrl(`${window.location.origin}${window.location.pathname}?d=${d}`);
+  }, [answers, fields, signer]);
+
+  const handleCopyLink = async () => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(shareUrl);
+      } else if (shareInputRef.current) {
+        shareInputRef.current.select();
+        document.execCommand("copy");
+      }
+      setCopied(true);
+    } catch {
+      // Fallback: select the field so the user can copy manually.
+      shareInputRef.current?.select();
+    }
+  };
+
+  const handlePrint = () => window.print();
+
+  const buildShareUrl = () => {
+    if (typeof window === "undefined") return "";
+    const d = encodeLetterState({ answers, fields, signer });
+    return `${window.location.origin}${window.location.pathname}?d=${d}`;
+  };
+
+  const buildMessage = () => {
+    const roleFields = ROLE_FIELDS[letterType] || [];
+    const lines = [
+      `Volunteer letter request: ${LETTER_LABELS[letterType] || letterType}`,
+      `Event: ${fields.eventName || event_id} (${fields.eventDates || "dates n/a"})`,
+      `Location: ${fields.eventLocation || "n/a"}`,
+      `Recipient: ${fields.recipientName || "n/a"} <${fields.recipientEmail || "n/a"}>`,
+      `Address: ${(fields.recipientAddress || "n/a").replace(/\n/g, ", ")}`,
+      `Letter date: ${fields.letterDate || "n/a"}`,
+    ];
+    roleFields.forEach((rf) => {
+      lines.push(`${rf.label}: ${fields[rf.key] || "(blank)"}`);
+    });
+    lines.push("");
+    lines.push("Reviewer: open this link to fill the signer block, then print/save as PDF:");
+    lines.push(buildShareUrl());
+    return lines.join("\n");
+  };
+
+  const recipientReady =
+    Boolean(letterType) &&
+    Boolean(fields.recipientName && fields.recipientName.trim()) &&
+    Boolean(fields.recipientEmail && fields.recipientEmail.trim());
+
+  const handleSubmit = async () => {
+    setSubmitError("");
+    if (!recipientReady) {
+      setSubmitError("Please provide your name and email before submitting.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const recaptchaToken = await getRecaptchaToken("volunteer_letter");
+      if (!recaptchaToken && process.env.NODE_ENV !== "development") {
+        setSubmitError("Failed to verify you are human. Please try again.");
+        setSubmitting(false);
+        return;
+      }
+      const nameParts = (fields.recipientName || "").trim().split(/\s+/);
+      const firstName = nameParts[0] || "Volunteer";
+      const lastName = nameParts.slice(1).join(" ") || "Volunteer";
+      await axios.post(`${apiServerUrl}/api/contact`, {
+        firstName,
+        lastName,
+        email: fields.recipientEmail,
+        organization: fields.eventName || `Hackathon ${event_id}`,
+        inquiryType: "volunteer_letter",
+        message: buildMessage(),
+        receiveUpdates: false,
+        recaptchaToken,
+      });
+      setSuccess(true);
+    } catch (e) {
+      setSubmitError(
+        "Failed to submit your request. Please try again or email volunteer@ohack.org."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const roleFields = ROLE_FIELDS[letterType] || [];
+
+  return (
+    <>
+      <Head>
+        <title>Volunteer Letter Generator | Opportunity Hack</title>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
+
+      {/* Print only the letter; hide nav/footer/form. */}
+      <style jsx global>{`
+        @media print {
+          body * {
+            visibility: hidden !important;
+          }
+          #letter-print-root,
+          #letter-print-root * {
+            visibility: visible !important;
+          }
+          #letter-print-root {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 100%;
+          }
+        }
+        @page {
+          size: Letter;
+          margin: 1in;
+        }
+      `}</style>
+
+      <Container maxWidth="xl" sx={{ pt: { xs: 10, md: 12 }, pb: 4 }}>
+        <Box className="no-print">
+          <Typography variant="h1" component="h1" sx={{ fontSize: "2.25rem", mb: 1 }}>
+            Volunteer Letter Generator
+          </Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ mb: 3, maxWidth: 720 }}>
+            Answer a few questions and we'll generate the right confirmation letter for your
+            volunteer work. Submit it to Opportunity Hack to review and sign, or print a draft
+            for your records.
+          </Typography>
+        </Box>
+
+        {success ? (
+          <Alert severity="success" className="no-print" sx={{ mb: 3 }}>
+            <Typography variant="body1" sx={{ fontWeight: 700 }}>
+              Request submitted!
+            </Typography>
+            <Typography variant="body2">
+              Opportunity Hack will review your letter, sign it, and follow up by email. You can
+              still print a draft below for your own records.
+            </Typography>
+          </Alert>
+        ) : null}
+
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
+            gap: 3,
+            alignItems: "flex-start",
+          }}
+        >
+          {/* LEFT: form (hidden on print) */}
+          <Box className="no-print" sx={{ flex: 1, width: "100%", minWidth: 0 }}>
+            <LetterChecklist answers={answers} setAnswers={setAnswers} result={result} />
+
+            {letterType && (
+              <Paper variant="outlined" sx={{ p: { xs: 2, md: 3 }, mb: 3 }}>
+                <Typography variant="h6" component="h2" sx={{ fontWeight: 700, mb: 2 }}>
+                  Your details
+                </Typography>
+                <ProfileAutofillNotice show={autofilled} />
+
+                {RECIPIENT_FIELDS.map((def) => (
+                  <FieldInput key={def.key} def={def} value={fields[def.key]} onChange={setField} />
+                ))}
+                <TextField
+                  fullWidth
+                  label="Your email"
+                  type="email"
+                  value={fields.recipientEmail || ""}
+                  onChange={(e) => setField("recipientEmail", e.target.value)}
+                  helperText="Where we'll send the signed letter."
+                  sx={{ mb: 2 }}
+                />
+
+                <Divider sx={{ my: 2 }} />
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5 }}>
+                  Event details (pre-filled — edit if needed)
+                </Typography>
+                {EVENT_FIELDS.map((def) => (
+                  <FieldInput key={def.key} def={def} value={fields[def.key]} onChange={setField} />
+                ))}
+
+                {roleFields.length > 0 && (
+                  <>
+                    <Divider sx={{ my: 2 }} />
+                    <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5 }}>
+                      {LETTER_LABELS[letterType]} details
+                    </Typography>
+                    {roleFields.map((def) => (
+                      <FieldInput
+                        key={def.key}
+                        def={def}
+                        value={fields[def.key] ?? def.default}
+                        onChange={setField}
+                      />
+                    ))}
+                  </>
+                )}
+
+                <Divider sx={{ my: 2 }} />
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                  Signer (Opportunity Hack use only)
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                  Leave blank — OHack fills this in before signing.
+                </Typography>
+                {SIGNER_FIELDS.map((def) => (
+                  <FieldInput
+                    key={def.key}
+                    def={def}
+                    value={signer[def.key]}
+                    onChange={setSignerField}
+                  />
+                ))}
+
+                <Divider sx={{ my: 2 }} />
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 1 }}>
+                  <LinkIcon fontSize="small" color="action" />
+                  <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                    Shareable link
+                  </Typography>
+                </Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                  Everything you've entered is saved right inside this link — no draft to lose.
+                  Copy it to finish later on any device, or share it with Opportunity Hack.
+                </Typography>
+                <TextField
+                  fullWidth
+                  inputRef={shareInputRef}
+                  value={shareUrl}
+                  onFocus={(e) => e.target.select()}
+                  InputProps={{
+                    readOnly: true,
+                    sx: { fontFamily: "monospace", fontSize: "0.8rem" },
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <Tooltip title={copied ? "Copied!" : "Copy link"}>
+                          <IconButton
+                            onClick={handleCopyLink}
+                            edge="end"
+                            color={copied ? "success" : "default"}
+                            aria-label="Copy shareable link"
+                          >
+                            {copied ? <CheckIcon /> : <ContentCopyIcon />}
+                          </IconButton>
+                        </Tooltip>
+                      </InputAdornment>
+                    ),
+                  }}
+                  sx={{ mb: 2 }}
+                />
+
+                {(submitError || recaptchaError) && (
+                  <Alert severity="error" sx={{ my: 2 }}>
+                    {submitError || recaptchaError}
+                  </Alert>
+                )}
+
+                <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mt: 2 }}>
+                  <Button
+                    variant="contained"
+                    startIcon={submitting ? <CircularProgress size={18} /> : <SendIcon />}
+                    onClick={handleSubmit}
+                    disabled={submitting || !recipientReady}
+                  >
+                    {submitting ? "Submitting…" : "Submit to OHack"}
+                  </Button>
+                  <Button variant="outlined" startIcon={<PrintIcon />} onClick={handlePrint}>
+                    Print / Save as PDF
+                  </Button>
+                </Box>
+              </Paper>
+            )}
+          </Box>
+
+          {/* RIGHT: live preview (the print surface) */}
+          <Box sx={{ flex: 1, width: "100%", minWidth: 0 }}>
+            {loadingEvent && !letterType ? (
+              <Box sx={{ textAlign: "center", py: 6 }} className="no-print">
+                <CircularProgress />
+              </Box>
+            ) : (
+              <LetterPreview letterType={letterType} fields={fields} signer={signer} />
+            )}
+          </Box>
+        </Box>
+      </Container>
+      <Snackbar
+        open={copied}
+        autoHideDuration={2500}
+        onClose={() => setCopied(false)}
+        message="Link copied — it saves everything you've entered"
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      />
+    </>
+  );
+}
+
+export default function VolunteerLettersPage() {
+  const router = useRouter();
+  const { event_id } = router.query;
+  const currentUrl =
+    typeof window !== "undefined" && event_id
+      ? `${window.location.origin}/hack/${event_id}/letters`
+      : null;
+
+  return (
+    <ReCaptchaProvider>
+      <RequiredAuthProvider
+        authUrl={process.env.NEXT_PUBLIC_REACT_APP_AUTH_URL}
+        displayIfLoggedOut={
+          <RedirectToLogin
+            postLoginRedirectUrl={
+              currentUrl || (typeof window !== "undefined" ? window.location.href : "")
+            }
+          />
+        }
+      >
+        <LettersComponent />
+      </RequiredAuthProvider>
+    </ReCaptchaProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- New self-service page `/hack/[event_id]/letters` where a hackathon volunteer answers a short **branching decision checklist** that *picks* the right letter type for them — they never choose a letter name directly. Four types: **General Volunteer**, **Software Engineering Volunteer (OPT)**, **Mentor**, **Judge**.
- **Live letter preview** beside the form; auth-gated (PropelAuth) with profile prefill of recipient name/email; event metadata (name, dates, location, host, theme) pre-fills editable fields and degrades gracefully when missing.
- **OPT safety guardrails:** the OPT letter is offered *only* when Q3 = initial post-completion OPT **and** all 4 acknowledgments are checked. STEM OPT extension → blocked to a General letter; "not sure" → advisory + General; mentor/judge branches never reach OPT.
- **Print to PDF** via `window.print()` + `@media print` visibility trick (`#letter-print-root` only) and `@page { size: Letter; margin: 1in }` — no PDF library.
- **Submission reuses `POST /api/contact`** (`inquiryType: "volunteer_letter"`, no backend change required for the core flow). The contact message packs a readable summary **plus a shareable `?d=<base64>` link** that re-renders the *filled* letter so an OHack reviewer can type the signer block and print/sign.
- **Senior-UX shareable-link affordance:** read-only monospace URL field with copy button (icon swaps to a green check), explanatory microcopy ("everything you've entered is saved right inside this link"), and a confirmation Snackbar.

## Files
- New: `src/components/Letters/letterConfig.js` (pure config + `runChecklist` branch logic + field defs + `encode/decodeLetterState`), `LetterChecklist.js` (Q1–Q4 wizard), `LetterPreview.js` (all 4 letter templates + print surface), `src/pages/hack/[event_id]/letters.js` (page).
- Modified: `src/components/admin/ContactSubmissionDetailDialog.js` (map `volunteer_letter` → "Volunteer Letter Request" so admin replies thread), `CLAUDE.md` (feature docs).

## Notes
- General + SE/OPT letter bodies reproduce the two existing reference `.docx` verbatim (with variable substitution); Mentor/Judge are new event-based service confirmations. Every letter carries the guardrail bullets (volunteer not employee; no compensation; no visa sponsorship; no immigration advice/certification).
- A one-line backend parity change (`api/contact/contact_service.py` inquiry-type map, for confirmation-email/reply-subject threading) is **not** included here — it currently sits on an unrelated backend branch and is optional for the MVP.

## Test plan
- [ ] Logged in, open `/hack/<real_event_id>/letters`; confirm header clears the NavBar and event fields + recipient name/email prefill.
- [ ] Walk each checklist branch: software→General; software→OPT initial + all 4 acks → OPT; STEM → blocked (General only); not-sure → advisory + General; mentor → Mentor; judge → Judge. Confirm OPT never offered from mentor/judge/STEM paths.
- [ ] Event missing `location`/`theme` renders an editable blank, not a crash.
- [ ] Compare rendered General + OPT letters vs. the reference `.docx` for wording/structure; verify guardrail bullets in all four.
- [ ] Cmd+P: only the letter prints (US Letter, ~1in margins, single page), nav/form hidden.
- [ ] Copy shareable link → open in a fresh tab → confirms the filled letter re-renders.
- [ ] Submit → success state, row appears in `/admin/contact` as "Volunteer Letter Request" with a working `?d=` link in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)