### PR TITLE
[Volunteer Admin] Mobile, LinkedIn filter, OHack profile link, all submitted fields

### DIFF
--- a/src/components/admin/ApplicationReviewCard.js
+++ b/src/components/admin/ApplicationReviewCard.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Image from "next/image";
+import NextLink from "next/link";
 import {
   Card,
   CardContent,
@@ -31,7 +32,15 @@ import {
   LocationOn as LocationIcon,
   Edit as EditIcon,
   Gavel as StatusIcon,
+  OpenInNew as OpenInNewIcon,
 } from "@mui/icons-material";
+
+// Resolve LinkedIn URL from any of the field names forms use
+const getLinkedInUrl = (app) => {
+  const raw = app.linkedin || app.linkedinProfile || app.linkedinUrl || '';
+  if (!raw) return null;
+  return raw.startsWith('http') ? raw : `https://${raw}`;
+};
 
 const ApplicationReviewCard = ({
   application,
@@ -425,28 +434,65 @@ const ApplicationReviewCard = ({
         <Box
           sx={{
             display: "flex",
-            alignItems: "center",
+            alignItems: "flex-start",
             justifyContent: "space-between",
             mb: 2,
+            flexWrap: "wrap",
+            gap: 1,
           }}
         >
-          <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Box sx={{ display: "flex", alignItems: "center", minWidth: 0 }}>
             <Avatar
-              src={application.photoUrl}
-              sx={{ mr: 2, bgcolor: "primary.main", width: 48, height: 48 }}
+              src={application.profile_image || application.photoUrl}
+              sx={{ mr: 2, bgcolor: "primary.main", width: 48, height: 48, flexShrink: 0 }}
             >
               <PersonIcon />
             </Avatar>
-            <Box>
-              <Typography variant="h6" component="h3">
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="h6" component="h3" sx={{ wordBreak: 'break-word' }}>
                 {application.name || "No name provided"}
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 {config.title}
               </Typography>
+              {/* LinkedIn + OHack profile quick-access chips */}
+              <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5, flexWrap: 'wrap' }}>
+                {(() => {
+                  const liUrl = getLinkedInUrl(application);
+                  return liUrl ? (
+                    <Chip
+                      icon={<LinkedInIcon sx={{ fontSize: '0.9rem !important' }} />}
+                      label="LinkedIn"
+                      size="small"
+                      component="a"
+                      href={liUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      clickable
+                      sx={{ bgcolor: '#0077b5', color: '#fff', '& .MuiChip-icon': { color: '#fff' } }}
+                    />
+                  ) : (
+                    <Chip label="No LinkedIn" size="small" variant="outlined" sx={{ opacity: 0.5 }} />
+                  );
+                })()}
+                {application.user_db_id && (
+                  <Chip
+                    icon={<OpenInNewIcon sx={{ fontSize: '0.9rem !important' }} />}
+                    label="OHack profile"
+                    size="small"
+                    component={NextLink}
+                    href={`/profile/${application.user_db_id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    clickable
+                    variant="outlined"
+                    color="primary"
+                  />
+                )}
+              </Box>
             </Box>
           </Box>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexShrink: 0 }}>
             {/* Show status for judges, or approval status for others */}
             {applicationType === "judge" && application.status ? (
               <Chip {...getStatusChipConfig(application.status)} size="small" />
@@ -962,7 +1008,7 @@ const ApplicationReviewCard = ({
                               };
 
                               return (
-                                <Box>
+                                <Box sx={{ overflowX: 'auto' }}>
                                   {/* Summary stats */}
                                   <Box
                                     sx={{
@@ -1204,11 +1250,66 @@ const ApplicationReviewCard = ({
               )}
             </Grid>
           </Box>
+
+          {/* All submitted fields — shows anything the applicant filled in that isn't already displayed above */}
+          {(() => {
+            const alreadyRendered = new Set([
+              ...config.primaryFields,
+              ...config.secondaryFields,
+              ...config.additionalFields,
+              'name', 'photoUrl', 'status', 'timestamp', 'event_id',
+              // internal / audit fields never shown to reviewers
+              'id', 'user_id', 'user_db_id', 'propel_id', 'slack_user_id',
+              'volunteer_type', 'isSelected', 'created_by', 'created_timestamp',
+              'updated_by', 'updated_timestamp', 'sent_emails', 'certificates',
+              'profile_image', 'checkedIn', 'checkedInBy', 'checkedInAt',
+              'checkInTime', 'checkInTimeList', 'isCheckedIn', 'timeSlot',
+            ]);
+            const extraEntries = Object.entries(application).filter(([key, val]) => {
+              if (alreadyRendered.has(key)) return false;
+              if (val === null || val === undefined || val === '') return false;
+              if (Array.isArray(val) && val.length === 0) return false;
+              return true;
+            });
+            if (extraEntries.length === 0) return null;
+            return (
+              <Box sx={{ mt: 2 }}>
+                <Divider sx={{ mb: 2 }} />
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                  All Submitted Fields
+                </Typography>
+                <Grid container spacing={2}>
+                  {extraEntries.map(([key, val]) => {
+                    const isLink = ['linkedin', 'linkedinProfile', 'linkedinUrl', 'github', 'portfolio', 'website'].includes(key);
+                    const displayVal = Array.isArray(val)
+                      ? val.join(', ')
+                      : typeof val === 'object'
+                      ? JSON.stringify(val)
+                      : String(val);
+                    return (
+                      <Grid size={{ xs: 12, sm: 6 }} key={key}>
+                        <Typography variant="body2" color="text.secondary">
+                          {getFieldLabel(key)}
+                        </Typography>
+                        <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+                          {isLink && val ? (
+                            <Link href={val.startsWith('http') ? val : `https://${val}`} target="_blank" rel="noopener noreferrer">
+                              {displayVal}
+                            </Link>
+                          ) : displayVal}
+                        </Typography>
+                      </Grid>
+                    );
+                  })}
+                </Grid>
+              </Box>
+            );
+          })()}
         </Collapse>
       </CardContent>
 
       {/* Action buttons */}
