### PR TITLE
Refine /volunteer/track: accurate time tracking + fix load bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,21 @@ if (env.TWITTER_API_KEY && env.TWITTER_API_SECRET) {
 3. Add environment variables to `.env`
 4. Update `SUPPORTED_PLATFORMS` in `src/lib/social-media/index.js`
 
+## Volunteer Time Tracking (`/volunteer/track`)
+
+Refined rewrite (`RefinedRoot` + `.ohx-*`, navy/terracotta, native form controls — no MUI for inputs). Page is wrapped in `withAuthInfo` (client-rendered), which has two load-bearing consequences:
+
+- **Fonts are injected via `useEffect`, NOT `<RefinedFonts/>`.** On this page `next/head` silently drops the Google Fonts `<link>`s (the `<Head>` lives in the client-rendered withAuthInfo subtree next to the JSON-LD `<script>` + meta). A one-time effect appends the Fraunces/Hanken stylesheet to `document.head` (guarded by `#ohx-refined-fonts`). Don't revert to `<RefinedFonts/>` here — it renders as serif fallback.
+- **Verify with cache disabled** (Next 16 dev stale-chunk gotcha) — a plain reload serves old JS and the change looks like it didn't apply.
+
+**Tracking model = two numbers: committed vs actively-tracked.**
+- **Live session** (`FunVolunteerTimer`) is **wall-clock based**. Start POSTs `{commitmentHours, reason}` and persists `{startEpoch, commitmentHours, reason}` to `localStorage["volunteeringSession"]`. Elapsed = `now − startEpoch`, **capped at the committed total** (prevents overnight runaway) — survives refresh/background tabs (was `setTimeout` tick-counting, which throttled in bg tabs and lost the session on refresh via a stale-`isVolunteering` save). Auto-finalizes (POST `finalHours`) when elapsed hits the commitment; manual "End" POSTs elapsed. Legacy `localStorage["volunteeringState"]` is cleared on load.
+- **Manual log** ("Log time you already did"): POSTs `{commitmentHours:h, finalHours:h, reason, manual:true, timestamp}` — one entry carrying BOTH so both totals + the table row reflect it (`manual` tag shown). Backdates via `timestamp`.
+- Date range uses native `<input type=date>`; fetch normalizes to start-of-day/**end-of-day** ISO so the selected end day is inclusive (the old MUI DatePicker sent local-midnight → UTC, excluding same-day sessions).
+- `FunVolunteerTimer` ring shows elapsed filling toward the commitment; `VolunteerStatsTable` is a hairline day-grouped table. Both use CSS-var fallbacks so they render refined inside `RefinedRoot`. On-theme `Toast` (not MUI Snackbar); single inline error (no Alert+Snackbar duplicate).
+
+**Backend** (`backend-ohack.dev/services/users_service.py`): `save_volunteering_time`/`get_volunteering_time` go through `_resolve_and_ensure_user()` which **lazily creates the `users` doc** — new users with no profile doc previously 404'd on both read and write (the "Failed to load your volunteer data" bug + couldn't start a session). `get_volunteering_time` returns `([],0,0)` (never None/404) and filters in ONE pass (an entry may carry `commitmentHours`, `finalHours`, or both — no duplicate table rows).
+
 ## Volunteer Letter Generator (`/hack/[event_id]/letters`)
 
 Self-service page where a volunteer answers a branching checklist that _picks_ one of four letter types (General Volunteer, SE/OPT, Mentor, Judge), fills details against a live preview, and submits to OHack to review/sign. Auth-gated (`RequiredAuthProvider`, like the application forms) with profile prefill of recipient name/email.

--- a/src/components/FunVolunteerTimer/FunVolunteerTimer.js
+++ b/src/components/FunVolunteerTimer/FunVolunteerTimer.js
@@ -1,81 +1,94 @@
-import React, { useState, useEffect } from "react";
-import { Box, Typography, keyframes } from "@mui/material";
-import { styled } from "@mui/system";
+import React from "react";
 
-const pulse = keyframes`
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-  }
-  100% {
-    transform: scale(1);
-  }
-`;
+// Refined navy progress ring for the live volunteering session.
+// Self-contained with CSS-var fallbacks so it renders correctly inside a
+// <RefinedRoot> (navy + warm hairline) and on plain surfaces alike.
+//
+// The ring FILLS as elapsed time grows toward the committed total. The headline
+// is the time volunteered so far (actual time) — that's what we want people to
+// watch — with the remaining time as a quiet caption underneath.
 
-const TimerContainer = styled(Box)(({ theme }) => ({
-  position: "relative",
-  width: "200px",
-  height: "200px",
-  margin: "20px auto",
-  animation: `${pulse} 2s infinite ease-in-out`,
-}));
-
-const CircularProgress = styled("div")(({ theme, percentage }) => ({
-  position: "absolute",
-  height: "100%",
-  width: "100%",
-  borderRadius: "50%",
-  background: `conic-gradient(
-    ${theme.palette.primary.main} ${percentage}%,
-    ${theme.palette.grey[300]} ${percentage}%
-  )`,
-  transition: "all 0.5s ease",
-}));
-
-const InnerCircle = styled(Box)(({ theme }) => ({
-  position: "absolute",
-  top: "10%",
-  left: "10%",
-  right: "10%",
-  bottom: "10%",
-  borderRadius: "50%",
-  background: theme.palette.background.paper,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  flexDirection: "column",
-}));
+const formatTime = (seconds) => {
+  const s = Math.max(0, Math.floor(seconds || 0));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const secs = s % 60;
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+};
 
 const FunVolunteerTimer = ({ timeLeft, totalTime }) => {
-  const [percentage, setPercentage] = useState(100);
+  const total = totalTime > 0 ? totalTime : 1;
+  const elapsed = Math.min(total, Math.max(0, total - timeLeft));
+  const pct = Math.min(100, Math.max(0, (elapsed / total) * 100));
+  const isComplete = timeLeft <= 0;
 
-  useEffect(() => {
-    setPercentage((timeLeft / totalTime) * 100);
-  }, [timeLeft, totalTime]);
-
-  const formatTime = (seconds) => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = seconds % 60;
-    return `${hours.toString().padStart(2, "0")}:${minutes
-      .toString()
-      .padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
-  };
+  const brand = "var(--brand, #1B3A6B)";
+  const track = "var(--line, #E7E1D4)";
 
   return (
-    <TimerContainer>
-      <CircularProgress percentage={percentage} />
-      <InnerCircle>
-        <Typography variant="h4" color="primary" fontWeight="bold">
-          {formatTime(timeLeft)}
-        </Typography>
-        <Typography variant="subtitle1" color="text.secondary">
-          Time Left
-        </Typography>
-      </InnerCircle>
-    </TimerContainer>
+    <div
+      style={{
+        position: "relative",
+        width: 220,
+        height: 220,
+        margin: "8px auto 0",
+      }}
+      role="timer"
+      aria-label={`${formatTime(elapsed)} volunteered of ${formatTime(total)} committed`}
+    >
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: "50%",
+          background: `conic-gradient(${brand} ${pct}%, ${track} ${pct}%)`,
+          transition: "background 0.6s ease",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          inset: "11%",
+          borderRadius: "50%",
+          background: "var(--surface, #ffffff)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 2,
+        }}
+      >
+        <span
+          className="ohx-eyebrow"
+          style={{ letterSpacing: "0.16em", fontSize: "0.6rem" }}
+        >
+          {isComplete ? "Complete" : "Volunteered"}
+        </span>
+        <span
+          className="ohx-display"
+          style={{
+            fontSize: "2.1rem",
+            fontWeight: 500,
+            color: brand,
+            lineHeight: 1.05,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {formatTime(elapsed)}
+        </span>
+        <span
+          style={{
+            fontSize: "0.78rem",
+            color: "var(--muted, #5B6270)",
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {isComplete ? "Goal reached 🎉" : `${formatTime(timeLeft)} left`}
+        </span>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/VolunteerStatsTable/VolunteerStatsTable.js
+++ b/src/components/VolunteerStatsTable/VolunteerStatsTable.js
@@ -1,78 +1,138 @@
 // components/VolunteerStatsTable/VolunteerStatsTable.js
+// Refined hairline table of volunteering entries, grouped by day. Uses CSS-var
+// fallbacks so it renders correctly inside <RefinedRoot> and on plain surfaces.
 import React from "react";
-import {
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from "@mui/material";
 import moment from "moment";
 
-const roundToOneDecimal = (number) => {
-  return isNaN(number) ? 0 : parseFloat(number.toFixed(2));
+const REASON_LABELS = {
+  mentoring: "Mentoring",
+  event_organization: "Event organization",
+  judging: "Judging",
+  coding: "Coding",
+  other: "Other",
+};
+
+const fmtHours = (n) =>
+  n === undefined || n === null || isNaN(n) ? null : parseFloat(Number(n).toFixed(2));
+
+const cellBase = {
+  padding: "10px 12px",
+  fontSize: "0.9rem",
+  borderBottom: "1px solid var(--line, #E7E1D4)",
+  verticalAlign: "middle",
 };
 
 const VolunteerStatsTable = ({ volunteerStats }) => {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  if (!volunteerStats || volunteerStats.length === 0) return null;
 
-  const groupedStats = volunteerStats.reduce((acc, stat) => {
+  // Newest day first; entries within a day newest first.
+  const grouped = volunteerStats.reduce((acc, stat) => {
     const date = moment.utc(stat.timestamp).format("YYYY-MM-DD");
-    if (!acc[date]) {
-      acc[date] = [];
-    }
-    acc[date].push(stat);
+    (acc[date] = acc[date] || []).push(stat);
     return acc;
   }, {});
+  const days = Object.keys(grouped).sort((a, b) => (a < b ? 1 : -1));
 
   return (
-    <TableContainer component={Paper} sx={{ mt: 2, overflowX: "auto" }}>
-      <Table aria-label="volunteer statistics table">
-        <TableHead>
-          <TableRow>
-            <TableCell>Date</TableCell>
-            <TableCell align="right">Committed Hours</TableCell>
-            <TableCell align="right">Actively Tracked Hours</TableCell>
-            <TableCell>Reason</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {Object.entries(groupedStats).map(([date, stats]) => (
-            <React.Fragment key={date}>
-              <TableRow>
-                <TableCell colSpan={4}>
-                  <Typography variant="subtitle1" fontWeight="bold">
-                    {moment(date).format("MMMM Do YYYY")}
-                  </Typography>
-                </TableCell>
-              </TableRow>
-              {stats.map((stat, index) => (
-                <TableRow key={`${date}-${index}`}>
-                  <TableCell>
-                    {moment
-                      .utc(stat.timestamp)
-                      .format(isMobile ? "HH:mm" : "h:mm:ss a")}
-                  </TableCell>
-                  <TableCell align="right">
-                    {roundToOneDecimal(stat.commitmentHours)}
-                  </TableCell>
-                  <TableCell align="right">
-                    {roundToOneDecimal(stat.finalHours)}
-                  </TableCell>
-                  <TableCell>{stat.reason}</TableCell>
-                </TableRow>
-              ))}
-            </React.Fragment>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <div
+      style={{
+        marginTop: 20,
+        border: "1px solid var(--line, #E7E1D4)",
+        borderRadius: 8,
+        overflowX: "auto",
+        background: "var(--surface, #fff)",
+      }}
+    >
+      <table
+        style={{ width: "100%", borderCollapse: "collapse", minWidth: 520 }}
+        aria-label="Volunteering history"
+      >
+        <thead>
+          <tr>
+            {["Time", "Committed", "Tracked", "Reason"].map((h, i) => (
+              <th
+                key={h}
+                style={{
+                  ...cellBase,
+                  textAlign: i === 1 || i === 2 ? "right" : "left",
+                  fontFamily: "var(--body, sans-serif)",
+                  fontSize: "0.72rem",
+                  fontWeight: 600,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.1em",
+                  color: "var(--muted, #5B6270)",
+                  background: "var(--surface-2, #F4F1E9)",
+                }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {days.map((date) => {
+            const entries = grouped[date]
+              .slice()
+              .sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
+            return (
+              <React.Fragment key={date}>
+                <tr>
+                  <td
+                    colSpan={4}
+                    style={{
+                      ...cellBase,
+                      fontFamily: "var(--display, serif)",
+                      fontSize: "0.95rem",
+                      fontWeight: 500,
+                      color: "var(--ink, #16181D)",
+                      background: "var(--surface-2, #F4F1E9)",
+                    }}
+                  >
+                    {moment(date).format("dddd, MMMM D, YYYY")}
+                  </td>
+                </tr>
+                {entries.map((stat, index) => {
+                  const committed = fmtHours(stat.commitmentHours);
+                  const tracked = fmtHours(stat.finalHours);
+                  return (
+                    <tr key={`${date}-${index}`}>
+                      <td style={{ ...cellBase, color: "var(--muted, #5B6270)", whiteSpace: "nowrap" }}>
+                        {moment.utc(stat.timestamp).local().format("h:mm a")}
+                        {stat.manual && (
+                          <span
+                            className="ohx-tag"
+                            style={{ marginLeft: 8, fontSize: "0.62rem", padding: "0.1em 0.5em" }}
+                          >
+                            manual
+                          </span>
+                        )}
+                      </td>
+                      <td style={{ ...cellBase, textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+                        {committed === null ? <span style={{ color: "var(--faint, #8A8F9A)" }}>—</span> : committed}
+                      </td>
+                      <td
+                        style={{
+                          ...cellBase,
+                          textAlign: "right",
+                          fontVariantNumeric: "tabular-nums",
+                          fontWeight: tracked !== null ? 600 : 400,
+                          color: tracked !== null ? "var(--brand, #1B3A6B)" : "var(--faint, #8A8F9A)",
+                        }}
+                      >
+                        {tracked === null ? "—" : tracked}
+                      </td>
+                      <td style={{ ...cellBase, color: "var(--ink, #16181D)" }}>
+                        {REASON_LABELS[stat.reason] || stat.reason || "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </React.Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 };
 

--- a/src/pages/volunteer/track.js
+++ b/src/pages/volunteer/track.js
@@ -1,26 +1,8 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import Head from "next/head";
 import Link from "next/link";
-import {
-  Button,
-  TextField,
-  Typography,
-  Box,
-  Select,
-  MenuItem,
-  FormControl,
-  InputLabel,
-  Grid,
-  Paper,
-  useTheme,
-  useMediaQuery,
-  Alert,
-  Snackbar,
-  CircularProgress,
-} from "@mui/material";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
-import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import dynamic from "next/dynamic";
+import moment from "moment";
 import {
   BarChart,
   Bar,
@@ -28,39 +10,74 @@ import {
   YAxis,
   Tooltip,
   Legend,
+  CartesianGrid,
   ResponsiveContainer,
 } from "recharts";
+import { withAuthInfo } from "@propelauth/react";
 import FunVolunteerTimer from "../../components/FunVolunteerTimer/FunVolunteerTimer";
 import VolunteerStatsTable from "../../components/VolunteerStatsTable/VolunteerStatsTable";
-import moment from "moment";
-import { withAuthInfo } from "@propelauth/react";
-import dynamic from "next/dynamic";
-import { styled } from "@mui/material";
+import { RefinedRoot, Eyebrow, Stat, Arrow } from "../../components/design/refined";
 import { initFacebookPixel, trackEvent } from "../../lib/ga";
 
-// Dynamic imports with loading state
-const Confetti = dynamic(() => import("react-confetti"), {
-  ssr: false,
-  loading: () => null,
-});
-
+const Confetti = dynamic(() => import("react-confetti"), { ssr: false, loading: () => null });
 const LoginOrRegister = dynamic(
   () => import("../../components/LoginOrRegister/LoginOrRegister2"),
   { ssr: false }
 );
 
-export const StyledLink = styled(Link)({
-  textDecoration: "none",
-  color: "#0000ff",
-  transitionDuration: "0.3s",
-  "&:hover": {
-    color: "orange",
-  },
-});
+const SESSION_KEY = "volunteeringSession";
+const LEGACY_KEY = "volunteeringState";
 
-const roundToOneDecimal = (number) => {
-  return isNaN(number) ? 0 : parseFloat(number.toFixed(2));
+const REASON_OPTIONS = [
+  { value: "mentoring", label: "Mentoring" },
+  { value: "event_organization", label: "Event organization" },
+  { value: "judging", label: "Judging" },
+  { value: "coding", label: "Coding (we also track this via GitHub commits)" },
+  { value: "other", label: "Other" },
+];
+
+const COMMITMENT_OPTIONS = Array.from({ length: 49 }, (_, i) => i * 0.5 + 0.5);
+
+const round2 = (n) => (isNaN(n) ? 0 : parseFloat(Number(n).toFixed(2)));
+
+const toYMD = (dt) => {
+  const y = dt.getFullYear();
+  const m = String(dt.getMonth() + 1).padStart(2, "0");
+  const d = String(dt.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 };
+
+// Refined native form-control styles (avoid MUI's blue inside the calm scope).
+const fieldStyle = {
+  width: "100%",
+  padding: "0.7em 0.85em",
+  fontSize: "1rem",
+  fontFamily: "var(--body)",
+  color: "var(--ink)",
+  background: "var(--surface)",
+  border: "1px solid var(--line)",
+  borderRadius: 6,
+  outline: "none",
+  boxSizing: "border-box",
+};
+const labelStyle = {
+  display: "block",
+  fontSize: "0.72rem",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.1em",
+  color: "var(--muted)",
+  marginBottom: 6,
+};
+
+const PHOTOS = [
+  "https://cdn.ohack.dev/ohack.dev/2023_hackathon_1.webp",
+  "https://cdn.ohack.dev/ohack.dev/2023_hackathon_2.webp",
+  "https://cdn.ohack.dev/ohack.dev/2023_hackathon_3.webp",
+  "https://cdn.ohack.dev/ohack.dev/2023_hackathon_4.webp",
+  "https://cdn.ohack.dev/ohack.dev/icon-of-hearts-surrounding-a-technological-cyberpunk-heart-supernova-in-space-.jpeg",
+  "https://cdn.ohack.dev/ohack.dev/definition-of-done-65b90f271348b.webp",
+];
 
 export async function getStaticProps() {
   return {
@@ -77,283 +94,264 @@ export async function getStaticProps() {
 }
 
 const VolunteerTrackingPage = withAuthInfo(
-  ({
-    user,
-    isLoggedIn,
-    accessToken,
-    metaTitle,
-    metaDescription,
-    metaKeywords,
-    ogImage,
-    canonicalUrl,
-  }) => {
-    const theme = useTheme();
-    const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  ({ isLoggedIn, accessToken, metaTitle, metaDescription, metaKeywords, ogImage, canonicalUrl }) => {
+    // --- Live session (wall-clock based; persisted so it survives refresh) ---
+    const [session, setSession] = useState(null); // { startEpoch, commitmentHours, reason }
+    const [nowTs, setNowTs] = useState(() => Date.now());
+    const endingRef = useRef(false);
 
-    const [commitmentHours, setCommitmentHours] = useState(0.5);
-    const [reason, setReason] = useState("");
-    const [isVolunteering, setIsVolunteering] = useState(false);
-    const [timeLeft, setTimeLeft] = useState(0);
-    const [totalTime, setTotalTime] = useState(0);
+    // --- Start-a-session form ---
+    const [commitmentHours, setCommitmentHours] = useState(3);
+    const [reason, setReason] = useState("mentoring");
+
+    // --- Manual log form ---
+    const [manualDate, setManualDate] = useState(() => toYMD(new Date()));
+    const [manualHours, setManualHours] = useState(1);
+    const [manualReason, setManualReason] = useState("mentoring");
+
+    // --- Stats ---
     const [totalActiveHours, setTotalActiveHours] = useState(0);
-    const [totalCommittmentHours, setTotalCommittmentHours] = useState(0);
-    const [startDate, setStartDate] = useState(() => {
-      const lastMonth = new Date();
-      lastMonth.setMonth(lastMonth.getMonth() - 6);
-      return lastMonth;
-    });
-    const [endDate, setEndDate] = useState(new Date());
-    const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0);
-    const [showConfetti, setShowConfetti] = useState(false);
+    const [totalCommitmentHours, setTotalCommitmentHours] = useState(0);
     const [volunteerStats, setVolunteerStats] = useState([]);
-    
-    // New state variables for better UX
-    const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState("");
-    const [showNotification, setShowNotification] = useState(false);
-    const [notificationMessage, setNotificationMessage] = useState("");
-    const [notificationSeverity, setNotificationSeverity] = useState("success");
+    const [startDate, setStartDate] = useState(() => {
+      const d = new Date();
+      d.setMonth(d.getMonth() - 6);
+      return toYMD(d);
+    });
+    const [endDate, setEndDate] = useState(() => toYMD(new Date()));
 
-    const photos = [
-      "https://cdn.ohack.dev/ohack.dev/2023_hackathon_1.webp",
-      "https://cdn.ohack.dev/ohack.dev/2023_hackathon_2.webp",
-      "https://cdn.ohack.dev/ohack.dev/2023_hackathon_3.webp",
-      "https://cdn.ohack.dev/ohack.dev/2023_hackathon_4.webp",
-      "https://cdn.ohack.dev/ohack.dev/404/sleeping1.webp",
-      "https://cdn.ohack.dev/ohack.dev/404/sleeping2.webp",
-      "https://cdn.ohack.dev/ohack.dev/404/sleeping3.webp",
-      "https://cdn.ohack.dev/ohack.dev/icon-of-hearts-surrounding-a-technological-cyberpunk-heart-supernova-in-space-.jpeg",
-      "https://cdn.ohack.dev/ohack.dev/definition-of-done-65b90f271348b.webp",
-    ];
+    // --- UI state ---
+    const [statsLoading, setStatsLoading] = useState(false);
+    const [actionLoading, setActionLoading] = useState(false);
+    const [loadError, setLoadError] = useState("");
+    const [showConfetti, setShowConfetti] = useState(false);
+    const [photoIndex, setPhotoIndex] = useState(0);
+    const [toast, setToast] = useState(null); // { message, severity }
 
-    // Display notification helper
-    const showNotify = useCallback((message, severity = "success") => {
-      setNotificationMessage(message);
-      setNotificationSeverity(severity);
-      setShowNotification(true);
+    const isVolunteering = Boolean(session);
+    const totalSeconds = (session?.commitmentHours || 0) * 3600;
+    const rawElapsed = session ? Math.floor((nowTs - session.startEpoch) / 1000) : 0;
+    const elapsed = Math.min(totalSeconds, Math.max(0, rawElapsed));
+    const timeLeft = Math.max(0, totalSeconds - elapsed);
+
+    const notify = useCallback((message, severity = "success") => {
+      setToast({ message, severity });
     }, []);
-
-    // Memoized fetch function to reduce rerenders
-    const fetchtotalActiveHours = useCallback(async () => {
-      if (!isLoggedIn || !accessToken) return;
-      
-      setIsLoading(true);
-      setError("");
-      
-      try {
-        const response = await fetch(
-          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/users/volunteering?startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`,
-          {
-            method: "GET",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${accessToken}`,
-            },
-          }
-        );
-        
-        if (!response.ok) {
-          throw new Error(`Server responded with status: ${response.status}`);
-        }
-        
-        const data = await response.json();
-        setTotalActiveHours(data.totalActiveHours);
-        setTotalCommittmentHours(data.totalCommitmentHours);
-        setVolunteerStats(data.allVolunteering || []);
-      } catch (error) {
-        console.error("Error fetching total hours: ", error);
-        setError("Failed to load your volunteer data. Please try again later.");
-        showNotify("Failed to load your volunteer data.", "error");
-      } finally {
-        setIsLoading(false);
-      }
-    }, [isLoggedIn, accessToken, startDate, endDate, showNotify]);
-
-    useEffect(() => {
-      initFacebookPixel();
-      if (isLoggedIn) {
-        fetchtotalActiveHours();
-        loadVolunteeringState();
-      }
-    }, [isLoggedIn, fetchtotalActiveHours]);
-
-    useEffect(() => {
-      let timer;
-      if (isVolunteering && timeLeft > 0) {
-        timer = setTimeout(() => {
-          setTimeLeft((prevTime) => {
-            const newTime = prevTime - 1;
-            saveVolunteeringState(newTime);
-            if (newTime > 0 && (totalTime - newTime) % 1795 === 0) {
-              triggerConfetti();
-            }
-            return newTime;
-          });
-        }, 1000);
-      } else if (timeLeft === 0 && isVolunteering) {
-        endVolunteering();
-      }
-      return () => clearTimeout(timer);
-    }, [isVolunteering, timeLeft, totalTime]);
-
-    useEffect(() => {
-      let photoTimer;
-      if (isVolunteering) {
-        photoTimer = setInterval(() => {
-          setCurrentPhotoIndex((prevIndex) => (prevIndex + 1) % photos.length);
-        }, 60000);
-      }
-      return () => clearInterval(photoTimer);
-    }, [isVolunteering, photos.length]);
 
     const triggerConfetti = () => {
       setShowConfetti(true);
       setTimeout(() => setShowConfetti(false), 5000);
     };
 
-    const loadVolunteeringState = () => {
+    // --- Data fetch ---
+    const fetchVolunteerData = useCallback(async (rangeStart, rangeEnd) => {
+      if (!isLoggedIn || !accessToken) return;
+      const from = typeof rangeStart === "string" ? rangeStart : startDate;
+      const to = typeof rangeEnd === "string" ? rangeEnd : endDate;
+      setStatsLoading(true);
+      setLoadError("");
       try {
-        const savedState = JSON.parse(localStorage.getItem("volunteeringState"));
-        if (savedState) {
-          setIsVolunteering(savedState.isVolunteering);
-          setTimeLeft(savedState.timeLeft);
-          setTotalTime(savedState.totalTime);
-          setCommitmentHours(savedState.commitmentHours);
-          setReason(savedState.reason);
-        }
-      } catch (error) {
-        console.error("Error loading volunteering state:", error);
-        localStorage.removeItem("volunteeringState");
+        const startISO = new Date(`${from}T00:00:00`).toISOString();
+        const endISO = new Date(`${to}T23:59:59.999`).toISOString();
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/users/volunteering?startDate=${startISO}&endDate=${endISO}`,
+          { headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` } }
+        );
+        if (!res.ok) throw new Error(`Server responded with ${res.status}`);
+        const data = await res.json();
+        setTotalActiveHours(data.totalActiveHours || 0);
+        setTotalCommitmentHours(data.totalCommitmentHours || 0);
+        setVolunteerStats(data.allVolunteering || []);
+      } catch (err) {
+        console.error("Error fetching volunteer data:", err);
+        setLoadError("We couldn't load your volunteer data just now. Please try again.");
+      } finally {
+        setStatsLoading(false);
       }
-    };
+    }, [isLoggedIn, accessToken, startDate, endDate]);
 
-    const saveVolunteeringState = (currentTimeLeft) => {
-      try {
-        const stateToSave = {
-          isVolunteering,
-          timeLeft: currentTimeLeft,
-          totalTime,
-          commitmentHours,
-          reason,
+    // --- Init: pixel, fonts, restore session, initial fetch (once) ---
+    useEffect(() => {
+      initFacebookPixel();
+      // Inject the refined webfonts directly. This page is wrapped in
+      // withAuthInfo (client-rendered), where next/head silently drops the
+      // external Google Fonts <link>s — so we append them ourselves, once.
+      if (typeof document !== "undefined" && !document.getElementById("ohx-refined-fonts")) {
+        const mk = (attrs) => {
+          const l = document.createElement("link");
+          Object.entries(attrs).forEach(([k, v]) => l.setAttribute(k, v));
+          document.head.appendChild(l);
         };
-        localStorage.setItem("volunteeringState", JSON.stringify(stateToSave));
-      } catch (error) {
-        console.error("Error saving volunteering state:", error);
-        showNotify("Failed to save your session state.", "warning");
+        mk({ rel: "preconnect", href: "https://fonts.googleapis.com" });
+        mk({ rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "anonymous" });
+        mk({
+          id: "ohx-refined-fonts",
+          rel: "stylesheet",
+          href: "https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400&family=Hanken+Grotesk:wght@400;500;600;700&display=swap",
+        });
       }
-    };
+    }, []);
 
-    const handleCloseNotification = (_, reason) => {
-      if (reason === 'clickaway') return;
-      setShowNotification(false);
-    };
+    const didInit = useRef(false);
+    useEffect(() => {
+      if (!isLoggedIn || !accessToken || didInit.current) return;
+      didInit.current = true;
+      // Restore an in-progress session (wall-clock, so elapsed is recomputed).
+      try {
+        localStorage.removeItem(LEGACY_KEY);
+        const saved = JSON.parse(localStorage.getItem(SESSION_KEY));
+        if (saved && saved.startEpoch && saved.commitmentHours) {
+          endingRef.current = false;
+          setSession(saved);
+        }
+      } catch {
+        localStorage.removeItem(SESSION_KEY);
+      }
+      fetchVolunteerData();
+    }, [isLoggedIn, accessToken, fetchVolunteerData]);
+
+    // --- 1s tick while volunteering (wall-clock; accurate across bg tabs) ---
+    useEffect(() => {
+      if (!isVolunteering) return undefined;
+      const id = setInterval(() => setNowTs(Date.now()), 1000);
+      return () => clearInterval(id);
+    }, [isVolunteering]);
+
+    // --- Rotate the encouragement photo during a session ---
+    useEffect(() => {
+      if (!isVolunteering) return undefined;
+      const id = setInterval(() => setPhotoIndex((i) => (i + 1) % PHOTOS.length), 60000);
+      return () => clearInterval(id);
+    }, [isVolunteering]);
+
+    const endVolunteering = useCallback(async () => {
+      if (!session || endingRef.current) return;
+      endingRef.current = true;
+      setActionLoading(true);
+      const sec = Math.min(
+        session.commitmentHours * 3600,
+        Math.max(0, Math.floor((Date.now() - session.startEpoch) / 1000))
+      );
+      const finalHours = round2(sec / 3600);
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/users/volunteering`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+          body: JSON.stringify({ finalHours, reason: session.reason }),
+        });
+        if (!res.ok) throw new Error(`Server responded with ${res.status}`);
+        trackEvent("volunteering_end", { finalHours, reason: session.reason });
+        localStorage.removeItem(SESSION_KEY);
+        setSession(null);
+        triggerConfetti();
+        notify(`Logged ${finalHours} ${finalHours === 1 ? "hour" : "hours"} — thank you!`);
+        await fetchVolunteerData();
+      } catch (err) {
+        console.error("Error ending session:", err);
+        endingRef.current = false; // allow retry
+        notify("Couldn't save your session. Please try ending again.", "error");
+      } finally {
+        setActionLoading(false);
+      }
+    }, [session, accessToken, fetchVolunteerData, notify]);
+
+    // --- Auto-finalize when the committed time is reached ---
+    useEffect(() => {
+      if (isVolunteering && timeLeft <= 0 && !endingRef.current) {
+        endVolunteering();
+      }
+    }, [isVolunteering, timeLeft, endVolunteering]);
 
     const startVolunteering = async () => {
       if (!reason) {
-        showNotify("Please select a reason for volunteering", "error");
+        notify("Please pick a reason for volunteering.", "error");
         return;
       }
-
-      setIsLoading(true);
-      const totalSeconds = commitmentHours * 3600;
-      
+      setActionLoading(true);
       try {
-        const response = await fetch(
-          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/users/volunteering`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${accessToken}`,
-            },
-            body: JSON.stringify({
-              commitmentHours: commitmentHours,
-              reason: reason,
-            }),
-          }
-        );
-        
-        if (!response.ok) {
-          throw new Error(`Server responded with status: ${response.status}`);
-        }
-
-        setIsVolunteering(true);
-        setTimeLeft(totalSeconds);
-        setTotalTime(totalSeconds);
-        saveVolunteeringState(totalSeconds);
-
-        trackEvent("volunteering_start", {
-          commitmentHours: commitmentHours,
-          reason: reason,
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/users/volunteering`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+          body: JSON.stringify({ commitmentHours, reason }),
         });
-        
-        showNotify("Volunteering session started successfully!");
-      } catch (error) {
-        console.error("Error starting volunteering session:", error);
-        showNotify("Failed to start volunteering session. Please try again.", "error");
+        if (!res.ok) throw new Error(`Server responded with ${res.status}`);
+        const newSession = { startEpoch: Date.now(), commitmentHours, reason };
+        endingRef.current = false;
+        localStorage.setItem(SESSION_KEY, JSON.stringify(newSession));
+        setNowTs(Date.now());
+        setSession(newSession);
+        trackEvent("volunteering_start", { commitmentHours, reason });
+        notify("Your volunteering session has started. Go make an impact!");
+        await fetchVolunteerData();
+      } catch (err) {
+        console.error("Error starting session:", err);
+        notify("Couldn't start your session. Please try again.", "error");
       } finally {
-        setIsLoading(false);
+        setActionLoading(false);
       }
     };
 
-    const endVolunteering = async () => {
-      setIsLoading(true);
-      
+    const logManualTime = async () => {
+      const hours = Number(manualHours);
+      if (!hours || hours <= 0) {
+        notify("Enter how many hours you volunteered.", "error");
+        return;
+      }
+      if (!manualReason) {
+        notify("Pick a reason for the time you're logging.", "error");
+        return;
+      }
+      const when = new Date(`${manualDate}T12:00:00`);
+      if (isNaN(when.getTime())) {
+        notify("That date doesn't look right.", "error");
+        return;
+      }
+      if (when.getTime() > Date.now() + 24 * 3600 * 1000) {
+        notify("You can't log time in the future.", "error");
+        return;
+      }
+      setActionLoading(true);
       try {
-        const response = await fetch(
-          `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/users/volunteering`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${accessToken}`,
-            },
-            body: JSON.stringify({
-              finalHours: (totalTime - timeLeft) / 3600,
-              reason: reason,
-            }),
-          }
-        );
-        
-        if (!response.ok) {
-          throw new Error(`Server responded with status: ${response.status}`);
-        }
-
-        setIsVolunteering(false);
-        trackEvent("volunteering_end", {
-          finalHours: (totalTime - timeLeft) / 3600,
-          reason: reason,
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/users/volunteering`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+          body: JSON.stringify({
+            commitmentHours: hours,
+            finalHours: hours,
+            reason: manualReason,
+            manual: true,
+            timestamp: when.toISOString(),
+          }),
         });
-
-        localStorage.removeItem("volunteeringState");
-        await fetchtotalActiveHours();
-        showNotify("Volunteering session ended successfully!");
-      } catch (error) {
-        console.error("Error ending volunteering session:", error);
-        showNotify("Failed to end volunteering session. Please try again.", "error");
+        if (!res.ok) throw new Error(`Server responded with ${res.status}`);
+        trackEvent("volunteering_manual_log", { hours, reason: manualReason });
+        notify(`Logged ${round2(hours)} ${hours === 1 ? "hour" : "hours"} for ${moment(manualDate).format("MMM D")}.`);
+        // Make sure the new entry is in the visible range, then refresh with the
+        // widened range explicitly (state updates are async this tick).
+        const newStart = manualDate < startDate ? manualDate : startDate;
+        const newEnd = manualDate > endDate ? manualDate : endDate;
+        if (newStart !== startDate) setStartDate(newStart);
+        if (newEnd !== endDate) setEndDate(newEnd);
+        await fetchVolunteerData(newStart, newEnd);
+      } catch (err) {
+        console.error("Error logging manual time:", err);
+        notify("Couldn't log that time. Please try again.", "error");
       } finally {
-        setIsLoading(false);
+        setActionLoading(false);
       }
     };
 
-    const prepareChartData = () => {
-      return volunteerStats.map((stat) => ({
-        date: moment.utc(stat.timestamp).format("MM/DD/YY"),
-        Committed: roundToOneDecimal(stat.commitmentHours),
-        "Actively Tracked": roundToOneDecimal(stat.finalHours),
+    const chartData = volunteerStats
+      .slice()
+      .sort((a, b) => (a.timestamp < b.timestamp ? -1 : 1))
+      .map((s) => ({
+        label: moment.utc(s.timestamp).local().format("MMM D"),
+        Committed: round2(s.commitmentHours || 0),
+        Tracked: round2(s.finalHours || 0),
       }));
-    };
 
     return (
-      <Box
-        sx={{
-          width: "100%",
-          maxWidth: 800,
-          margin: "auto",
-          mt: { xs: 10, sm: 10 },
-          p: { xs: 1, sm: 2 },
-        }}
-      >
+      <>
         <Head>
           <title>{metaTitle}</title>
           <meta name="description" content={metaDescription} />
@@ -376,286 +374,405 @@ const VolunteerTrackingPage = withAuthInfo(
               __html: JSON.stringify({
                 "@context": "https://schema.org",
                 "@type": "SoftwareApplication",
-                "name": "Volunteer Tracking Platform",
-                "description": metaDescription,
-                "url": canonicalUrl,
-                "applicationCategory": "VolunteerManagement",
-                "operatingSystem": "Web",
-                "offers": {
-                  "@type": "Offer",
-                  "price": "0",
-                  "priceCurrency": "USD"
-                },
-                "provider": {
-                  "@type": "Organization",
-                  "name": "Opportunity Hack"
-                }
-              })
+                name: "Volunteer Tracking Platform",
+                description: metaDescription,
+                url: canonicalUrl,
+                applicationCategory: "VolunteerManagement",
+                operatingSystem: "Web",
+                offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+                provider: { "@type": "Organization", name: "Opportunity Hack" },
+              }),
             }}
           />
         </Head>
 
-        {showConfetti && <Confetti />}
-        <Typography variant="h1" sx={{ fontSize: { xs: '2rem', sm: '2.5rem' } }} gutterBottom align="center">
-          Volunteer Tracking & Time Management
-        </Typography>
+        {showConfetti && <Confetti recycle={false} numberOfPieces={220} />}
 
-        <Paper elevation={3} sx={{ p: { xs: 1, sm: 2 }, mb: 2 }}>
-          <Typography variant="h2" sx={{ fontSize: { xs: '1.5rem', sm: '1.75rem' } }} gutterBottom>
-            Professional Volunteer Tracking Platform
-          </Typography>
-          <Typography variant="body1" paragraph>
-            Our volunteer tracking system helps you efficiently manage and record your volunteer hours.
-            Whether you're tracking community service for nonprofits, managing volunteer schedules, 
-            or measuring social impact, our platform provides comprehensive volunteer time management tools.
-          </Typography>
-          <Typography variant="h3" sx={{ fontSize: { xs: '1.25rem', sm: '1.5rem' } }} gutterBottom>
-            Why Track Volunteer Hours?
-          </Typography>
-          <ul>
-            <li><strong>Impact Measurement:</strong> Quantify your contributions to community service and social causes</li>
-            <li><strong>Professional Recognition:</strong> Build a verified record of your volunteer work for resumes and applications</li>
-            <li><strong>Nonprofit Support:</strong> Help organizations track volunteer engagement and program effectiveness</li>
-            <li><strong>Personal Growth:</strong> Monitor your volunteer journey and celebrate milestones</li>
-          </ul>
-          <Typography variant="body1" paragraph>
-            For coding contributions, we also track time through GitHub commits.
-            Learn more about our{" "}
-            <StyledLink href="/cert">
-              volunteer certification process
-            </StyledLink>
-            .
-          </Typography>
-          <Typography variant="body1" paragraph>
-            This volunteer tracking platform is open-source and available on GitHub. 
-            Contribute to improving volunteer management tools by checking out the{" "}
-            <StyledLink href="https://github.com/opportunity-hack/frontend-ohack.dev/blob/main/src/pages/volunteer/track.js">
-              source code
-            </StyledLink>
-            .
-          </Typography>
-        </Paper>
-
-        {!isLoggedIn ? (
-          <Paper elevation={3} sx={{ p: { xs: 1, sm: 2 }, mb: 2 }}>
-            <Typography variant="body1" paragraph align="center">
-              Please log in to access the volunteer time tracking feature.
-            </Typography>
-            <LoginOrRegister
-              introText="Ready to track your volunteer hours?"
-              previousPage="/volunteer/track"
-            />
-          </Paper>
-        ) : (
-          <>
-            <Paper elevation={3} sx={{ p: { xs: 1, sm: 2 }, mb: 2 }}>
-              <Grid container spacing={2} alignItems="center">
-                <Grid size={{ xs: 12 }}>
-                  <FormControl fullWidth error={isVolunteering && !commitmentHours}>
-                    <InputLabel id="commitment-hours-label">Commitment Hours</InputLabel>
-                    <Select
-                      labelId="commitment-hours-label"
-                      value={commitmentHours}
-                      onChange={(e) =>
-                        setCommitmentHours(Number(e.target.value))
-                      }
-                      disabled={isVolunteering || isLoading}
-                      label="Commitment Hours"
-                    >
-                      {Array.from({ length: 49 }, (_, i) => i * 0.5 + 0.5).map(
-                        (hours) => (
-                          <MenuItem key={hours} value={hours}>
-                            {hours} hours
-                          </MenuItem>
-                        )
-                      )}
-                    </Select>
-                  </FormControl>
-                </Grid>
-                <Grid size={{ xs: 12 }}>
-                  <FormControl fullWidth error={isVolunteering && !reason}>
-                    <InputLabel id="reason-label">Reason for Volunteering</InputLabel>
-                    <Select
-                      labelId="reason-label"
-                      value={reason}
-                      onChange={(e) => setReason(e.target.value)}
-                      disabled={isVolunteering || isLoading}
-                      label="Reason for Volunteering"
-                    >
-                      <MenuItem value="mentoring">Mentoring</MenuItem>
-                      <MenuItem value="event_organization">
-                        Event Organization
-                      </MenuItem>
-                      <MenuItem value="judging">Judging</MenuItem>
-                      <MenuItem value="coding">
-                        Coding (we track this with GitHub commits too)
-                      </MenuItem>
-                      <MenuItem value="other">Other</MenuItem>
-                    </Select>
-                  </FormControl>
-                </Grid>
-                <Grid size={{ xs: 12 }}>
-                  <Button
-                    variant="contained"
-                    color={isVolunteering ? "secondary" : "primary"}
-                    onClick={
-                      isVolunteering ? endVolunteering : startVolunteering
-                    }
-                    fullWidth
-                    disabled={isLoading}
-                    aria-label={isVolunteering ? "End volunteering session" : "Start volunteering session"}
-                  >
-                    {isLoading ? (
-                      <CircularProgress size={24} color="inherit" />
-                    ) : isVolunteering ? (
-                      "End Volunteering"
-                    ) : (
-                      "Start Volunteering"
-                    )}
-                  </Button>
-                </Grid>
-              </Grid>
-            </Paper>
-
-            {isVolunteering && (
-              <Paper elevation={3} sx={{ p: { xs: 1, sm: 2 }, mb: 2 }}>
-                <Typography variant="h6" gutterBottom align="center">
-                  Current Session
-                </Typography>
-                <FunVolunteerTimer timeLeft={timeLeft} totalTime={totalTime} />
-                <Box sx={{ mt: 2, textAlign: "center" }}>
-                  <img
-                    src={photos[currentPhotoIndex]}
-                    alt="Opportunity Hack"
-                    style={{
-                      maxWidth: "100%",
-                      maxHeight: "200px",
-                      objectFit: "cover",
-                    }}
-                  />
-                </Box>
-              </Paper>
-            )}
-
-            <Paper elevation={3} sx={{ p: { xs: 1, sm: 2 } }}>
-              <Typography variant="h6" gutterBottom>
-                Volunteering Statistics
-              </Typography>
-              <Typography variant="body1" paragraph>
-                Total Hours Committed:{" "}
-                {roundToOneDecimal(totalCommittmentHours)}
-              </Typography>
-              <Typography variant="body1" paragraph>
-                Total Hours Actively Tracked:{" "}
-                {roundToOneDecimal(totalActiveHours)}
-              </Typography>
-
-              <LocalizationProvider dateAdapter={AdapterDateFns}>
-                <Grid container spacing={2} alignItems="center">
-                  <Grid size={{ xs: 12, sm: 5 }}>
-                    <DatePicker
-                      label="Start Date"
-                      value={startDate}
-                      onChange={(newValue) => setStartDate(newValue)}
-                      slotProps={{ textField: { fullWidth: true } }}
-                    />
-                  </Grid>
-                  <Grid size={{ xs: 12, sm: 5 }}>
-                    <DatePicker
-                      label="End Date"
-                      value={endDate}
-                      onChange={(newValue) => setEndDate(newValue)}
-                      slotProps={{ textField: { fullWidth: true } }}
-                    />
-                  </Grid>
-                  <Grid size={{ xs: 12, sm: 2 }}>
-                    <Button
-                      variant="outlined"
-                      onClick={fetchtotalActiveHours}
-                      fullWidth
-                      disabled={isLoading}
-                      aria-label="Fetch volunteer report"
-                    >
-                      {isLoading ? (
-                        <CircularProgress size={24} color="inherit" />
-                      ) : (
-                        "Fetch Report"
-                      )}
-                    </Button>
-                  </Grid>
-                </Grid>
-              </LocalizationProvider>
-
-              {error && (
-                <Alert severity="error" sx={{ mt: 2 }}>
-                  {error}
-                </Alert>
-              )}
-
-              {/* Stacked Bar Chart */}
-              {volunteerStats.length > 0 ? (
-                <Box sx={{ height: 300, mt: 2 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={prepareChartData()}
-                      margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
-                    >
-                      <XAxis dataKey="date" />
-                      <YAxis />
-                      <Tooltip />
-                      <Legend />
-                      <Bar dataKey="Committed" stackId="a" fill="#8884d8" />
-                      <Bar
-                        dataKey="Actively Tracked"
-                        stackId="a"
-                        fill="#82ca9d"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </Box>
-              ) : (
-                !isLoading && (
-                  <Alert severity="info" sx={{ mt: 2 }}>
-                    No volunteering data available for the selected date range.
-                  </Alert>
-                )
-              )}
-
-              {/* Explanation */}
-              {volunteerStats.length > 0 && (
-                <Typography variant="body2" sx={{ mt: 2, fontStyle: "italic" }}>
-                  The chart above shows your committed hours (purple) and actively
-                  tracked hours (green) for each volunteering session. Committed
-                  hours represent your intended volunteer time, while actively
-                  tracked hours show the time you spent with the browser window
-                  open.
-                </Typography>
-              )}
-
-              {/* Use the new VolunteerStatsTable component */}
-              <VolunteerStatsTable volunteerStats={volunteerStats} />
-            </Paper>
-          </>
-        )}
-
-        {/* Notification system */}
-        <Snackbar 
-          open={showNotification} 
-          autoHideDuration={6000} 
-          onClose={handleCloseNotification}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        >
-          <Alert 
-            onClose={handleCloseNotification} 
-            severity={notificationSeverity} 
-            sx={{ width: '100%' }}
+        <RefinedRoot>
+          {/* HERO */}
+          <section
+            className="ohx-wrap ohx-narrow"
+            style={{ paddingTop: "clamp(104px, 13vh, 150px)", paddingBottom: "clamp(20px, 4vh, 36px)" }}
           >
