### PR TITLE
[Fix] Show clean text for markdown event descriptions on homepage

### DIFF
--- a/src/components/HackathonList/EventFeature.js
+++ b/src/components/HackathonList/EventFeature.js
@@ -32,6 +32,7 @@ import {
 import { format, getYear } from 'date-fns';
 import Link from 'next/link';
 import { parseLocalDate, isValidDate } from '../../lib/dateUtils';
+import { stripMarkdown } from '../../lib/textUtils';
 import { useAuthInfo } from '@propelauth/react';
 import ImpactMetrics from '../ImpactMetrics';
 
@@ -59,6 +60,11 @@ function EventFeature(props) {
   
   // TODO: Is the schema on the backend wrong? Or is the schema here wrong?
   const eventLinks = typeof rawEventLinks === 'string' ? [rawEventLinks] : rawEventLinks
+
+  // Descriptions may contain Markdown. These cards are clamped teasers wrapped
+  // in a single navigation <a>, so strip to clean plain text rather than render
+  // Markdown (which would nest anchors and break the line-clamp).
+  const descriptionText = stripMarkdown(description);
   
   
 
@@ -108,7 +114,7 @@ function EventFeature(props) {
                 lineHeight: 1.4
               }}
             >
-              {description}
+              {descriptionText}
             </Typography>
             
             <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
@@ -144,7 +150,7 @@ function EventFeature(props) {
         <div style={{ cursor: 'pointer', width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
           <div style={{ marginBottom: '12px' }}>
             <EventLink variant="h3">{title}</EventLink>
-            <EventText variant="h3">{description}</EventText>
+            <EventText variant="h3">{descriptionText}</EventText>
           </div>
           
           <div style={{ marginBottom: '16px' }}>

--- a/src/lib/textUtils.js
+++ b/src/lib/textUtils.js
@@ -1,0 +1,43 @@
+/**
+ * Strip Markdown syntax down to clean, readable plain text.
+ *
+ * Used for teaser/preview snippets (e.g. event cards) where the text lives
+ * inside a clamped, single-anchor card and rendering real Markdown would
+ * either break the line-clamp or nest <a> tags inside an <a> (invalid HTML).
+ * For full-fidelity Markdown rendering use react-markdown instead.
+ */
+export function stripMarkdown(input) {
+  if (!input || typeof input !== "string") return "";
+
+  return (
+    input
+      // Fenced code blocks -> keep inner text
+      .replace(/```[\w-]*\n?([\s\S]*?)```/g, "$1")
+      // Images ![alt](url) -> alt
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+      // Links [text](url) -> text
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+      // Reference-style links [text][ref] -> text
+      .replace(/\[([^\]]*)\]\[[^\]]*\]/g, "$1")
+      // Inline code `code` -> code
+      .replace(/`([^`]+)`/g, "$1")
+      // Bold / italic / strikethrough markers
+      .replace(/(\*\*\*|___)(.*?)\1/g, "$2")
+      .replace(/(\*\*|__)(.*?)\1/g, "$2")
+      .replace(/(\*|_)(.*?)\1/g, "$2")
+      .replace(/~~(.*?)~~/g, "$1")
+      // Headings (#, ##, ...)
+      .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+      // Blockquote markers
+      .replace(/^\s{0,3}>\s?/gm, "")
+      // Unordered list bullets
+      .replace(/^\s*[-*+]\s+/gm, "")
+      // Ordered list markers
+      .replace(/^\s*\d+\.\s+/gm, "")
+      // Horizontal rules
+      .replace(/^\s*([-*_])\s*(?:\1\s*){2,}$/gm, "")
+      // Collapse whitespace/newlines into single spaces
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}


### PR DESCRIPTION
## Summary
- Event descriptions containing markdown (`**bold**`, `[links](url)`, `##` headings, lists) were rendering raw syntax in the homepage **Upcoming Events** cards.
- Added `stripMarkdown()` in `src/lib/textUtils.js` and applied it to both render paths of `EventFeature.js` (compact card + full card).

## Why strip instead of render markdown
Each event card is already wrapped in a single `<Link>` to `/hack/[event_id]`, and the compact description is clamped to 2 lines. Rendering real markdown there would:
- nest `<a>` tags inside the card anchor (invalid HTML), and
- break the line-clamp teaser layout.

These are preview snippets, so clean plain-text prose is the correct UX. Full-fidelity markdown rendering still belongs on the event detail page (which already uses `react-markdown`).

## Reviewer notes
- `stripMarkdown()` is regex-based (no new dependency), handles bold/italic/strikethrough, links/images, inline + fenced code, headings, blockquotes, ordered/unordered lists, and horizontal rules, then collapses whitespace.
- Plain-text descriptions pass through unchanged.

## Test plan
- [ ] Homepage `/` → Upcoming Events cards render descriptions without raw markdown characters
- [ ] Plain-text descriptions display unchanged
- [ ] Full-width `/hack` event cards render the same clean text

🤖 Generated with [Claude Code](https://claude.com/claude-code)