-      <CardActions sx={{ justifyContent: "space-between", p: 2 }}>
+      <CardActions sx={{ justifyContent: "space-between", p: 2, flexDirection: { xs: 'column', sm: 'row' }, alignItems: { xs: 'stretch', sm: 'center' }, gap: { xs: 1, sm: 0 } }}>
         <Button
           variant="outlined"
           startIcon={<EditIcon />}

--- a/src/components/admin/ApplicationReviewList.js
+++ b/src/components/admin/ApplicationReviewList.js
@@ -15,15 +15,27 @@ import {
   ButtonGroup,
   Checkbox,
   FormControlLabel,
-  Divider
+  Divider,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import {
   Check as CheckIcon,
   Close as CloseIcon,
   FilterList as FilterIcon,
-  Sort as SortIcon
+  Sort as SortIcon,
+  ExpandMore as ExpandMoreIcon,
+  LinkedIn as LinkedInIcon,
 } from '@mui/icons-material';
 import ApplicationReviewCard from './ApplicationReviewCard';
+
+const getLinkedInUrl = (app) => {
+  const raw = app.linkedin || app.linkedinProfile || app.linkedinUrl || '';
+  return raw ? (raw.startsWith('http') ? raw : `https://${raw}`) : null;
+};
 
 const ApplicationReviewList = ({
   applications = [],
@@ -52,8 +64,11 @@ const ApplicationReviewList = ({
   onSortOrderChange,
   onShowBatchActionsChange
 }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [selectedApplications, setSelectedApplications] = useState(new Set());
-  
+  const [linkedInFilter, setLinkedInFilter] = useState('all'); // 'all' | 'has' | 'missing'
+
   // Use controlled props if provided, otherwise fall back to local state
   const [localFilter, setLocalFilter] = useState('');
   const [localStatusFilter, setLocalStatusFilter] = useState('all');
@@ -185,6 +200,15 @@ const ApplicationReviewList = ({
       }
     }
 
+    // Apply LinkedIn filter
+    if (linkedInFilter !== 'all') {
+      if (linkedInFilter === 'has') {
+        filtered = filtered.filter(app => !!getLinkedInUrl(app));
+      } else if (linkedInFilter === 'missing') {
+        filtered = filtered.filter(app => !getLinkedInUrl(app));
+      }
+    }
+
     // Apply sorting
     filtered.sort((a, b) => {
       let aValue = a[currentSortBy];
@@ -205,7 +229,7 @@ const ApplicationReviewList = ({
     });
 
     return filtered;
-  }, [applications, currentFilter, currentStatusFilter, currentInPersonFilter, currentCheckedInFilter, currentSortBy, currentSortOrder, applicationType]);
+  }, [applications, currentFilter, currentStatusFilter, currentInPersonFilter, currentCheckedInFilter, linkedInFilter, currentSortBy, currentSortOrder, applicationType]);
 
   // Handle individual application actions
   const handleApprove = useCallback(async (application) => {
@@ -343,126 +367,140 @@ const ApplicationReviewList = ({
         </Grid>
       </Paper>
 
-      {/* Filters and Controls */}
-      <Paper sx={{ p: 2, mb: 3 }}>
-        <Grid container spacing={2} alignItems="center">
-          <Grid size={{ xs: 12, sm: 4 }}>
-            <TextField
-              fullWidth
-              label="Search applications"
-              variant="outlined"
-              value={currentFilter}
-              onChange={(e) => handleFilterChange(e.target.value)}
-              placeholder="Name, email, organization..."
-              size="small"
-            />
-          </Grid>
-          
-          <Grid size={{ xs: 12, sm: 2 }}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Status</InputLabel>
-              <Select
-                value={currentStatusFilter}
-                onChange={(e) => handleStatusFilterChange(e.target.value)}
-                label="Status"
-              >
-                <MenuItem value="all">All</MenuItem>
-                <MenuItem value="pending">Pending</MenuItem>
-                <MenuItem value="approved">Approved</MenuItem>
-                {/* Additional status options for judges */}
-                {applicationType === 'judge' && [
-                  <MenuItem key="denied" value="denied">Denied</MenuItem>,
-                  <MenuItem key="verified_travel" value="verified_travel">Verified Travel</MenuItem>,
-                  <MenuItem key="confirmed" value="confirmed">Confirmed</MenuItem>,
-                  <MenuItem key="withdrew" value="withdrew">Withdrew</MenuItem>,
-                  <MenuItem key="no_show" value="no_show">No Show</MenuItem>
-                ]}
-              </Select>
-            </FormControl>
-          </Grid>
+      {/* Filters and Controls — collapsed accordion on mobile, plain Paper on desktop */}
+      {(() => {
+        const filterGridItems = (
+          <>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <TextField
+                fullWidth
+                label="Search applications"
+                variant="outlined"
+                value={currentFilter}
+                onChange={(e) => handleFilterChange(e.target.value)}
+                placeholder="Name, email, organization..."
+                size="small"
+              />
+            </Grid>
 
-          {/* Checked In Filter - Show for all volunteer types */}
-          <Grid size={{ xs: 12, sm: 2 }}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Checked In</InputLabel>
-              <Select
-                value={currentCheckedInFilter}
-                onChange={(e) => handleCheckedInFilterChange(e.target.value)}
-                label="Checked In"
-              >
-                <MenuItem value="all">All</MenuItem>
-                <MenuItem value="yes">Checked In</MenuItem>
-                <MenuItem value="no">Not Checked In</MenuItem>
-              </Select>
-            </FormControl>
-          </Grid>
-
-          {/* In Person Filter - Only show for judges */}
-          {applicationType === 'judge' && (
             <Grid size={{ xs: 12, sm: 2 }}>
               <FormControl fullWidth size="small">
-                <InputLabel>In Person</InputLabel>
+                <InputLabel>Status</InputLabel>
                 <Select
-                  value={currentInPersonFilter}
-                  onChange={(e) => handleInPersonFilterChange(e.target.value)}
-                  label="In Person"
+                  value={currentStatusFilter}
+                  onChange={(e) => handleStatusFilterChange(e.target.value)}
+                  label="Status"
                 >
                   <MenuItem value="all">All</MenuItem>
-                  <MenuItem value="yes">In Person</MenuItem>
-                  <MenuItem value="no">Remote</MenuItem>
+                  <MenuItem value="pending">Pending</MenuItem>
+                  <MenuItem value="approved">Approved</MenuItem>
+                  {applicationType === 'judge' && [
+                    <MenuItem key="denied" value="denied">Denied</MenuItem>,
+                    <MenuItem key="verified_travel" value="verified_travel">Verified Travel</MenuItem>,
+                    <MenuItem key="confirmed" value="confirmed">Confirmed</MenuItem>,
+                    <MenuItem key="withdrew" value="withdrew">Withdrew</MenuItem>,
+                    <MenuItem key="no_show" value="no_show">No Show</MenuItem>
+                  ]}
                 </Select>
               </FormControl>
             </Grid>
-          )}
 
-          <Grid size={{ xs: 12, sm: 2 }}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Sort by</InputLabel>
-              <Select
-                value={currentSortBy}
-                onChange={(e) => handleSortByChange(e.target.value)}
-                label="Sort by"
-              >
-                <MenuItem value="timestamp">Date</MenuItem>
-                <MenuItem value="name">Name</MenuItem>
-                <MenuItem value="email">Email</MenuItem>
-                <MenuItem value="experienceLevel">Experience</MenuItem>
-              </Select>
-            </FormControl>
-          </Grid>
+            <Grid size={{ xs: 12, sm: 2 }}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Checked In</InputLabel>
+                <Select
+                  value={currentCheckedInFilter}
+                  onChange={(e) => handleCheckedInFilterChange(e.target.value)}
+                  label="Checked In"
+                >
+                  <MenuItem value="all">All</MenuItem>
+                  <MenuItem value="yes">Checked In</MenuItem>
+                  <MenuItem value="no">Not Checked In</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
 
-          <Grid size={{ xs: 12, sm: 2 }}>
-            <ButtonGroup size="small" fullWidth>
-              <Button
-                variant={currentSortOrder === 'asc' ? 'contained' : 'outlined'}
-                onClick={() => handleSortOrderChange('asc')}
-              >
-                A-Z
-              </Button>
-              <Button
-                variant={currentSortOrder === 'desc' ? 'contained' : 'outlined'}
-                onClick={() => handleSortOrderChange('desc')}
-              >
-                Z-A
-              </Button>
-            </ButtonGroup>
-          </Grid>
+            {applicationType === 'judge' && (
+              <Grid size={{ xs: 12, sm: 2 }}>
+                <FormControl fullWidth size="small">
+                  <InputLabel>In Person</InputLabel>
+                  <Select
+                    value={currentInPersonFilter}
+                    onChange={(e) => handleInPersonFilterChange(e.target.value)}
+                    label="In Person"
+                  >
+                    <MenuItem value="all">All</MenuItem>
+                    <MenuItem value="yes">In Person</MenuItem>
+                    <MenuItem value="no">Remote</MenuItem>
+                  </Select>
+                </FormControl>
+              </Grid>
+            )}
 
-          <Grid size={{ xs: 12, sm: 2 }}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={currentShowBatchActions}
-                  onChange={(e) => handleShowBatchActionsChange(e.target.checked)}
-                />
-              }
-              label="Batch Actions"
-            />
-          </Grid>
-        </Grid>
+            <Grid size={{ xs: 12, sm: 2 }}>
+              <FormControl fullWidth size="small">
+                <InputLabel>LinkedIn</InputLabel>
+                <Select
+                  value={linkedInFilter}
+                  onChange={(e) => setLinkedInFilter(e.target.value)}
+                  label="LinkedIn"
+                  startAdornment={<LinkedInIcon sx={{ mr: 0.5, color: '#0077b5', fontSize: '1rem' }} />}
+                >
+                  <MenuItem value="all">All</MenuItem>
+                  <MenuItem value="has">Has LinkedIn</MenuItem>
+                  <MenuItem value="missing">No LinkedIn</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
 
-        {/* Batch Actions */}
-        {currentShowBatchActions && (
+            <Grid size={{ xs: 12, sm: 2 }}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Sort by</InputLabel>
+                <Select
+                  value={currentSortBy}
+                  onChange={(e) => handleSortByChange(e.target.value)}
+                  label="Sort by"
+                >
+                  <MenuItem value="timestamp">Date</MenuItem>
+                  <MenuItem value="name">Name</MenuItem>
+                  <MenuItem value="email">Email</MenuItem>
+                  <MenuItem value="experienceLevel">Experience</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+
+            <Grid size={{ xs: 12, sm: 2 }}>
+              <ButtonGroup size="small" fullWidth>
+                <Button
+                  variant={currentSortOrder === 'asc' ? 'contained' : 'outlined'}
+                  onClick={() => handleSortOrderChange('asc')}
+                >
+                  A-Z
+                </Button>
+                <Button
+                  variant={currentSortOrder === 'desc' ? 'contained' : 'outlined'}
+                  onClick={() => handleSortOrderChange('desc')}
+                >
+                  Z-A
+                </Button>
+              </ButtonGroup>
+            </Grid>
+
+            <Grid size={{ xs: 12, sm: 2 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={currentShowBatchActions}
+                    onChange={(e) => handleShowBatchActionsChange(e.target.checked)}
+                  />
+                }
+                label="Batch Actions"
+              />
+            </Grid>
+          </>
+        );
+
+        const batchActionsBlock = currentShowBatchActions && (
           <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
               <FormControlLabel
@@ -475,7 +513,6 @@ const ApplicationReviewList = ({
                 }
                 label={`Select All (${selectedApplications.size} selected)`}
               />
-              
               {selectedApplications.size > 0 && (
                 <>
                   <Button
@@ -502,8 +539,37 @@ const ApplicationReviewList = ({
               )}
             </Box>
           </Box>
-        )}
-      </Paper>
+        );
+
+        if (isMobile) {
+          const hasActiveFilters = !!(currentFilter || currentStatusFilter !== 'all' || currentCheckedInFilter !== 'all' || linkedInFilter !== 'all');
+          return (
+            <Accordion sx={{ mb: 3 }} defaultExpanded={false}>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <FilterIcon fontSize="small" />
+                  <Typography variant="body2">Filters &amp; Sort</Typography>
+                  {hasActiveFilters && <Chip label="Active" size="small" color="primary" />}
+                </Box>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2} alignItems="center">
+                  {filterGridItems}
+                </Grid>
+                {batchActionsBlock}
+              </AccordionDetails>
+            </Accordion>
+          );
+        }
+        return (
+          <Paper sx={{ p: 2, mb: 3 }}>
+            <Grid container spacing={2} alignItems="center">
+              {filterGridItems}
+            </Grid>
+            {batchActionsBlock}
+          </Paper>
+        );
+      })()}
 
       {/* Results Summary */}
       <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
@@ -546,6 +612,16 @@ const ApplicationReviewList = ({
             variant="outlined"
           />
         )}
+
+        {linkedInFilter !== 'all' && (
+          <Chip
+            icon={<LinkedInIcon sx={{ fontSize: '0.9rem !important', color: '#0077b5 !important' }} />}
+            label={linkedInFilter === 'has' ? 'Has LinkedIn' : 'No LinkedIn'}
+            onDelete={() => setLinkedInFilter('all')}
+            size="small"
+            variant="outlined"
+          />
+        )}
       </Box>
 
       {/* Applications List */}
@@ -557,7 +633,7 @@ const ApplicationReviewList = ({
               : 'No applications match your current filters'
             }
           </Typography>
-          {currentFilter || currentStatusFilter !== 'all' || currentInPersonFilter !== 'all' || currentCheckedInFilter !== 'all' ? (
+          {currentFilter || currentStatusFilter !== 'all' || currentInPersonFilter !== 'all' || currentCheckedInFilter !== 'all' || linkedInFilter !== 'all' ? (
             <Button
               variant="outlined"
               onClick={() => {
@@ -565,6 +641,7 @@ const ApplicationReviewList = ({
                 handleStatusFilterChange('all');
                 handleInPersonFilterChange('all');
                 handleCheckedInFilterChange('all');
+                setLinkedInFilter('all');
               }}
               sx={{ mt: 2 }}
             >

--- a/src/components/admin/VolunteerTable.js
+++ b/src/components/admin/VolunteerTable.js
@@ -39,8 +39,9 @@ import { styled } from "@mui/system";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import EditIcon from "@mui/icons-material/Edit";
-import { Email as EmailIcon, VolunteerActivism as CertificateIcon } from '@mui/icons-material';
+import { Email as EmailIcon, VolunteerActivism as CertificateIcon, OpenInNew as OpenInNewIcon } from '@mui/icons-material';
 import { FaPaperPlane, FaSlack, FaLinkedin } from 'react-icons/fa';
+import NextLink from 'next/link';
 import HackerDepositChip from "./HackerDepositChip";
 
 const StyledTableContainer = styled(TableContainer)(({ theme }) => ({
@@ -1531,7 +1532,7 @@ const VolunteerTable = ({
                 {/* Header Row */}
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                   <Avatar
-                    src={volunteer.photoUrl}
+                    src={volunteer.profile_image || volunteer.photoUrl}
                     alt={volunteer.name}
                     sx={{ width: 40, height: 40, mr: 2 }}
                   >
@@ -1657,7 +1658,7 @@ const VolunteerTable = ({
 
               {/* Actions */}
               <CardActions sx={{ pt: 0, px: 2, pb: 2 }}>
-                <Box sx={{ display: 'flex', gap: 0.5, width: '100%' }}>
+                <Box sx={{ display: 'flex', gap: 0.5, width: '100%', alignItems: 'center' }}>
                   <Tooltip title="Edit">
                     <IconButton
                       onClick={() => onEditVolunteer(volunteer)}
@@ -1678,7 +1679,20 @@ const VolunteerTable = ({
                       </IconButton>
                     </Tooltip>
                   )}
-                  <Box sx={{ flex: 1 }} /> {/* Spacer */}
+                  {volunteer.user_db_id && (
+                    <Tooltip title="View OHack profile">
+                      <IconButton
+                        component={NextLink}
+                        href={`/profile/${volunteer.user_db_id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="small"
+                      >
+                        <OpenInNewIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                  <Box sx={{ flex: 1 }} />
                   {volunteer.email && (
                     <Button
                       size="small"
@@ -1949,7 +1963,7 @@ const VolunteerTable = ({
                 <StyledTableCell data-label="Actions">
                   <Box sx={{ display: 'flex', gap: 0.5 }}>
                     <Tooltip title="Edit">
-                      <IconButton 
+                      <IconButton
                         onClick={() => onEditVolunteer(volunteer)}
                         size="small"
                       >
@@ -1958,12 +1972,26 @@ const VolunteerTable = ({
                     </Tooltip>
                     {onMessageVolunteer && (
                       <Tooltip title="Send Message">
-                        <IconButton 
+                        <IconButton
                           onClick={() => onMessageVolunteer(volunteer)}
                           size="small"
                           color="primary"
                         >
                           <FaPaperPlane size={12} />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                    {volunteer.user_db_id && (
+                      <Tooltip title="View OHack profile">
+                        <IconButton
+                          component={NextLink}
+                          href={`/profile/${volunteer.user_db_id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          size="small"
+                          color="default"
+                        >
+                          <OpenInNewIcon fontSize="small" />
                         </IconButton>
                       </Tooltip>
                     )}


### PR DESCRIPTION
## Summary
- **ApplicationReviewCard**: LinkedIn chip (blue) always visible in header; 'No LinkedIn' chip when absent; OHack profile link chip via `user_db_id`; avatar uses `profile_image` from backend enrichment; header `flexWrap` for narrow screens; `CardActions` stacks on mobile (`xs: column`); availability timeline wrapped in `overflowX: auto`; new 'All Submitted Fields' collapse section shows every submitted key not already rendered (skips internal/audit fields)
- **ApplicationReviewList**: LinkedIn filter dropdown (All / Has LinkedIn / No LinkedIn) with filter-active chip + clear; filter bar collapses into MUI Accordion on mobile (collapsed by default); `useTheme`/`useMediaQuery` added
- **VolunteerTable**: profile link `OpenInNew` icon button in table row actions and `MobileCardView`; avatar uses `profile_image` fallback; `NextLink` import added

Companion backend PR: `feat/volunteer-admin-profile-link` on backend-ohack.dev (adds `user_db_id`/`profile_image` to admin volunteer records).

## Test plan
- [ ] Open `/admin/hackathons/{event_id}?section=volunteer` → switch to Review mode → header shows LinkedIn chip or 'No LinkedIn' indicator for each card
- [ ] Expand a card → 'All Submitted Fields' section shows fields not in primary/secondary/additional lists
- [ ] Volunteer with `user_db_id` from backend → 'OHack profile' chip appears and opens correct `/profile/{id}` in new tab
- [ ] Narrow viewport (<600px) → filter bar collapses to Accordion; CardActions buttons stack vertically
- [ ] LinkedIn filter: set 'Has LinkedIn' → only records with a LinkedIn URL shown; active chip appears; clear works
- [ ] VolunteerTable row and MobileCardView both show profile link icon when `user_db_id` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)