-            {notificationMessage}
-          </Alert>
-        </Snackbar>
-      </Box>
+            <Eyebrow>
+              <span className="rise" style={{ display: "inline-block" }}>Volunteer tracking</span>
+            </Eyebrow>
+            <h1 className="ohx-display rise" style={{ marginTop: 16, animationDelay: "60ms" }}>
+              Track your time <span className="ohx-italic">for good.</span>
+            </h1>
+            <p className="ohx-lead rise" style={{ marginTop: 20, animationDelay: "150ms", maxWidth: "58ch" }}>
+              Record the hours you commit and the time you actually volunteer with Opportunity Hack —
+              build a verified record for school, work, and your own milestones.
+            </p>
+            {isLoggedIn && (
+              <>
+                <hr className="ohx-rule rise" style={{ marginTop: 36, animationDelay: "280ms" }} />
+                <div
+                  className="rise"
+                  style={{ marginTop: 24, display: "flex", flexWrap: "wrap", gap: "clamp(28px, 6vw, 72px)", animationDelay: "340ms" }}
+                >
+                  <Stat value={`${round2(totalCommitmentHours)}h`} label="Committed (range)" />
+                  <Stat value={`${round2(totalActiveHours)}h`} label="Tracked (range)" />
+                </div>
+              </>
+            )}
+          </section>
+
+          {!isLoggedIn ? (
+            <section className="ohx-wrap ohx-narrow" style={{ paddingBottom: "clamp(48px, 8vh, 96px)" }}>
+              <div className="ohx-card" style={{ padding: "clamp(24px, 4vw, 40px)" }}>
+                <h2 className="ohx-display" style={{ fontSize: "1.4rem", marginBottom: 6 }}>Log in to track your hours</h2>
+                <p className="ohx-muted" style={{ marginTop: 0, marginBottom: 20 }}>
+                  Sign in with Slack or Google to start a session and see your volunteering history.
+                </p>
+                <LoginOrRegister introText="Ready to track your volunteer hours?" previousPage="/volunteer/track" />
+              </div>
+            </section>
+          ) : (
+            <>
+              {/* LIVE SESSION */}
+              {isVolunteering && (
+                <section className="ohx-wrap ohx-narrow" style={{ paddingBottom: "clamp(20px, 4vh, 36px)" }}>
+                  <div
+                    className="ohx-card"
+                    style={{ padding: "clamp(24px, 4vw, 40px)", textAlign: "center", borderColor: "var(--brand)" }}
+                  >
+                    <Eyebrow>Session in progress</Eyebrow>
+                    <p className="ohx-muted" style={{ marginTop: 6, marginBottom: 4 }}>
+                      {round2(session.commitmentHours)}h committed ·{" "}
+                      {REASON_OPTIONS.find((r) => r.value === session.reason)?.label || session.reason}
+                    </p>
+                    <FunVolunteerTimer timeLeft={timeLeft} totalTime={totalSeconds} />
+                    <div style={{ marginTop: 20 }}>
+                      <button
+                        type="button"
+                        className="ohx-btn ohx-btn--primary"
+                        onClick={endVolunteering}
+                        disabled={actionLoading}
+                        aria-label="End volunteering session"
+                        style={{ opacity: actionLoading ? 0.7 : 1 }}
+                      >
+                        {actionLoading ? "Saving…" : "End & log this session"}
+                      </button>
+                    </div>
+                    <div
+                      style={{
+                        marginTop: 24,
+                        position: "relative",
+                        width: "100%",
+                        maxWidth: 360,
+                        aspectRatio: "16 / 10",
+                        margin: "24px auto 0",
+                        borderRadius: 8,
+                        overflow: "hidden",
+                        border: "1px solid var(--line)",
+                      }}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={PHOTOS[photoIndex]}
+                        alt="Opportunity Hack volunteers"
+                        width="360"
+                        height="225"
+                        style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                      />
+                    </div>
+                  </div>
+                </section>
+              )}
+
+              {/* START + MANUAL LOG (hidden during a live session) */}
+              {!isVolunteering && (
+                <section className="ohx-wrap ohx-narrow" style={{ paddingBottom: "clamp(20px, 4vh, 36px)" }}>
+                  <div
+                    style={{
+                      display: "grid",
+                      gap: 20,
+                      gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+                    }}
+                  >
+                    {/* Start a live session */}
+                    <div className="ohx-card" style={{ padding: "clamp(20px, 3vw, 28px)" }}>
+                      <h2 className="ohx-display" style={{ fontSize: "1.25rem", marginTop: 0, marginBottom: 4 }}>
+                        Start a live session
+                      </h2>
+                      <p className="ohx-faint" style={{ marginTop: 0, marginBottom: 18, fontSize: "0.85rem" }}>
+                        A timer tracks your actual time. It keeps counting if you switch tabs or refresh.
+                      </p>
+                      <div style={{ marginBottom: 14 }}>
+                        <label style={labelStyle} htmlFor="commit-hours">Commitment</label>
+                        <select
+                          id="commit-hours"
+                          style={fieldStyle}
+                          value={commitmentHours}
+                          onChange={(e) => setCommitmentHours(Number(e.target.value))}
+                        >
+                          {COMMITMENT_OPTIONS.map((h) => (
+                            <option key={h} value={h}>{h} {h === 1 ? "hour" : "hours"}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <div style={{ marginBottom: 18 }}>
+                        <label style={labelStyle} htmlFor="reason">Reason</label>
+                        <select id="reason" style={fieldStyle} value={reason} onChange={(e) => setReason(e.target.value)}>
+                          {REASON_OPTIONS.map((r) => (
+                            <option key={r.value} value={r.value}>{r.label}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <button
+                        type="button"
+                        className="ohx-btn ohx-btn--primary"
+                        onClick={startVolunteering}
+                        disabled={actionLoading}
+                        aria-label="Start volunteering session"
+                        style={{ width: "100%", justifyContent: "center", opacity: actionLoading ? 0.7 : 1 }}
+                      >
+                        {actionLoading ? "Starting…" : "Start volunteering"}
+                      </button>
+                    </div>
+
+                    {/* Log past time */}
+                    <div className="ohx-card" style={{ padding: "clamp(20px, 3vw, 28px)" }}>
+                      <h2 className="ohx-display" style={{ fontSize: "1.25rem", marginTop: 0, marginBottom: 4 }}>
+                        Log time you already did
+                      </h2>
+                      <p className="ohx-faint" style={{ marginTop: 0, marginBottom: 18, fontSize: "0.85rem" }}>
+                        Volunteered away from your computer? Add it here so your record stays accurate.
+                      </p>
+                      <div style={{ display: "flex", gap: 12, marginBottom: 14 }}>
+                        <div style={{ flex: 1 }}>
+                          <label style={labelStyle} htmlFor="manual-date">Date</label>
+                          <input
+                            id="manual-date"
+                            type="date"
+                            style={fieldStyle}
+                            value={manualDate}
+                            max={toYMD(new Date())}
+                            onChange={(e) => setManualDate(e.target.value)}
+                          />
+                        </div>
+                        <div style={{ width: 120 }}>
+                          <label style={labelStyle} htmlFor="manual-hours">Hours</label>
+                          <select
+                            id="manual-hours"
+                            style={fieldStyle}
+                            value={manualHours}
+                            onChange={(e) => setManualHours(Number(e.target.value))}
+                          >
+                            {COMMITMENT_OPTIONS.map((h) => (
+                              <option key={h} value={h}>{h}</option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+                      <div style={{ marginBottom: 18 }}>
+                        <label style={labelStyle} htmlFor="manual-reason">Reason</label>
+                        <select
+                          id="manual-reason"
+                          style={fieldStyle}
+                          value={manualReason}
+                          onChange={(e) => setManualReason(e.target.value)}
+                        >
+                          {REASON_OPTIONS.map((r) => (
+                            <option key={r.value} value={r.value}>{r.label}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <button
+                        type="button"
+                        className="ohx-btn ohx-btn--ghost"
+                        onClick={logManualTime}
+                        disabled={actionLoading}
+                        aria-label="Log past volunteer time"
+                        style={{ width: "100%", justifyContent: "center", opacity: actionLoading ? 0.7 : 1 }}
+                      >
+                        {actionLoading ? "Logging…" : "Log this time"}
+                      </button>
+                    </div>
+                  </div>
+                </section>
+              )}
+
+              {/* STATISTICS */}
+              <section
+                id="statistics"
+                style={{ background: "var(--surface-2)", borderTop: "1px solid var(--line)", borderBottom: "1px solid var(--line)" }}
+              >
+                <div className="ohx-wrap ohx-narrow" style={{ paddingTop: "clamp(40px, 6vh, 64px)", paddingBottom: "clamp(40px, 6vh, 64px)" }}>
+                  <Eyebrow>Your record</Eyebrow>
+                  <h2 className="ohx-display" style={{ marginTop: 8, marginBottom: 6 }}>Volunteering statistics</h2>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "clamp(28px, 6vw, 64px)", margin: "18px 0 28px" }}>
+                    <Stat value={`${round2(totalCommitmentHours)}h`} label="Total committed" />
+                    <Stat value={`${round2(totalActiveHours)}h`} label="Total tracked" />
+                    <Stat value={volunteerStats.length} label="Entries in range" />
+                  </div>
+
+                  {/* Date range */}
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 12, alignItems: "flex-end" }}>
+                    <div style={{ flex: "1 1 150px" }}>
+                      <label style={labelStyle} htmlFor="start-date">From</label>
+                      <input id="start-date" type="date" style={fieldStyle} value={startDate} max={endDate} onChange={(e) => setStartDate(e.target.value)} />
+                    </div>
+                    <div style={{ flex: "1 1 150px" }}>
+                      <label style={labelStyle} htmlFor="end-date">To</label>
+                      <input id="end-date" type="date" style={fieldStyle} value={endDate} min={startDate} max={toYMD(new Date())} onChange={(e) => setEndDate(e.target.value)} />
+                    </div>
+                    <button
+                      type="button"
+                      className="ohx-btn ohx-btn--ghost"
+                      onClick={() => fetchVolunteerData()}
+                      disabled={statsLoading}
+                      aria-label="Fetch volunteer report"
+                      style={{ flex: "0 0 auto", opacity: statsLoading ? 0.7 : 1 }}
+                    >
+                      {statsLoading ? "Loading…" : "Fetch report"}
+                    </button>
+                  </div>
+
+                  {loadError && (
+                    <div
+                      role="alert"
+                      style={{
+                        marginTop: 18,
+                        padding: "12px 16px",
+                        borderRadius: 6,
+                        background: "var(--accent-soft)",
+                        border: "1px solid #f3d3c7",
+                        color: "#b23a18",
+                        fontSize: "0.9rem",
+                        display: "flex",
+                        gap: 12,
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <span>{loadError}</span>
+                      <button type="button" className="ohx-link" onClick={() => fetchVolunteerData()} style={{ fontSize: "0.85rem" }}>
+                        Retry <Arrow />
+                      </button>
+                    </div>
+                  )}
+
+                  {chartData.length > 0 ? (
+                    <>
+                      <div style={{ height: 300, marginTop: 24 }}>
+                        <ResponsiveContainer width="100%" height="100%">
+                          <BarChart data={chartData} margin={{ top: 16, right: 8, left: -12, bottom: 4 }}>
+                            <CartesianGrid strokeDasharray="3 3" stroke="#E7E1D4" vertical={false} />
+                            <XAxis dataKey="label" tick={{ fontSize: 12, fill: "#5B6270" }} stroke="#E7E1D4" />
+                            <YAxis tick={{ fontSize: 12, fill: "#5B6270" }} stroke="#E7E1D4" />
+                            <Tooltip contentStyle={{ borderRadius: 8, border: "1px solid #E7E1D4", fontSize: 13 }} />
+                            <Legend wrapperStyle={{ fontSize: 13 }} />
+                            <Bar dataKey="Committed" fill="#1B3A6B" radius={[3, 3, 0, 0]} />
+                            <Bar dataKey="Tracked" fill="#E2552E" radius={[3, 3, 0, 0]} />
+                          </BarChart>
+                        </ResponsiveContainer>
+                      </div>
+                      <p className="ohx-faint" style={{ marginTop: 8, fontSize: "0.82rem" }}>
+                        <strong style={{ color: "var(--brand)" }}>Committed</strong> is time you set out to give;{" "}
+                        <strong style={{ color: "var(--accent)" }}>tracked</strong> is the time actually recorded.
+                      </p>
+                      <VolunteerStatsTable volunteerStats={volunteerStats} />
+                    </>
+                  ) : (
+                    !statsLoading && !loadError && (
+                      <div className="ohx-card" style={{ marginTop: 24, padding: "28px 24px", background: "var(--surface)" }}>
+                        <p className="ohx-muted" style={{ margin: 0 }}>
+                          No volunteering logged in this range yet. Start a live session or log time you already did above —
+                          your hours will show up here.
+                        </p>
+                      </div>
+                    )
+                  )}
+                </div>
+              </section>
+
+              {/* WHY TRACK (SEO + context) */}
+              <section className="ohx-wrap ohx-narrow" style={{ paddingTop: "clamp(40px, 6vh, 64px)", paddingBottom: "clamp(48px, 8vh, 88px)" }}>
+                <Eyebrow>Why track volunteer hours?</Eyebrow>
+                <h2 className="ohx-display" style={{ marginTop: 8, marginBottom: 18 }}>A verified record of your impact</h2>
+                <div style={{ display: "grid", gap: 16, gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
+                  {[
+                    ["Impact measurement", "Quantify your contributions to community service and social causes."],
+                    ["Professional recognition", "Build a verified record of volunteer work for resumes and applications."],
+                    ["Nonprofit support", "Help organizations understand volunteer engagement and program reach."],
+                    ["Personal growth", "Watch your volunteer journey add up and celebrate the milestones."],
+                  ].map(([title, body]) => (
+                    <div key={title} className="ohx-card" style={{ padding: "20px 22px" }}>
+                      <h3 className="ohx-display" style={{ fontSize: "1.05rem", marginTop: 0, marginBottom: 6 }}>{title}</h3>
+                      <p className="ohx-muted" style={{ margin: 0, fontSize: "0.92rem" }}>{body}</p>
+                    </div>
+                  ))}
+                </div>
+                <p className="ohx-muted" style={{ marginTop: 24 }}>
+                  For coding contributions, we also track time through GitHub commits. Learn about our{" "}
+                  <Link href="/cert" className="ohx-link">volunteer certification process</Link>.
+                </p>
+                <p className="ohx-faint" style={{ marginTop: 8, fontSize: "0.88rem" }}>
+                  This platform is open source.{" "}
+                  <a
+                    href="https://github.com/opportunity-hack/frontend-ohack.dev/blob/main/src/pages/volunteer/track.js"
+                    className="ohx-link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    View the source <Arrow />
+                  </a>
+                </p>
+              </section>
+            </>
+          )}
+        </RefinedRoot>
+
+        {/* Toast */}
+        {toast && <Toast toast={toast} onClose={() => setToast(null)} />}
+      </>
     );
   }
 );
+
+// Lightweight on-theme toast (auto-dismiss). Avoids pulling in MUI Snackbar.
+function Toast({ toast, onClose }) {
+  useEffect(() => {
+    const id = setTimeout(onClose, 5000);
+    return () => clearTimeout(id);
+  }, [toast, onClose]);
+  const isError = toast.severity === "error";
+  return (
+    <div
+      role="status"
+      style={{
+        position: "fixed",
+        left: "50%",
+        bottom: 24,
+        transform: "translateX(-50%)",
+        zIndex: 1400,
+        maxWidth: "92vw",
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        padding: "12px 16px",
+        borderRadius: 8,
+        fontFamily: "'Hanken Grotesk', system-ui, sans-serif",
+        fontSize: "0.92rem",
+        color: "#fff",
+        background: isError ? "#b23a18" : "#1B3A6B",
+        boxShadow: "0 14px 40px -16px rgba(22,24,29,0.5)",
+      }}
+    >
+      <span>{toast.message}</span>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Dismiss notification"
+        style={{ background: "none", border: 0, color: "#fff", fontSize: "1.1rem", cursor: "pointer", lineHeight: 1, opacity: 0.85 }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
 
 export default VolunteerTrackingPage;


### PR DESCRIPTION
Rebuilds `/volunteer/track` on the civic-editorial **refined** system and fixes the flows so volunteers can accurately track **committed** and **actual** time. Pairs with backend-ohack.dev#250 (the lazy-create fix for the "Failed to load your volunteer data" bug).

## The reported problem
The page showed *"Failed to load your volunteer data"* for some people, and they couldn't start a session. Root cause is in the backend (separate PR): new users with no Firestore profile doc 404'd. This PR adds the matching frontend fix (graceful empty state, no scary error) plus a full refresh + UX rework.

## Theme
- `RefinedRoot` + `.ohx-*`, Fraunces/Hanken, navy `#1B3A6B` / terracotta, hairline cards, native form controls (no MUI blue).
- `FunVolunteerTimer` → navy ring showing **elapsed** filling toward the commitment.
- `VolunteerStatsTable` → hairline, day-grouped, friendly reason labels + a `manual` tag.

## Accuracy & UX fixes
- **Wall-clock timer**: elapsed computed from a persisted `startEpoch` (capped at the commitment) — accurate across background tabs and survives refresh. Replaces `setTimeout` tick-counting (browser-throttled in bg tabs) and a stale-closure save that lost the session if you refreshed right after starting.
- **Manual time logging**: new "Log time you already did" card (date + hours + reason) for time done away from the keyboard — the biggest gap against accurate tracking.
- **Inclusive date range**: native date inputs normalized to start/end-of-day ISO, fixing the bug where picking *today* as the end date excluded today's sessions.
- De-duplicated error UI (one inline message + on-theme `Toast`, not Alert **and** Snackbar); friendly empty state.

## Notes for reviewers
- Fonts are injected via a one-time `useEffect` (not `<RefinedFonts/>`): this page is wrapped in `withAuthInfo` (client-rendered), where `next/head` silently drops the external Google Fonts `<link>`s. Documented in CLAUDE.md.
- Verified the refined render + clean hydration with cache disabled (Next 16 dev stale-chunk gotcha). The logged-in interactive flow was reviewed but not click-tested end-to-end (no PropelAuth session available in the sandbox) — worth a quick manual check after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)