### PR TITLE
Add GA Comm Champs

### DIFF
--- a/src/components/CommunityChampions/CommunityChampions.js
+++ b/src/components/CommunityChampions/CommunityChampions.js
@@ -25,6 +25,7 @@ import Image from "next/image";
 import Head from "next/head";
 import { useEnv } from "../../context/env.context";
 import { TIERS, getTierForHearts } from "../../lib/heartTiers";
+import { trackEvent } from "../../lib/ga";
 
 export default function CommunityChampions() {
   const { apiServerUrl } = useEnv();
@@ -32,6 +33,22 @@ export default function CommunityChampions() {
   const [search, setSearch] = useState("");
   const [tierFilter, setTierFilter] = useState("all");
   const [viewMode, setViewMode] = useState("table");
+
+  useEffect(() => {
+    trackEvent({
+      action: "community_champions_view_mode",
+      params: { view_mode: "table", interaction: "page_load" },
+    });
+  }, []);
+
+  const handleViewModeChange = (_, val) => {
+    if (!val || val === viewMode) return;
+    setViewMode(val);
+    trackEvent({
+      action: "community_champions_view_mode",
+      params: { view_mode: val, interaction: "toggle" },
+    });
+  };
 
   useEffect(() => {
     const controller = new AbortController();
@@ -295,7 +312,7 @@ export default function CommunityChampions() {
             <ToggleButtonGroup
               value={viewMode}
               exclusive
-              onChange={(_, val) => val && setViewMode(val)}
+              onChange={handleViewModeChange}
               size="small"
               aria-label="Community champions display mode"
               sx={{


### PR DESCRIPTION
Google Analytics code for Community Champions - Screenshots possibly indicating GA activation

Below is when viewing card view
<img width="1276" height="629" alt="image" src="https://github.com/user-attachments/assets/bdaf906b-076e-4c80-a438-b3bd1b62918a" />

Below is when viewing table view
<img width="1269" height="673" alt="image" src="https://github.com/user-attachments/assets/d21ebb55-0368-416b-bea1-8bb95f57ff84" />
