### PR TITLE
Fix truncated stat labels in Hackathon Leaderboard

### DIFF
--- a/src/components/Hackathon/HackathonLeaderboard.js
+++ b/src/components/Hackathon/HackathonLeaderboard.js
@@ -75,9 +75,7 @@ const StatLabel = styled(Typography)(({ theme }) => ({
   color: 'var(--muted, #5B6270)',
   textAlign: 'center',
   width: '100%',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
+  overflowWrap: 'break-word',
 }));
 
 const AchievementCard = styled(Box)(({ theme }) => ({
@@ -585,44 +583,44 @@ const HackathonLeaderboard = ({
               placement="top"
             >
               <StatBox sx={{
-                flexDirection: { xs: 'column', md: 'row' },
-                justifyContent: { md: 'flex-start' },
-                alignItems: { xs: 'center', md: 'center' },
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
                 height: '100%',
                 px: { xs: 1, md: 2 },
                 py: { xs: 1.5, md: 1.5 }
               }}>
-                <Box sx={{ 
-                  display: 'flex', 
-                  justifyContent: 'center', 
-                  mr: { md: 2 },
-                  mb: { xs: 1, md: 0 }
+                <Box sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  mb: 1
                 }}>
                   {renderIcon(stat.icon, { fontSize: "large", sx: { color: "var(--accent, #E2552E)" } })}
                 </Box>
-                <Box sx={{ 
-                  display: 'flex', 
-                  flexDirection: { xs: 'column', md: 'column' },
-                  alignItems: { xs: 'center', md: 'flex-start' },
+                <Box sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
                   justifyContent: 'center',
-                  width: '100%'
+                  width: '100%',
+                  minWidth: 0
                 }}>
-                  <StatValue 
-                    variant="h4" 
-                    sx={{ 
-                      fontSize: { xs: '1.3rem', md: '1.3rem' },
-                      textAlign: { xs: 'center', md: 'left' },
+                  <StatValue
+                    variant="h4"
+                    sx={{
+                      fontSize: '1.3rem',
+                      textAlign: 'center',
                       lineHeight: 1.2
                     }}
                   >
                     {stat.value.toLocaleString()}
                   </StatValue>
-                  <StatLabel 
-                    variant="subtitle2" 
+                  <StatLabel
+                    variant="subtitle2"
                     title={stat.stat}
-                    sx={{ 
-                      mt: { xs: 0.2, md: 0.2 },
-                      textAlign: { xs: 'center', md: 'left' },
+                    sx={{
+                      mt: 0.2,
+                      textAlign: 'center',
                       maxWidth: '100%',
                       lineHeight: 1.2,
                       fontSize: '0.75rem'


### PR DESCRIPTION
## What

Fixes cut-off labels in the **General Statistics** section of the Hackathon Leaderboard (visible on `/hack/summer-2026`), where labels like "GitHub Commits", "Pull Requests", and "Contributors" rendered as "GitHub Com…", "Pull Reques…", "Contributo…".

## Why

In narrow column layouts (e.g. the two-column event page), the stat cards are only ~130px wide. The cards used a horizontal layout (icon *beside* the number+label), which left the label box too little width. The label box couldn't shrink, so it overflowed the card and was clipped by `overflow:hidden` — and `StatLabel` additionally had `whiteSpace:nowrap` + ellipsis, truncating the text.

## Changes

`src/components/Hackathon/HackathonLeaderboard.js`:
- **StatLabel** — removed `nowrap`/`overflow`/`textOverflow:ellipsis`, added `overflowWrap:break-word` so labels wrap instead of truncate.
- **Stat card body** — stacked the icon *above* the number+label (column layout at all breakpoints) so every label gets the full card width.

## Reviewer notes

- This component is shared with the archive's `ImpactMetrics`, so the readability improvement applies anywhere the leaderboard/impact tiles appear.
- Verified in-browser at the event-page (narrow column) width: all five labels — GitHub Commits, Pull Requests, Contributors, Issues Closed, Lines of Code — now render fully within their cards with no clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)