### PR TITLE
[Bugfix] Recall hacker required-question answers from saved application

### DIFF
--- a/src/pages/hack/[event_id]/hacker-application.js
+++ b/src/pages/hack/[event_id]/hacker-application.js
@@ -495,12 +495,19 @@ const HackerApplicationComponent = () => {
           constraints: eventData.constraints || {},
         });
 
-        // Initialize requiredQuestionAnswers array to match questions
+        // Initialize requiredQuestionAnswers to match question count without
+        // clobbering answers already loaded from a previous submission /
+        // localStorage (these effects resolve independently of this one).
         if (requiredQuestions.length > 0) {
-          setFormData((prev) => ({
-            ...prev,
-            requiredQuestionAnswers: new Array(requiredQuestions.length).fill(null),
-          }));
+          setFormData((prev) => {
+            const existing = prev.requiredQuestionAnswers || [];
+            if (existing.length === requiredQuestions.length) return prev;
+            const filled = new Array(requiredQuestions.length).fill(null);
+            existing.forEach((v, i) => {
+              if (i < filled.length) filled[i] = v;
+            });
+            return { ...prev, requiredQuestionAnswers: filled };
+          });
         }
 
         // If it's an online event, automatically set inPerson to "No"
@@ -687,6 +694,11 @@ const HackerApplicationComponent = () => {
                     state: prevData.state || "",
                     additionalInfo:
                       prevData.additionalInfo || prevData.comments || "",
+                    requiredQuestionAnswers: Array.isArray(
+                      prevData.requiredQuestionAnswers,
+                    )
+                      ? prevData.requiredQuestionAnswers
+                      : [],
                     event_id: event_id,
                   };
                   setIsSelected(prevData.isSelected || false);


### PR DESCRIPTION
## Summary
Saved hacker eligibility answers (`requiredQuestionAnswers`) rendered blank when reloading an existing application, even though they were correctly stored in Firestore.

## Root cause
- **Recall path dropped the field.** `loadPreviousSubmission()` returns the full backend doc, but the `transformedData` mapping in `hacker-application.js` hand-maps ~40 fields and never copied `requiredQuestionAnswers` — it just inherited the empty `[]` from `initialFormData`. So the radios always showed blank on reload.
- **Latent race.** The event-fetch effect unconditionally reset the array to `new Array(n).fill(null)`. Since the event fetch and the previous-submission load run as independent async effects, if the event fetch landed last it clobbered the just-loaded answers.

The save path was already correct (`POST .../submit|update` → backend `set(..., merge=True)`), which is why the values were visible in the DB.

## Changes
- Copy `requiredQuestionAnswers` from the loaded submission into `transformedData`.
- Guard the init effect so it merges into existing answers instead of overwriting with nulls, making it order-independent.

## Notes for reviewer
- Scoped to the hacker form only. Judge/Mentor load the previous submission sequentially inside the event-fetch effect (no race); Volunteer uses the same two-effect split but its only overlapping field (`inPerson`) is already guarded with `prev.inPerson || "Yes"`. No changes needed there.
- localStorage path was already fine — it round-trips the whole `formData`.

## Test plan
- [ ] Load `/hack/<event_id>/hacker-application` as a user with a saved application that has required-question answers; accept the "load previous application" prompt and confirm the Yes/No radios reflect the stored answers.
- [ ] Confirm a fresh (no prior submission) load still shows unanswered required questions.
- [ ] Re-submit and verify answers persist round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)