### PR TITLE
[SEO] Fix Event schema on /hack — add missing required fields

### DIFF
--- a/src/pages/hack/index.js
+++ b/src/pages/hack/index.js
@@ -20,7 +20,7 @@ const RX = {
   display: "'Fraunces', Georgia, serif",
 };
 
-const HackathonIndex = () => {
+const HackathonIndex = ({ nextEvent }) => {
   const style = { fontSize: '15px' };
 
   useEffect(() => { initFacebookPixel(); }, []);
@@ -85,21 +85,10 @@ const HackathonIndex = () => {
           content="Join tech volunteers to create solutions for nonprofits at our global hackathons."
         />
         <link rel="canonical" href="https://www.ohack.dev/hack" />
-        <script type="application/ld+json">{`
-          {
-            "@context": "https://schema.org",
-            "@type": "Event",
-            "name": "Opportunity Hack Global Hackathons",
-            "description": "Opportunity Hack hosts impactful hackathons globally where tech volunteers create solutions for nonprofits.",
-            "image": "https://cdn.ohack.dev/ohack.dev/2023_hackathon_2.webp",
-            "url": "https://www.ohack.dev/hack",
-            "organizer": {
-              "@type": "Organization",
-              "name": "Opportunity Hack",
-              "url": "https://www.ohack.dev"
-            }
-          }
-        `}</script>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(buildEventSchema(nextEvent)) }}
+        />
       </Head>
 
       <TitleContainer container sx={{ pt: { xs: 3, md: 5 }, pb: { xs: 2, md: 2 } }}>
@@ -313,3 +302,90 @@ const HackathonIndex = () => {
 };
 
 export default HackathonIndex;
+
+// Build Event schema from the next upcoming hackathon returned by getStaticProps.
+// Falls back gracefully when the API is unavailable at build time.
+function buildEventSchema(event) {
+  const isVirtual = !event?.location ||
+    /online|virtual/i.test(event.location);
+
+  // Date-only strings from the API (e.g. "2026-11-14") get a time appended so
+  // Google sees a full ISO datetime rather than a bare date.
+  const startDate = event?.start_date
+    ? (event.start_date.includes('T') ? event.start_date : `${event.start_date}T09:00:00`)
+    : null;
+  const endDate = event?.end_date
+    ? (event.end_date.includes('T') ? event.end_date : `${event.end_date}T18:00:00`)
+    : null;
+
+  const eventUrl = event?.event_id
+    ? `https://www.ohack.dev/hack/${event.event_id}`
+    : 'https://www.ohack.dev/hack';
+
+  const location = isVirtual
+    ? [{ '@type': 'VirtualLocation', url: eventUrl }]
+    : [
+        { '@type': 'VirtualLocation', url: eventUrl },
+        { '@type': 'Place', name: event.location },
+      ];
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: event?.title || 'Opportunity Hack Global Hackathons',
+    description: event?.description ||
+      'Opportunity Hack hosts impactful hackathons globally where tech volunteers create solutions for nonprofits.',
+    image: event?.image_url || 'https://cdn.ohack.dev/ohack.dev/2023_hackathon_2.webp',
+    url: eventUrl,
+    eventStatus: 'https://schema.org/EventScheduled',
+    eventAttendanceMode: isVirtual
+      ? 'https://schema.org/OnlineEventAttendanceMode'
+      : 'https://schema.org/MixedEventAttendanceMode',
+    location,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+      url: eventUrl,
+      availability: 'https://schema.org/InStock',
+    },
+    organizer: {
+      '@type': 'Organization',
+      name: 'Opportunity Hack',
+      url: 'https://www.ohack.dev',
+    },
+  };
+
+  if (startDate) schema.startDate = startDate;
+  if (endDate) schema.endDate = endDate;
+
+  return schema;
+}
+
+export async function getStaticProps() {
+  const API_URL = process.env.NEXT_PUBLIC_API_SERVER_URL;
+  let nextEvent = null;
+  try {
+    const res = await fetch(`${API_URL}/api/messages/hackathons?current=true`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const hackathons = data.hackathons || data || [];
+      const today = new Date().toISOString().slice(0, 10);
+      // Prefer future events; fall back to most-recent past event.
+      const upcoming = hackathons
+        .filter(h => h.start_date >= today)
+        .sort((a, b) => a.start_date.localeCompare(b.start_date));
+      nextEvent = upcoming[0] ||
+        hackathons.sort((a, b) => b.start_date.localeCompare(a.start_date))[0] ||
+        null;
+    }
+  } catch (_) {
+    // API unavailable at build time — schema will render without dates.
+  }
+  return {
+    props: { nextEvent },
+    revalidate: 3600,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `getStaticProps` to fetch the real next upcoming hackathon from the API (ISR, revalidates every hour)
- Build Event JSON-LD schema dynamically from the live event data rather than hardcoded dates
- Add `buildEventSchema(event)` helper with fallbacks for each field when the API is unavailable at build time
- `startDate` / `endDate` derived from `event.start_date` / `event.end_date`; bare date strings get a time appended so Google sees a full ISO datetime
- `location` array: `VirtualLocation` + `Place(name: event.location)` for in-person events; `VirtualLocation`-only for online events
- `eventAttendanceMode` is `MixedEventAttendanceMode` for venues, `OnlineEventAttendanceMode` for virtual
- `name`, `description`, `image`, `url` all use real event fields with sensible fallbacks
- Resolves 2 critical GSC issues (`startDate`, `location`) and 4 non-critical ones (`endDate`, `eventStatus`, `eventAttendanceMode`, `offers`)

## Why

Google Search Console flagged "Opportunity Hack Global Hackathons" Event schema with 2 critical issues. The previous fix hardcoded Fall 2026 dates — this version uses the live API so the schema stays accurate across events without manual updates.

## Test plan

- [ ] Paste `https://www.ohack.dev/hack` into [Google Rich Results Test](https://search.google.com/test/rich-results) — 0 errors on the Event item
- [ ] Verify `startDate` / `location` / `name` in the emitted JSON-LD match the current next upcoming event from the API
- [ ] Confirm ISR revalidates: after a new event is added to the backend, the schema updates within 1 hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)